### PR TITLE
Verify packaged installs and document safe inbox upgrade recovery

### DIFF
--- a/docs/upgrading-0.2.md
+++ b/docs/upgrading-0.2.md
@@ -24,6 +24,11 @@ returns a string-keyed `from`/`to` hash, or `nil` for legacy requests. Legacy
 signatures remain accepted, but HTTP/MIME envelope headers are never trusted for
 those requests. Route tenant mailboxes using the trusted SMTP recipient instead
 of MIME `To`/`Cc`; decide explicitly how the application handles missing metadata.
+The dogfooding inbox defaults to strict envelope routing: during a staged upgrade,
+its `ALLOW_LEGACY_EMAIL_ROUTING=true` flag temporarily permits only legacy
+single-To/no-Cc traffic. Deploy the v2 Worker, verify envelope routing, and remove
+that flag. Pause ingress during the transition if legacy multi-recipient traffic
+must not be interrupted. See the [upgrade rehearsal](verification/2026-09-10-install-upgrade.md).
 Identical MIME for separate SMTP recipients is stored separately; retries for the
 same exact recipient remain duplicates. This includes Bcc deliveries without a
 visible recipient header. The envelope format supports ASCII dot-atom addresses
@@ -63,4 +68,6 @@ In an account and mailboxes you control, verify these before production rollout:
 - Queue subscription, event encoding, handler persistence, and acknowledgements.
 - Actual delivered Message-ID and reply threading if using the legacy signed-ID helper.
 
-No live account actions, messages, or releases were performed as part of the automated update.
+The automated suite needs no live account. Separate authorized isolated live runs
+are documented in the [live follow-up](verification/2026-09-10-followup.md).
+The gem has not been published by these verification tasks.

--- a/docs/verification/2026-09-10-followup.md
+++ b/docs/verification/2026-09-10-followup.md
@@ -1,5 +1,9 @@
 # Envelope, drafting, and delivery verification — 2026-09-10
 
+The [install/upgrade rehearsal](2026-09-10-install-upgrade.md) and the
+[inbox E2E report](https://github.com/cole-robertson/agentic-inbox-rails-full/blob/verification/remaining-e2e/docs/verification/2026-09-10-e2e.md)
+extend this pass with crash/restart and live queue dead-letter/replay evidence.
+
 This follow-up supersedes the missing-envelope, missing-ledger, and maintenance-failure findings in the initial reports. The app pins gem candidate `be879439353752d2127dd6413bf915f7321e3fa6`; its runtime matches the live-tested `cb9b87a` (the later commit fixes test-fixture reloading only).
 
 ## Implemented

--- a/docs/verification/2026-09-10-install-upgrade.md
+++ b/docs/verification/2026-09-10-install-upgrade.md
@@ -1,0 +1,86 @@
+# Install, upgrade, rollback, and staged protocol rehearsal
+
+Executed 2026-09-10 with Ruby 4.0.0, Rails 8.1.3.1, gem 0.2.0.
+Gem merge: `cb8d8932296f64b5531ee2e1b773e9937c6df884`.
+Inbox merge: `21bc3627ad70c586c45e7df297db4af4cd070066`.
+The inbox retains its release-candidate gem pin `be879439353752d2127dd6413bf915f7321e3fa6`.
+
+## Packaged install
+
+```sh
+bundle exec ruby script/verify_package.rb
+```
+
+Passed: isolated consumer installed the built `.gem` into a temporary bundle,
+loaded version 0.2.0, and did not load Rails. Rails integration fixtures loaded
+the extracted packaged files in separate processes:
+
+| Fixture | Tests | Assertions | Failures/errors/skips |
+| --- | ---: | ---: | --- |
+| Inbound | 18 | 95 | 0/0/0 |
+| Send only | 11 | 40 | 0/0/0 |
+| Fresh inbound | 19 | 100 | 0/0/0 |
+
+The fresh Rails harness invoked the actual install generator, installed and
+ran Active Storage/Action Mailbox migrations, generated mailbox files and Worker
+files, then received and routed a signed message. This verifies the packaged
+generator in a minimal fresh Rails application; it does not claim a RubyGems
+publication, Docker deployment, or a production installation.
+
+## Existing inbox migration and backup recovery
+
+From the gem checkout, using the inbox bundle:
+
+```sh
+INBOX_ROOT=/absolute/path/to/agentic-inbox-rails-full \
+BUNDLE_GEMFILE=/absolute/path/to/agentic-inbox-rails-full/Gemfile \
+bundle exec ruby script/verification/install_upgrade.rb
+```
+
+All **16 checks passed**. The script creates temporary SQLite databases and
+storage, uses inert test credentials, disables mail delivery, and blocks network
+access during routing. It removes those resources on exit and never migrates the
+configured inbox database.
+
+- Migrate a completely empty database to the pre-ledger migration
+  `20260418012251`; insert representative incoming, sent, and unapproved messages.
+- Upgrade to the current schema; preserve every original message field and
+  timestamp. Previously sent messages become `legacy_sent`, while unsent messages
+  become `pending`. No provider IDs or delivery attempts are fabricated.
+- Check review-field defaults on existing rows.
+- Insert an ambiguous send and durable attempt. Take a quiesced SQLite snapshot
+  with `VACUUM INTO`, roll back both new migrations, and reapply them.
+- Restore the snapshot into a different database; verify the original ambiguous
+  attempt and message state survive. Re-running migrations is idempotent, and an
+  actual `DraftDelivery.call` remains blocked without creating another attempt.
+
+**Schema rollback is destructive to delivery history.** The rehearsal confirmed
+that down/up migrations preserve old message content but drop attempts and reset
+an ambiguous draft to `pending`. A schema rollback after send attempts exist must
+not be treated as a safe retry/recovery procedure. Stop writers and retain the
+ledger; prefer a forward fix. If restoring a backup, coordinate ingress, jobs,
+and provider reconciliation first: the local quiesced backup test does not prove
+that restoring an earlier production snapshot is safe while external sends are
+in flight. Rolling back to old sending code can also bypass the new ledger guard.
+
+## Rails-before-Worker rollout
+
+The same script POSTs correctly signed v1/v2 payloads to the real Rails ingress
+and routes them through `AgentMailbox`. A closed, existing conversation avoids
+LLM requests and outbound mail.
+
+| Protocol and configuration | Observed result |
+| --- | --- |
+| v1, `ALLOW_LEGACY_EMAIL_ROUTING=true`, single To/no Cc | Accepted and routed into the existing conversation |
+| v1, transitional mode, Cc present | Ingress accepts; mailbox refuses ambiguous routing and records bounced |
+| v1, strict mode | Ingress accepts; mailbox refuses missing authenticated envelope and records bounced |
+| v2, strict mode | Accepted and routed into the existing conversation |
+
+Only the two permitted messages enter the conversation; no outbound mail is sent.
+For a staged rollout, deploy Rails with the explicitly temporary legacy flag,
+deploy the v2 Worker, verify authenticated-envelope delivery, then disable the
+flag. Legacy multi-recipient traffic is intentionally refused even during this
+transition; use a controlled ingress pause if this traffic must not be interrupted.
+The protocol replay tests exercise real HMAC verification, persistence, and
+mailbox execution, with synthetic local HTTP requests; they are not additional
+Cloudflare-deployed Worker tests.

--- a/script/verification/install_upgrade.rb
+++ b/script/verification/install_upgrade.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+
+# Run with the inbox bundle; never connects to the configured application DB.
+# INBOX_ROOT=/path/to/inbox BUNDLE_GEMFILE=/path/to/inbox/Gemfile bundle exec ruby script/verification/install_upgrade.rb
+require "tmpdir"
+require "fileutils"
+require "json"
+
+app_root = File.realpath(ENV.fetch("INBOX_ROOT"))
+checks = []
+check = lambda do |condition, name|
+  raise "FAIL: #{name}" unless condition
+  checks << name
+  puts "PASS: #{name}"
+end
+
+Dir.mktmpdir("cloudflare-email-upgrade-") do |temporary|
+  ENV["RAILS_ENV"] = "test"
+  ENV["DATABASE_URL"] = "sqlite3:#{temporary}/upgrade.sqlite3"
+  ENV["SECRET_KEY_BASE"] = "isolated-upgrade-test-" * 8
+  ENV["CLOUDFLARE_INGRESS_SECRET"] = "isolated-upgrade-ingress"
+  ENV.delete("RAILS_MASTER_KEY")
+  Dir.chdir(app_root)
+  require File.join(app_root, "config/application")
+  Rails.application.config.credentials.content_path = File.join(temporary, "unused.yml.enc")
+  Rails.application.config.credentials.key_path = File.join(temporary, "unused.key")
+  Rails.application.config.logger = ActiveSupport::Logger.new(File.join(temporary, "rails.log"))
+  Rails.application.initialize!
+  ActiveJob::Base.queue_adapter = :test
+  ActionMailbox.ingress = :cloudflare
+  ActionMailer::Base.perform_deliveries = false
+  storage = {"isolated" => {"service" => "Disk", "root" => File.join(temporary, "storage")}}
+  ActiveStorage::Blob.services = ActiveStorage::Service::Registry.new(storage)
+  ActiveStorage::Blob.service = ActiveStorage::Blob.services.fetch("isolated")
+
+  ActiveRecord::Migration.verbose = false
+  migration_path = File.join(app_root, "db/migrate")
+  context = -> { ActiveRecord::MigrationContext.new(migration_path) }
+  baseline = 20260418012251
+  context.call.migrate(baseline)
+  connection = ActiveRecord::Base.connection
+  check.call(!connection.column_exists?(:messages, :delivery_state), "clean baseline schema predates delivery ledger")
+
+  # Raw SQL deliberately avoids new-model defaults against the old schema.
+  connection.execute("INSERT INTO users (id,name,email,password_digest,created_at,updated_at) VALUES (1,'Fixture','owner@example.test','unused',CURRENT_TIMESTAMP,CURRENT_TIMESTAMP)")
+  connection.execute("INSERT INTO mailboxes (id,user_id,address) VALUES (1,1,'inbox@example.test')")
+  connection.execute("INSERT INTO folders (id,mailbox_id,name,kind,created_at,updated_at) VALUES (1,1,'Inbox','inbox',CURRENT_TIMESTAMP,CURRENT_TIMESTAMP)")
+  connection.execute("INSERT INTO conversations (id,mailbox_id,folder_id,thread_id,sender_email,subject,status,created_at,updated_at) VALUES (1,1,1,'upgrade-fixture','sender@example.test','Upgrade','closed',CURRENT_TIMESTAMP,CURRENT_TIMESTAMP)")
+  connection.execute("INSERT INTO messages (id,conversation_id,role,body,message_id,drafted,created_at,updated_at) VALUES (1,1,'user','Preserved incoming','legacy-incoming@example.test',0,CURRENT_TIMESTAMP,CURRENT_TIMESTAMP)")
+  connection.execute("INSERT INTO messages (id,conversation_id,role,body,message_id,drafted,sent_at,created_at,updated_at) VALUES (2,1,'assistant','Preserved sent reply','legacy-sent@example.test',0,CURRENT_TIMESTAMP,CURRENT_TIMESTAMP,CURRENT_TIMESTAMP)")
+  connection.execute("INSERT INTO messages (id,conversation_id,role,body,drafted,created_at,updated_at) VALUES (3,1,'assistant','Preserved unapproved draft',1,CURRENT_TIMESTAMP,CURRENT_TIMESTAMP)")
+  original_columns = connection.columns(:messages).map(&:name)
+  original_rows = connection.select_all("SELECT #{original_columns.join(',')} FROM messages ORDER BY id").to_a
+  preserved = -> { connection.select_all("SELECT #{original_columns.join(',')} FROM messages ORDER BY id").to_a == original_rows }
+
+  context.call.migrate
+  check.call(preserved.call, "upgrade preserves every original message column and timestamp")
+  check.call(connection.select_rows("SELECT id,delivery_state FROM messages ORDER BY id") == [[1, "pending"], [2, "legacy_sent"], [3, "pending"]], "upgrade marks old sends legacy_sent without inventing provider acceptance")
+  check.call(connection.select_value("SELECT COUNT(*) FROM delivery_attempts").zero?, "upgrade creates no fabricated delivery attempts")
+  check.call(connection.select_value("SELECT COUNT(*) FROM messages WHERE draft_review_required = 0 AND draft_review_reasons = '[]'") == 3, "existing rows receive valid draft review defaults")
+
+  # Model a request lost during a process crash, then exercise backup recovery.
+  connection.execute("UPDATE messages SET delivery_state = 'unknown' WHERE id = 3")
+  connection.execute("INSERT INTO delivery_attempts (id,message_id,state,recipient,body,request_started_at,created_at,updated_at) VALUES (1,3,'unknown','sender@example.test','Preserved unapproved draft',CURRENT_TIMESTAMP,CURRENT_TIMESTAMP,CURRENT_TIMESTAMP)")
+  backup = File.join(temporary, "before-rollback.sqlite3")
+  connection.execute("VACUUM INTO #{connection.quote(backup)}")
+  context.call.migrate(baseline)
+  check.call(preserved.call && !connection.table_exists?(:delivery_attempts), "schema rollback preserves legacy messages but removes the durable attempt ledger")
+  context.call.migrate
+  check.call(preserved.call && connection.select_value("SELECT COUNT(*) FROM delivery_attempts").zero?, "schema reapply succeeds but cannot recover dropped attempt history")
+
+  ActiveRecord::Base.connection_pool.disconnect!
+  restored = File.join(temporary, "restored.sqlite3")
+  FileUtils.cp(backup, restored)
+  ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: restored)
+  connection = ActiveRecord::Base.connection
+  check.call(connection.select_value("SELECT state FROM delivery_attempts WHERE id = 1") == "unknown" && connection.select_value("SELECT delivery_state FROM messages WHERE id = 3") == "unknown", "quiesced SQLite backup restores ambiguous attempt and blocked message state")
+  context.call.migrate
+  check.call(connection.select_value("SELECT COUNT(*) FROM delivery_attempts") == 1, "migrating restored current schema is idempotent")
+
+  # Exercise real Rails ingress and mailbox routing with old/new Worker protocols.
+  # Closed conversation avoids all LLM calls and outbound delivery.
+  require "rack/mock"
+  require "cloudflare/email/verification"
+  require "cloudflare/email/envelope"
+  require "webmock"
+  WebMock.enable!
+  WebMock.disable_net_connect!
+  [Message, Conversation, ActionMailbox::InboundEmail, ActiveStorage::Blob].each(&:reset_column_information)
+  blocked = false
+  begin
+    DraftDelivery.call(Message.find(3))
+  rescue DraftDelivery::Error => error
+    blocked = error.message.include?("reconciliation")
+  end
+  check.call(blocked && DeliveryAttempt.count == 1, "restored ambiguous send remains blocked without creating another attempt")
+  request = Rack::MockRequest.new(Rails.application)
+  deliver = lambda do |name, version:, legacy:, cc: false|
+    ENV["ALLOW_LEGACY_EMAIL_ROUTING"] = legacy ? "true" : "false"
+    body = "From: sender@example.test\r\nTo: inbox@example.test\r\n"
+    body += "Cc: cc@example.test\r\n" if cc
+    body += "Message-ID: <#{name}@example.test>\r\nIn-Reply-To: <legacy-incoming@example.test>\r\nSubject: Re: Upgrade\r\n\r\nSynthetic rollout message\r\n"
+    timestamp = Time.now.to_i.to_s
+    envelope = version ? Cloudflare::Email::Envelope.encode(from: "sender@example.test", to: "inbox@example.test") : nil
+    signature = Cloudflare::Email::Verification.sign(secret: ENV.fetch("CLOUDFLARE_INGRESS_SECRET"), body: body, timestamp: timestamp, version: version, envelope: envelope)
+    headers = {"CONTENT_TYPE" => "message/rfc822", "HTTP_X_CF_EMAIL_TIMESTAMP" => timestamp, "HTTP_X_CF_EMAIL_SIGNATURE" => signature}
+    headers["HTTP_X_CF_EMAIL_SIGNATURE_VERSION"] = version if version
+    headers["HTTP_X_CF_EMAIL_ENVELOPE"] = envelope if envelope
+    response = request.post("/rails/action_mailbox/cloudflare/inbound_emails", input: body, **headers)
+    raise "Ingress failed: #{response.status}" unless response.status == 200
+    inbound = ActionMailbox::InboundEmail.find_by!(message_id: "#{name}@example.test")
+    inbound.route
+    inbound.reload
+  end
+  check.call(deliver.call("v1-transition", version: nil, legacy: true).delivered?, "Rails-first transitional mode routes old Worker single-To messages")
+  check.call(deliver.call("v1-cc", version: nil, legacy: true, cc: true).bounced?, "transitional mode refuses ambiguous legacy Cc messages")
+  check.call(deliver.call("v1-strict", version: nil, legacy: false).bounced?, "strict mode records old Worker ingress but refuses unauthenticated routing")
+  check.call(deliver.call("v2-strict", version: "2", legacy: false).delivered?, "new Worker v2 routes successfully after strict routing enabled")
+  check.call(Message.where(conversation_id: 1, role: "user").count == 3, "only the two authorized rollout messages enter the existing conversation")
+  check.call(ActionMailer::Base.deliveries.empty?, "rollout rehearsal sends no outbound mail")
+
+  puts JSON.pretty_generate({ruby: RUBY_VERSION, rails: Rails.version, gem: Cloudflare::Email::VERSION, checks: checks, isolation: "temporary SQLite databases and Active Storage; network disabled during routing"})
+ensure
+  ActiveRecord::Base.connection_pool.disconnect! if defined?(ActiveRecord::Base)
+end


### PR DESCRIPTION
Add a reproducible isolated inbox upgrade/restore/protocol rehearsal and record packaged installation results. The checks found two rollout hazards that the instructions now address: schema rollback destroys delivery history, and strict inbox routing needs an explicit temporary legacy mode while an old Worker is still deployed.

- Packaged consumer/fresh Rails fixtures:48 tests,235 assertions passed.
- New rehearsal:16 checks passed for baseline migration, preservation of existing messages, legacy_sent backfill, backup restoration of ambiguous attempts, retry blocking and v1/v2 transition.
- Document forward-fix/ledger-preserving recovery and the Rails-before-Worker sequence.

The script uses temporary SQLite/storage, inert credentials, and blocks network while routing. No shared app database, cloud resources, production migrations or publication. Existing gem CI continues covering the runtime; no gem runtime code changed.

See [rehearsal evidence](docs/verification/2026-09-10-install-upgrade.md) and linked inbox E2E results for real queue/crash/HTTP verification and remaining browser/DNS/external mailbox limits.
