### PR TITLE
Add durable outbound delivery and shared mailbox infrastructure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,34 @@ jobs:
       - run: bundle exec ruby script/verify_package.rb
         if: matrix.ruby == '3.4' && matrix.rails == '8_1'
 
+  postgres-outbox:
+    name: PostgreSQL durable outbound concurrency
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: cloudflare_email_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      BUNDLE_GEMFILE: "${{ github.workspace }}/gemfiles/postgres.gemfile"
+      POSTGRES_TEST_URL: postgres://postgres:postgres@localhost:5432/cloudflare_email_test
+    steps:
+      - uses: actions/checkout@v7
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.4"
+          bundler-cache: true
+      - run: bundle exec ruby script/verify_postgres_outbox.rb
+
   worker:
     name: Cloudflare Worker (JavaScript)
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## 0.2.0 — Unreleased
 
+- Add an optional durable Rails outbox: immutable MIME/envelope snapshots,
+  account-scoped operation keys, committed send claims, per-recipient acceptance
+  evidence, blocked uncertain retries, and audited subset reconciliation.
+- Add `Outbox.prepare_mail`, identity-only `SendJob`, replay jobs/tasks and
+  `DeliveryEvents` to correlate provider events and update recipient lifecycle
+  state transactionally. Normalize receipt message IDs for indexed replay.
+- Verify concurrent sends and event projection on PostgreSQL as well as SQLite;
+  include process termination, partial outcomes and post-acceptance persistence
+  failures. The inbox uses the shared ledger with preserved historical records.
+
 - Authenticate SMTP envelope sender/recipient with the Worker's v2 HMAC format,
   persist trusted metadata before routing, and expose `Envelope.for(inbound_email)`.
   Preserve raw MIME and scope duplicate detection to the exact SMTP recipient.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # cloudflare-email
 
-Ruby client for [Cloudflare Email Service](https://developers.cloudflare.com/email-service/), with an ActionMailer delivery method, an ActionMailbox ingress, a signed forwarding Worker, and an outbound delivery-event consumer.
+Ruby client for [Cloudflare Email Service](https://developers.cloudflare.com/email-service/), with ActionMailer, authenticated ActionMailbox ingress, a forwarding Worker, and optional durable Rails sending and delivery-event tracking.
 
 Version **0.2.0** (release candidate). Ruby 3.2+, Rails 7.1–8.1; Ruby 4.0 is tested with Rails 8.1. Prefer a maintained Ruby/Rails release for new applications. The plain Ruby client uses Ruby's standard libraries plus the Base64 gem. Node is optional: Worker deployment also works through the included Ruby deployer.
 
@@ -11,7 +11,7 @@ bundle add cloudflare-email
 bin/rails generate cloudflare:email:install --no-inbound
 ```
 
-Until 0.2.0 is published, use this repository's update branch or a local checkout to try the new features; RubyGems still serves 0.1.0.
+Until 0.2.0 is published, pin a reviewed commit from this repository to try the new features; RubyGems still serves 0.1.0.
 
 Add Rails credentials (encrypted, per environment) or environment variables:
 
@@ -54,6 +54,40 @@ WelcomeMailer.welcome(user).deliver_later
 ```
 
 Multipart, attachments, cc/bcc, and threading headers are serialized through `send_raw`. Cloudflare still controls final delivery and header acceptance.
+
+## Durable mailbox delivery from Rails
+
+For a mailbox application, use the optional outbox instead of recreating send
+claims, attempt records, recipient outcomes, and event correlation:
+
+```sh
+bin/rails generate cloudflare:email:tracking
+bin/rails generate cloudflare:email:outbox
+bin/rails db:migrate
+```
+
+```ruby
+account = Cloudflare::Email::Credentials.account_id
+operation = Cloudflare::Email::ActiveRecord::Outbox.prepare_mail(
+  account_id: account,
+  operation_key: "reply:#{draft.id}:revision:#{draft.revision}",
+  mail: ReplyMailer.reply(draft).message,
+)
+# Enqueue after the transaction that prepared the operation commits.
+Cloudflare::Email::SendJob.perform_later(account, operation.operation_key)
+```
+
+The job sends the stored MIME once per operation claim. Accepted repeats cannot
+resend; uncertain sends remain blocked for audited reconciliation. Each recipient
+has separate acceptance evidence and lifecycle status. `DeliveryEvents` persists,
+deduplicates, correlates, orders, and replays queue events, with transactional
+callbacks for your product records. The reference Rails inbox uses these same
+tables and APIs for compose, replies, approved AI drafts, and recovery.
+
+`ReplyMailer`, `draft`, and its revision are application examples. Authorize the
+send before preparation and use a durable job backend. See the [complete outbox
+setup and recovery guide](docs/outbox.md) and [gem/inbox architecture](docs/architecture.md).
+The adapter is opt-in; the plain Ruby client does not load Rails or ActiveRecord.
 
 ## Plain Ruby
 
@@ -192,6 +226,11 @@ delivery) and `DeliveryEvent#supersedes?(occurred_at:, terminal:)` for ordering
 matched recipient events. See the [architecture guide](docs/architecture.md) for
 what the gem provides and what belongs in the inbox product.
 
+Applications using the outbox can use `DeliveryEvents.record(event)` and
+`DeliveryEvents.replay(account_id:, message_id:)` for built-in correlation and
+recipient-state projection. Applications with their own delivery schema can
+continue to use the lower-level `EventInbox` with an explicit handler.
+
 ## Thread correlation
 
 Prefer storing the provider's returned `message_id` with your conversation and correlating inbound `In-Reply-To` / `References` against that record. Correlation does not authenticate the sender or authorize an action.
@@ -234,6 +273,15 @@ Notifications: `cloudflare_email.send` / `send_raw` include `account_id`, `path`
 | `provision_catchall DOMAIN=...` | Same routing management permissions; changes the zone-wide catch-all |
 | `dev` | Management token: Workers Scripts Edit; development only |
 | `consume_events` | Separate Queues Read/Write token, queue ID, configured handler |
+| `deliver OPERATION_KEY=...` | Dispatch a saved outbox operation using sending credentials |
+| `replay_events [MESSAGE_ID=...]` | Replay durable receipts for the configured account |
+| `pending_deliveries` | List prepared or uncertain outbox operations for operator review |
+
+The optional Rails adapter emits `cloudflare_email.outbox_prepare`,
+`cloudflare_email.outbox_send`, and `cloudflare_email.outbox_reconcile` notifications
+with operation identity and resulting state. These do not contain MIME or API
+tokens. A notification is method instrumentation; an enclosing application
+transaction may still roll back. Inspect the durable ledger for authoritative state.
 
 Management tasks fall back to the runtime token if `management_token` is unset. Restrict scopes and accounts to the operations you need. Event consumers use a separate `queues_token` and do not fall back to a send token.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -14,8 +14,10 @@ durable infrastructure without copying the reference inbox's models and services
 | Authenticated v2 ingress and recipient-scoped deduplication | Map trusted recipient to an authorized mailbox |
 | `MessageId.normalize` and returned provider IDs | Store conversation membership and scope reply lookups |
 | Queue decoding, validation and ACK | Queue/subscription setup and recurring execution |
-| Optional ActiveRecord event receipts, deduplication and replay | Match event to an application send and update product records |
-| `DeliveryEvent#supersedes?` | Correlate account/message/recipient before applying an event |
+| Optional ActiveRecord event receipts, deduplication and indexed replay | Configure queue polling and receipt retention |
+| Immutable outbox snapshots, send claims, per-recipient outcomes | Authorize sending and choose a stable operation key |
+| `DeliveryEvents` account/message/recipient correlation and ordering | Transactional callback to update product records |
+| Send/replay jobs, recovery tasks and audited reconciliation | Authorize operators and provide evidence of provider outcome |
 
 The ActiveRecord adapter is explicit opt-in. Its generator installs a receipt table
 and initializer; the default plain Ruby client does not load ActiveRecord. Its
@@ -27,13 +29,11 @@ removed. Cloudflare's documented queue encodings and recipient-response forms ar
 provider contracts, so accepting them is not obsolete application compatibility.
 Historical verification reports describe their dated runs, not the current API.
 
-## Next extraction: durable outbound delivery
+## Implemented: durable outbound delivery
 
-The inbox's send claim, immutable attempt snapshot, uncertainty handling and
-reconciliation are reusable infrastructure in principle. They still reside in the
-application in this change. Moving only its models would leave consumers copying
-the critical orchestration, so the next extraction should provide one opt-in
-outbound operation API with these guarantees:
+The inbox now uses the gem's ledger tables and orchestration. Its model subclasses
+add application message associations and display snapshots; they do not maintain
+a second sending ledger. See the [outbox guide](outbox.md) for installation and API.
 
 1. Claim an application-supplied operation key scoped to an account using a unique
    index before sending; repeated or concurrent calls cannot silently resend.
@@ -42,18 +42,41 @@ outbound operation API with these guarantees:
 3. Separate preparation failures from ambiguous outcomes. A timeout, process death
    or persistence failure after acceptance keeps the operation blocked. An elapsed
    timeout alone never proves the message was not sent.
-4. Persist returned provider IDs and recipient outcomes, then replay unmatched
-   delivery events. Never claim the provider request and database commit are atomic.
+4. Persist validated provider IDs and recipient acceptance outcomes separately
+   from later lifecycle events. Replay correlates account, message and recipient;
+   conflicting IDs remain uncertain. The network and database are not atomic.
 5. Expose audited reconciliation with caller-supplied actor/reason and evidence.
    The application authorizes the operator; the gem enforces legal transitions.
 6. Provide jobs/tasks and notifications that preserve the same claim on retries.
    Include migration/import support for the reference inbox's existing attempts.
 
-Before this becomes the default, test two concurrent senders, process termination
-during the request, acceptance followed by failed persistence, partial recipient
-acceptance, event-before-response, and recovery without a duplicate send. Exercise
-SQLite and PostgreSQL concurrency. Existing inbox recovery tests are a useful
-baseline, not evidence that an unimplemented generic ledger already works.
+The suite exercises concurrent senders, actual process termination, acceptance
+followed by persistence failure, partial recipients, event-before-response,
+out-of-order events, callbacks that roll back, and recovery without a duplicate
+send. PostgreSQL and SQLite run separate concurrency checks. Inbox HTTP and browser
+workflows use the shared implementation, with controlled local provider responses.
+
+Historic attempts did not preserve rendered MIME. Their import retains available
+bodies, IDs, outcomes and operator evidence and marks reconstructed snapshots.
+Unknown historical outcomes remain blocked. No migration claims to recreate the
+exact bytes of a previously sent message.
+
+## Operational completion
+
+The reference inbox supplies a functional mailbox product over these APIs. Before
+production use, configure sending DNS and receiving routes, queue subscriptions
+and dead-letter handling, durable Rails jobs, receipt/MIME retention and backups,
+and monitoring for prepared/sending/unknown/partial operations. Exercise live
+external mailbox delivery and recovery with the deployed revision. Installation
+does not automatically provision domains or deploy infrastructure.
+
+Current limitations are deliberate and visible: no provider exactly-once API,
+no automatic resend of uncertain or rejected operations, no multi-provider-ID
+operation (conflicting IDs require review), and no durable inbound Worker buffer.
+A prepared operation can be dispatched using its existing identity after a job
+enqueue failure; sending/unknown operations require evidence-based reconciliation.
+Notifications indicate method execution and may run inside an outer transaction;
+the durable database record is authoritative.
 
 ## Keep in the inbox product
 

--- a/docs/delivery-events.md
+++ b/docs/delivery-events.md
@@ -45,6 +45,11 @@ before returning; do not merely enqueue a non-durable job.
 
 ### Durable Rails receipts
 
+If you also use the [durable outbox](outbox.md), prefer `DeliveryEvents.record`
+and `DeliveryEvents.replay`: they provide account/message/recipient correlation
+and state ordering automatically. The lower-level example below supports an
+application's own delivery schema.
+
 ```sh
 bin/rails generate cloudflare:email:tracking
 bin/rails db:migrate
@@ -96,7 +101,7 @@ returning it. External effects and writes to other databases cannot be rolled ba
 Concurrent database conflicts raise; retry the job. Do not send email inside this
 handler; use durable outbound orchestration.
 
-Replay accepts optional `account_id:`, exact raw provider `message_id:`, and
+Replay accepts optional `account_id:`, normalized provider `message_id:`, and
 `batch_size:` filters. The batch size controls database fetch size, not the total
 number processed. `DeliveryEvent#supersedes?` accepts a Time or ISO8601 previous
 timestamp: only a newer known status replaces current state, equal timestamps keep
@@ -105,7 +110,10 @@ terminal complaint can replace delivery. Invalid timestamps raise. Match records
 and lock recipient state before using this ordering helper.
 
 Receipt retention, recurring jobs, and monitoring are application decisions. See
-the [gem/inbox boundary](architecture.md) for outbound-ledger scope.
+the [gem/inbox boundary](architecture.md) for outbound-ledger scope. Existing
+receipt tables from the earlier preproduction adapter must normalize stored
+`message_id` values with `MessageId.normalize` before using filtered replay;
+raw payloads remain unchanged. The reference inbox's outbox migration does this.
 
 Poll a single batch:
 

--- a/docs/outbox.md
+++ b/docs/outbox.md
@@ -1,0 +1,175 @@
+# Durable outbound email for Rails
+
+The optional Active Record layer supplies immutable send snapshots, single-attempt delivery claims, recipient outcomes, delivery-event receipts, and audited reconciliation. Use it when background retries, process crashes, or missing provider responses must not silently resend an email. The plain Ruby client and ordinary ActionMailer delivery method remain available without these tables.
+
+This is delivery infrastructure. Your application still authorizes sending, decides what belongs in a conversation, reviews drafts, and controls operator access.
+
+## Install
+
+After configuring the gem's sending credentials, generate both sets of tables:
+
+```sh
+bin/rails generate cloudflare:email:tracking
+bin/rails generate cloudflare:email:outbox
+bin/rails db:migrate
+```
+
+Skip a generator whose migration is already installed. The outbox initializer requires `cloudflare/email/active_record`, which loads the models, `Outbox`, `prepare_mail`, and `DeliveryEvents`, and also loads both jobs. For manual setup without the generator, require:
+
+```ruby
+require "cloudflare/email/active_record"
+require "cloudflare/email/send_job"
+require "cloudflare/email/replay_events_job"
+```
+
+Use a durable ActiveJob backend and a recurring scheduler suitable for your application. The gem does not install a job backend or Cloudflare Queue subscription. Configure delivery events and the separate queue token as described in [delivery-events.md](delivery-events.md).
+
+## Prepare once, dispatch after commit
+
+Render the mail, snapshot it together with your application update, and enqueue only after the outer database transaction commits:
+
+```ruby
+outbox = Cloudflare::Email::ActiveRecord::Outbox
+account_id = Cloudflare::Email::Credentials.account_id
+
+# Inside an application service that runs outside an existing transaction:
+delivery = nil
+Draft.transaction do
+  draft.lock!
+  # Apply the application's owner/approval checks here.
+  mail = ReplyMailer.reply(draft).message
+  delivery = outbox.prepare_mail(
+    account_id: account_id,
+    operation_key: "draft:#{draft.id}:revision:#{draft.revision}",
+    mail: mail
+  )
+  draft.update!(outbound_operation_key: delivery.operation_key)
+end
+
+Cloudflare::Email::SendJob.perform_later(account_id, delivery.operation_key)
+```
+
+`Draft`, `revision`, and `outbound_operation_key` above are application examples, not generated gem models. For nested application transactions, use an actual after-commit hook; returning from an inner transaction does not necessarily commit the outer one.
+
+`prepare_mail` accepts a rendered `Mail::Message` or an ActionMailer message delivery. It reads the SMTP envelope and encodes the MIME once, preserving attachments and To/Cc/Bcc delivery. It rejects `perform_deliveries == false`. Mailer rendering callbacks run during rendering; delivery callbacks are bypassed when sending the saved snapshot. Put required delivery authorization before preparation or in your application service.
+
+For an existing MIME source:
+
+```ruby
+delivery = outbox.prepare(
+  account_id: account_id,
+  operation_key: "invoice:123:notification:1",
+  from: "billing@example.com",
+  recipients: ["customer@example.net"],
+  mime_message: raw_mime
+)
+```
+
+The account plus operation key identifies one immutable attempt. Preparing the same envelope and MIME returns the existing operation. Changing its snapshot raises `Outbox::SnapshotConflict`. Recipient order is preserved, duplicate addresses are removed, domains are lowercased, and local parts retain their case. MIME is stored as binary data. Re-rendering a mail can change generated headers, so job retries use the saved operation identity instead of calling the mailer again.
+
+`Outbox.deliver(delivery, client: optional_client)` sends synchronously and refuses an ambient database transaction. Its `prepared → sending` claim commits before network I/O. A supplied client must match the account and expose `retry_ambiguous == false`. The standard `SendJob` uses the configured sending account/token and forces ambiguous retries off; applications managing several Cloudflare accounts can use their own account-aware job and pass the appropriate client.
+
+## States and retries
+
+| Operation state | Meaning and permitted action |
+| --- | --- |
+| `prepared` | Snapshot saved; safe to dispatch. |
+| `sending` | A process claimed the attempt. Another job cannot send it. A crashed process can leave this state indefinitely. |
+| `accepted` | All recipients have acceptance evidence. Repeated delivery returns the record without a network request. |
+| `partial` | Some recipients have acceptance evidence, while others were rejected or remain unknown. Repeated delivery never resends the batch. |
+| `rejected` | Available outcomes show rejection. The operation is terminal; correcting and sending again requires a new operation key. |
+| `unknown` | Acceptance cannot be established safely. Investigate and reconcile before deciding on another attempt. |
+| `confirmed_not_sent` | An operator confirmed the whole operation was not sent. Old jobs stay blocked; a deliberate new attempt needs a new key. |
+
+Each `outbound_recipients` row stores `acceptance_state` separately from lifecycle `state`. A later complaint or bounce must not erase evidence that the original send was accepted. Lifecycle `occurred_at` stays nil for immediate send results and operator reconciliation: local clock time is not a provider event timestamp.
+
+Malformed success responses, conflicting provider message IDs, timeouts, ambiguous transport errors, and failures saving an accepted response remain uncertain. Explicit supported provider rejection responses can produce `rejected`. Errors are re-raised after recording the conservative outcome. A database outage may leave the already committed `sending` claim instead of `unknown`; both block resend.
+
+This is not exactly-once delivery. Provider acceptance and a database commit cannot be one transaction. Client pre-send/rate-limit retry behavior remains available, but automatic ambiguous retries are prohibited by the outbox.
+
+## Recover dispatch and application projections
+
+An application can commit its snapshot and crash before enqueueing. Schedule a scan of `prepared` operations and enqueue their saved identities. Multiple scanners/jobs are safe because only one can claim an operation. Do not reset `sending` operations merely because they are old.
+
+Operational commands:
+
+```sh
+bin/rails cloudflare:email:pending_deliveries
+OPERATION_KEY='invoice:123:notification:1' bin/rails cloudflare:email:deliver
+bin/rails cloudflare:email:replay_events
+```
+
+The listing includes prepared, sending, unknown, and partial operations for the configured account; it does not automatically dispatch them. `deliver` uses `SendJob.perform_now` with the saved snapshot.
+
+Optional Rails callbacks reduce application glue:
+
+```ruby
+settings = Rails.application.config.x.cloudflare_email
+settings.outbox_delivery_handler = ->(delivery) {
+  # Idempotently project the saved operation into application records.
+}
+settings.outbox_recipient_handler = ->(delivery, recipient) {
+  # Project a lifecycle change into application records.
+}
+```
+
+The delivery callback runs under a delivery row lock after the result has been saved. If application projection fails after acceptance, retrying the job repairs the projection without another provider send. The recipient callback runs inside receipt processing's transaction. Keep callbacks idempotent and use the same database connection for atomic application writes. External side effects cannot be rolled back; schedule them through a durable application mechanism.
+
+## Consume and replay events
+
+Wire the supplied projector into the event consumer:
+
+```ruby
+settings = Rails.application.config.x.cloudflare_email
+settings.event_handler = ->(event) {
+  Cloudflare::Email::ActiveRecord::DeliveryEvents.record(event) do |delivery, recipient|
+    settings.outbox_recipient_handler&.call(delivery, recipient)
+  end
+}
+```
+
+`DeliveryEvents.record` commits the receipt before projecting it. Callback failures roll back projection and leave the saved receipt available for retry. It matches the account, normalized provider Message-ID, and recipient; ambiguous matches remain unmatched. Known events apply with lifecycle ordering and terminal-state guards. Event identity provides durable deduplication. Unknown future event statuses remain unmatched for later support.
+
+An event may arrive before the send result is saved. `SendJob` replays matching receipts after its delivery callback, and a recurring `ReplayEventsJob.perform_later(account_id)` covers later recovery. Direct callers can use:
+
+```ruby
+Cloudflare::Email::ActiveRecord::DeliveryEvents.replay(
+  account_id: account_id, message_id: delivery.provider_message_id
+) do |operation, recipient|
+  # Optional application projection.
+end
+```
+
+Message-ID normalization removes surrounding angle brackets; it is correlation, not authorization. No provider ID means there is no safe automatic provider-ID match.
+
+## Reconcile uncertainty
+
+Restrict this operation to an authorized application operator. The gem records the supplied actor string; it does not authenticate that actor or verify external evidence.
+
+```ruby
+outbox.reconcile(
+  delivery,
+  outcome: :accepted,
+  actor: "User:42",
+  reason: "Provider support confirmed acceptance",
+  evidence: "Support ticket 123 and retained provider response",
+  provider_message_id: "provider-message-id",
+  recipients: ["customer@example.net"]
+) do |operation|
+  # Optional application update, atomic with the audit and state change.
+end
+```
+
+`outcome: :accepted` requires a valid provider Message-ID. `outcome: :not_sent` requires evidence of nonacceptance. Actor, reason, and evidence must be nonempty strings. Reconciliation can run inside an application transaction; callbacks and audit writes roll back together if it fails. Existing audit records are read-only through the model.
+
+For a partial operation, only unresolved recipients can be reconciled. Omit `recipients` to select the unresolved subset. Known outcomes and lifecycle state are preserved; later decisions can resolve another unknown subset. A conflicting provider ID is refused. A batch with all recipients confirmed not sent becomes `confirmed_not_sent`; a mixed batch remains partial or otherwise reflects the remaining acceptance evidence. Never retry a complete partial batch to reach one unresolved recipient.
+
+For a `sending` operation, first stop the original sender and verify it cannot resume. Reconciliation additionally requires `confirm_sender_stopped: true` and a claim at least 15 minutes old. Elapsed time alone is insufficient. There is no automatic lease expiry or timeout-based resend.
+
+## Data ownership and migration
+
+The gem owns its operation, recipient, receipt, and reconciliation infrastructure. The inbox owns mailbox permissions, conversations, approval policy, AI drafts, and UI. Link product records to operations by a stable key or application foreign key instead of copying the ledger algorithm.
+
+The MIME snapshot contains email bodies, addresses, and attachments. Apply your application's database access, encryption, backup, and retention policies. Removing ledgers or replaying old backups can discard uncertainty and deduplication evidence; quiesce sending and reconcile provider activity during recovery.
+
+Importing historical attempts is application-specific. If the old application did not save exact MIME, a reconstructed snapshot is historical metadata, not proof of the original bytes. Preserve its known/unknown state and do not turn imported accepted or uncertain attempts into dispatchable `prepared` operations. The generated outbox and receipt migrations refuse rollback to preserve delivery and deduplication evidence; use a forward fix or a reconciled backup.

--- a/docs/upgrading-0.2.md
+++ b/docs/upgrading-0.2.md
@@ -58,6 +58,14 @@ Responses and notifications expose `message_id` when present and `suppressed_rec
 
 Add a dedicated Queue, Email Sending event subscription, and HTTP pull consumer to use [delivery events](delivery-events.md). Existing applications are not subscribed or polled automatically. Provide an idempotent handler and configure retries/dead-letter handling.
 
+For durable sending, install the optional [outbox](outbox.md) migrations and use
+its saved-operation API. Ordinary `deliver_now`/`deliver_later` do not silently
+opt into durable claims. Existing receipt tables from the earlier preproduction
+adapter should normalize their stored `message_id` column before filtered replay;
+retain the raw payload. The reference inbox's migration imports its existing
+attempts, recipients and audits without clearing uncertainty. Outbox and tracking
+generators now refuse destructive rollback; plan forward fixes and backups.
+
 The old README's signed-reply identity and exactly-once claims were too strong. The unused signed-ID helper has been removed. A repeated Message-ID is not a send idempotency key. Live testing confirmed Cloudflare replaces custom IDs: store provider IDs and include parent IDs in outgoing reply headers. See [thread correlation](thread-correlation.md).
 
 ## Verification before publishing/deploying

--- a/docs/verification/2026-09-11-outbound-ledger.md
+++ b/docs/verification/2026-09-11-outbound-ledger.md
@@ -1,0 +1,60 @@
+# Shared outbound ledger verification — September 11, 2026
+
+The optional Rails layer now owns immutable MIME preparation, account-scoped
+operation keys, committed send claims, recipient acceptance evidence, provider
+event projection, and audited reconciliation. The reference inbox consumes these
+tables and services rather than keeping its own transport ledger.
+
+## Local results
+
+| Check | Result |
+| --- | --- |
+| Gem suite, Ruby 3.4.1 / Rails 8.1.3.1 | 191 tests, 637 assertions, no failures/errors/skips |
+| Outbox subprocess included in suite | 21 SQLite tests, 112 assertions |
+| Mail snapshots, jobs, event projection subprocess | 9 SQLite tests, 45 assertions |
+| Existing receipt subprocess | 13 SQLite tests, 56 assertions |
+| Actual PostgreSQL 15 verifier | 9 tests, 45 assertions |
+| Packaged isolated Ruby + Rails install/ingress + outbound checks | 57 tests, 280 assertions; all passed |
+
+The top-level gem counts include subprocess assertions, not their individual
+inner assertions. PostgreSQL 16 verification is added to CI. The PostgreSQL
+driver remains an optional test dependency; the gem has no new runtime database
+or job dependencies for plain Ruby users.
+
+## Failure and concurrency coverage
+
+- Eight concurrent identical operations produce one stored snapshot and one
+  provider request. Conflicting snapshots cannot overwrite the winner.
+- Independent operations reach the controlled provider concurrently.
+- A real SIGKILL after the durable claim leaves the operation blocked after
+  restart. A real PostgreSQL backend termination plus simulated provider timeout
+  also preserves the non-retryable claim.
+- Acceptance followed by database failure does not permit another send.
+- Partial acceptance never resends the whole batch. Unknown recipients can be
+  reconciled independently while known lifecycle states remain intact.
+- Malformed IDs and conflicting per-recipient provider IDs become uncertainty;
+  a valid common ID on a later recipient entry is retained.
+- Event-before-response, duplicate callbacks, concurrent out-of-order events,
+  terminal guards, account mismatch and ambiguous IDs are exercised.
+- Application callback failure rolls back product and recipient writes while
+  retaining the receipt; replay applies it. A send-job retry repairs failed
+  product projection without another provider request.
+- MIME includes a binary attachment containing all 256 byte values and a hidden
+  Bcc envelope recipient. Jobs serialize only the account and operation key.
+- Reconciliation requires actor/reason/evidence and legal unresolved transitions.
+  Sending reconciliation requires a stopped sender confirmation and a minimum
+  claim age. Generated migrations refuse to delete safety evidence on rollback.
+
+## Boundaries
+
+HTTP acceptance and lifecycle payloads use controlled local fixtures. This pass
+does not send live mail, deploy a Worker, publish RubyGems, or prove inbox placement.
+Earlier Cloudflare live reports describe their own revisions. Provider-ID
+correlation assumes Cloudflare assigns unique IDs; pre-existing duplicate matches
+are retained as unmatched for review. The network and database remain separate
+transactions, and the system does not claim exactly-once provider delivery.
+
+The reference inbox has separate HTTP, browser, process-recovery and import
+verification recorded in its `docs/verification/2026-09-11-outbox.md`. Historical
+records preserve available content and audit data; reconstructed imported MIME
+is explicitly marked and is not claimed to reproduce historical wire bytes.

--- a/gemfiles/postgres.gemfile
+++ b/gemfiles/postgres.gemfile
@@ -1,0 +1,3 @@
+# Optional PostgreSQL concurrency verification; not a runtime dependency.
+eval_gemfile File.expand_path("../Gemfile", __dir__)
+gem "pg", "~> 1.6"

--- a/lib/cloudflare/email/active_record.rb
+++ b/lib/cloudflare/email/active_record.rb
@@ -1,0 +1,5 @@
+# Optional durable Rails/ActiveRecord integration. Jobs are a separate opt-in.
+require "cloudflare/email/active_record/outbox"
+require "cloudflare/email/active_record/mail_snapshot"
+require "cloudflare/email/active_record/delivery_events"
+require "cloudflare/email/active_record/outbox_notifications"

--- a/lib/cloudflare/email/active_record/delivery_events.rb
+++ b/lib/cloudflare/email/active_record/delivery_events.rb
@@ -1,0 +1,72 @@
+require "cloudflare/email/active_record/event_inbox"
+require "cloudflare/email/active_record/outbox"
+require "time"
+
+module Cloudflare
+  module Email
+    module ActiveRecord
+      # Durable receipt + recipient projection. Application callbacks may update
+      # product records on this connection; external effects need their own outbox.
+      class DeliveryEvents
+        class << self
+          def record(event, &on_change)
+            validate!(event)
+            receipt = EventInbox.record(event)
+            EventInbox.apply(receipt) { |stored| project(stored, &on_change) }
+          end
+
+          def replay(account_id:, message_id: nil, batch_size: 100, &on_change)
+            raise ArgumentError, "account_id is required" if account_id.to_s.empty?
+            EventInbox.replay(account_id: account_id, message_id: message_id,
+                              batch_size: batch_size) { |event| project(event, &on_change) }
+          end
+
+          private
+
+          def validate!(event)
+            raise ValidationError, "delivery event recipient is required" unless event.recipient.is_a?(String) && !event.recipient.strip.empty?
+            Time.iso8601(event.occurred_at.to_s)
+          rescue ArgumentError
+            raise ValidationError, "delivery event timestamp must be ISO8601"
+          end
+
+          def project(event)
+            validate!(event)
+            return :unmatched unless event.known?
+
+            # Refuse ambiguous correlation instead of picking the newest record.
+            ids = OutboundDelivery.where(account_id: event.account_id,
+              provider_message_id: MessageId.normalize(event.message_id),
+              state: %w[accepted partial]).limit(2).pluck(:id)
+            return :unmatched unless ids.length == 1
+
+            delivery = OutboundDelivery.find(ids.first)
+            outcome = :unmatched
+            delivery.with_lock do
+              next unless %w[accepted partial].include?(delivery.state)
+              recipient = delivery.outbound_recipients.find_by(
+                recipient: Outbox.normalize_recipient(event.recipient))
+              next unless recipient
+
+              if event.supersedes?(occurred_at: recipient.occurred_at, terminal: recipient.terminal?)
+                attributes = { state: event.status, occurred_at: Time.iso8601(event.occurred_at), terminal: event.terminal? }
+                # A correlated lifecycle event proves Cloudflare processed this
+                # recipient even if its initial response omitted the outcome.
+                if recipient.acceptance_state == "unknown"
+                  attributes[:acceptance_state] = "accepted"
+                end
+                recipient.update!(attributes)
+                if attributes[:acceptance_state]
+                  delivery.update!(state: Outbox.acceptance_state(delivery.outbound_recipients.pluck(:acceptance_state)))
+                end
+                yield delivery, recipient if block_given?
+              end
+              outcome = :applied
+            end
+            outcome
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/cloudflare/email/active_record/event_inbox.rb
+++ b/lib/cloudflare/email/active_record/event_inbox.rb
@@ -1,6 +1,7 @@
 require "active_record"
 require "cloudflare/email/error"
 require "cloudflare/email/delivery_event"
+require "cloudflare/email/message_id"
 require "cloudflare/email/active_record/event_receipt"
 
 module Cloudflare
@@ -20,7 +21,7 @@ module Cloudflare
 
             event = DeliveryEvent.new(event.raw)
             receipt = EventReceipt.create_or_find_by!(account_id: event.account_id, event_id: event.event_id) do |row|
-              row.message_id = event.message_id
+              row.message_id = MessageId.normalize(event.message_id)
               row.payload_json = JSON.generate(event.raw)
               row.state = "pending"
             end
@@ -61,7 +62,7 @@ module Cloudflare
 
             scope = EventReceipt.where(state: ["pending", "unmatched"])
             scope = scope.where(account_id: account_id) if account_id
-            scope = scope.where(message_id: message_id) if message_id
+            scope = scope.where(message_id: MessageId.normalize(message_id)) if message_id
             count = 0
             scope.find_each(batch_size: batch_size) do |receipt|
               apply(receipt, &handler)

--- a/lib/cloudflare/email/active_record/mail_snapshot.rb
+++ b/lib/cloudflare/email/active_record/mail_snapshot.rb
@@ -1,0 +1,24 @@
+require "cloudflare/email/active_record/outbox"
+
+module Cloudflare
+  module Email
+    module ActiveRecord
+      class Outbox
+        # Render before preparing. Delivery callbacks are intentionally not run:
+        # the worker sends the immutable snapshot, never a regenerated mailer.
+        def self.prepare_mail(account_id:, operation_key:, mail:)
+          mail = mail.message if mail.respond_to?(:message) && !mail.respond_to?(:encoded)
+          raise ValidationError, "mail must be a rendered Mail message" unless mail.respond_to?(:encoded)
+          if mail.respond_to?(:perform_deliveries) && !mail.perform_deliveries
+            raise ValidationError, "email delivery is disabled"
+          end
+
+          from = mail.respond_to?(:smtp_envelope_from) ? mail.smtp_envelope_from : Array(mail.from).first
+          recipients = mail.respond_to?(:smtp_envelope_to) ? mail.smtp_envelope_to : [mail.to, mail.cc, mail.bcc].flatten.compact
+          prepare(account_id: account_id, operation_key: operation_key, from: from,
+                  recipients: Array(recipients), mime_message: mail.encoded)
+        end
+      end
+    end
+  end
+end

--- a/lib/cloudflare/email/active_record/outbound_delivery.rb
+++ b/lib/cloudflare/email/active_record/outbound_delivery.rb
@@ -1,0 +1,20 @@
+module Cloudflare
+  module Email
+    module ActiveRecord
+      class OutboundDelivery < ::ActiveRecord::Base
+        self.table_name = "cloudflare_email_outbound_deliveries"
+        has_many :outbound_recipients, class_name: "Cloudflare::Email::ActiveRecord::OutboundRecipient", dependent: :restrict_with_exception
+        has_many :outbound_reconciliations, class_name: "Cloudflare::Email::ActiveRecord::OutboundReconciliation", dependent: :restrict_with_exception
+        attr_readonly :account_id, :operation_key, :from_address, :recipients_json, :mime_message, :snapshot_digest
+
+        def recipients
+          JSON.parse(recipients_json)
+        end
+
+        def response
+          Response.new(JSON.parse(response_json)) if response_json
+        end
+      end
+    end
+  end
+end

--- a/lib/cloudflare/email/active_record/outbound_recipient.rb
+++ b/lib/cloudflare/email/active_record/outbound_recipient.rb
@@ -1,0 +1,11 @@
+module Cloudflare
+  module Email
+    module ActiveRecord
+      class OutboundRecipient < ::ActiveRecord::Base
+        self.table_name = "cloudflare_email_outbound_recipients"
+        belongs_to :outbound_delivery, class_name: "Cloudflare::Email::ActiveRecord::OutboundDelivery"
+        attr_readonly :outbound_delivery_id, :recipient
+      end
+    end
+  end
+end

--- a/lib/cloudflare/email/active_record/outbound_reconciliation.rb
+++ b/lib/cloudflare/email/active_record/outbound_reconciliation.rb
@@ -1,0 +1,13 @@
+module Cloudflare
+  module Email
+    module ActiveRecord
+      class OutboundReconciliation < ::ActiveRecord::Base
+        self.table_name = "cloudflare_email_outbound_reconciliations"
+        belongs_to :outbound_delivery, class_name: "Cloudflare::Email::ActiveRecord::OutboundDelivery"
+        def readonly?
+          persisted?
+        end
+      end
+    end
+  end
+end

--- a/lib/cloudflare/email/active_record/outbox.rb
+++ b/lib/cloudflare/email/active_record/outbox.rb
@@ -1,0 +1,219 @@
+require "active_record"
+require "digest"
+require "cloudflare-email"
+require "cloudflare/email/active_record/outbound_delivery"
+require "cloudflare/email/active_record/outbound_recipient"
+require "cloudflare/email/active_record/outbound_reconciliation"
+
+module Cloudflare
+  module Email
+    module ActiveRecord
+      # Durable, single-attempt boundary. A retry job may revisit an accepted
+      # operation, but uncertainty always requires an explicit operator decision.
+      class Outbox
+        class Error < Cloudflare::Email::Error; end
+        class InvalidTransition < Error; end
+        class SnapshotConflict < Error; end
+
+        class << self
+          def acceptance_state(states)
+            aggregate(states)
+          end
+
+          def normalize_recipient(value)
+            local, separator, domain = value.to_s.rpartition("@")
+            separator.empty? ? value.to_s : "#{local}@#{domain.downcase}"
+          end
+
+          def prepare(account_id:, operation_key:, from:, recipients:, mime_message:)
+            [account_id, operation_key, from].each do |value|
+              raise ArgumentError, "account, operation key and sender must be nonempty strings" unless value.is_a?(String) && !value.strip.empty?
+            end
+            unless recipients.is_a?(Array) && recipients.any? && recipients.all? { |v| v.is_a?(String) && !v.strip.empty? }
+              raise ArgumentError, "recipients must be a nonempty array of addresses"
+            end
+            raise ArgumentError, "mime_message must be a nonempty String" unless mime_message.is_a?(String) && !mime_message.empty?
+            addresses = recipients.map { |address| normalize_recipient(address) }.uniq
+            json = JSON.generate(addresses)
+            digest = Digest::SHA256.hexdigest(JSON.generate([account_id, from, addresses]) + "\0" + mime_message.b)
+            OutboundDelivery.transaction do
+              delivery = OutboundDelivery.create_or_find_by!(account_id: account_id, operation_key: operation_key) do |row|
+                row.assign_attributes(from_address: from, recipients_json: json, mime_message: mime_message.b,
+                  snapshot_digest: digest, state: "prepared")
+              end
+              raise SnapshotConflict, "operation key already has a different immutable message" unless delivery.snapshot_digest == digest
+              addresses.each { |address| delivery.outbound_recipients.create_or_find_by!(recipient: address) }
+              delivery
+            end
+          end
+
+          def deliver(delivery, client: nil)
+            persisted!(delivery)
+            outside_transaction!
+            delivery.reload
+            return delivery if %w[accepted partial].include?(delivery.state)
+            client ||= Client.new(account_id: Credentials.account_id, api_token: Credentials.api_token)
+            unless client.account_id.to_s == delivery.account_id && client.respond_to?(:retry_ambiguous) && client.retry_ambiguous == false
+              raise ConfigurationError, "outbox client must match the account and disable ambiguous retries"
+            end
+            now = Time.now.utc
+            claimed = OutboundDelivery.where(id: delivery.id, state: "prepared").update_all(state: "sending", request_started_at: now, updated_at: now)
+            unless claimed == 1
+              delivery.reload
+              return delivery if %w[accepted partial].include?(delivery.state)
+              raise InvalidTransition, "cannot send an operation in #{delivery.state}; uncertainty requires reconciliation"
+            end
+
+            # Everything after this durable claim can leave an ambiguous outcome.
+            begin
+              response = client.send_raw(from: delivery.from_address, recipients: delivery.recipients, mime_message: delivery.mime_message)
+            rescue StandardError => error
+              record_failure(delivery, error)
+              raise
+            end
+            begin
+              outcomes, provider_message_id = response_outcomes(response, delivery.recipients)
+              delivery.with_lock do
+                raise InvalidTransition, "send claim changed during delivery" unless delivery.state == "sending"
+                outcomes.each do |address, state|
+                  delivery.outbound_recipients.find_by!(recipient: address).update!(state: state, acceptance_state: state, occurred_at: nil,
+                    terminal: %w[delivered bounced suppressed].include?(state))
+                end
+                delivery.update!(state: aggregate(outcomes.values), provider_message_id: provider_message_id,
+                  response_json: JSON.generate(response.to_h), completed_at: Time.now.utc, error_class: nil)
+              end
+            rescue StandardError => error
+              # Even a local validation/persistence error here follows provider
+              # acceptance. Never convert it into permission to resend.
+              mark_unknown(delivery.id, error)
+              raise
+            end
+            delivery.reload
+          end
+
+          def reconcile(delivery, outcome:, actor:, reason:, evidence:, provider_message_id: nil, recipients: nil, confirm_sender_stopped: false)
+            persisted!(delivery)
+            raise ArgumentError, "outcome must be accepted or not_sent" unless %w[accepted not_sent].include?(outcome.to_s)
+            [actor, reason, evidence].each do |value|
+              raise ArgumentError, "actor, reason and evidence are required strings" unless value.is_a?(String) && !value.strip.empty?
+            end
+            provider_message_id = validated_message_id(provider_message_id)
+            if outcome.to_s == "accepted" && provider_message_id.nil?
+              raise ArgumentError, "accepted reconciliation requires a provider message ID"
+            end
+            completed = false
+            delivery.with_lock(requires_new: true) do
+              allowed = %w[unknown partial].include?(delivery.state) || (delivery.state == "sending" && confirm_sender_stopped == true &&
+                delivery.request_started_at && delivery.request_started_at <= Time.now.utc - 900)
+              raise InvalidTransition, "only uncertain operations may be reconciled; a sending process must be confirmed stopped and at least 15 minutes old" unless allowed
+              rows = delivery.outbound_recipients.to_a
+              unresolved = rows.select { |row| %w[unknown prepared sending].include?(row.acceptance_state) }.map(&:recipient)
+              selected = recipients || unresolved
+              selected = selected.map { |address| normalize_recipient(address) } if selected.is_a?(Array)
+              unless selected.is_a?(Array) && selected.any? && (selected - unresolved).empty? && selected.uniq == selected
+                raise ArgumentError, "recipients must be unique unresolved snapshot recipients"
+              end
+              existing_id = validated_message_id(delivery.provider_message_id.presence)
+              if provider_message_id && existing_id && provider_message_id != existing_id
+                raise ArgumentError, "provider message ID conflicts with the existing operation"
+              end
+              delivery.outbound_reconciliations.create!(actor: actor, reason: reason, evidence: evidence,
+                outcome: outcome.to_s, provider_message_id: provider_message_id, recipients_json: JSON.generate(selected))
+              states = rows.map do |recipient|
+                unless selected.include?(recipient.recipient)
+                  recipient.update!(state: "unknown", acceptance_state: "unknown") if %w[prepared sending].include?(recipient.acceptance_state)
+                  next recipient.acceptance_state
+                end
+                state = outcome.to_s == "not_sent" ? "not_sent" : "accepted"
+                recipient.update!(state: state, acceptance_state: state, occurred_at: nil, terminal: state == "not_sent")
+                state
+              end
+              delivery.update!(state: states.all? { |state| state == "not_sent" } ? "confirmed_not_sent" : aggregate(states),
+                provider_message_id: provider_message_id || existing_id, completed_at: Time.now.utc)
+              yield delivery if block_given?
+              completed = true
+            end
+            raise InvalidTransition, "reconciliation rolled back instead of completing" unless completed
+            delivery.reload
+          end
+
+          private
+
+          def persisted!(delivery)
+            raise ArgumentError, "expected a persisted OutboundDelivery" unless delivery.is_a?(OutboundDelivery) && delivery.persisted?
+          end
+
+          def outside_transaction!
+            raise ArgumentError, "outbox network delivery must run outside an existing database transaction" if OutboundDelivery.connection.transaction_open?
+          end
+
+          def record_failure(delivery, error)
+            # Only an explicit provider 4xx rejection proves nonacceptance.
+            rejected = error.is_a?(Cloudflare::Email::Error) && [400, 401, 403, 422, 429].include?(error.status)
+            OutboundDelivery.transaction do
+              count = OutboundDelivery.where(id: delivery.id, state: "sending").update_all(state: rejected ? "rejected" : "unknown",
+                error_class: error.class.name, completed_at: Time.now.utc, updated_at: Time.now.utc)
+              OutboundRecipient.where(outbound_delivery_id: delivery.id).update_all(state: rejected ? "rejected" : "unknown", acceptance_state: rejected ? "rejected" : "unknown") if count == 1
+            end
+          rescue StandardError
+            # A database outage leaves the already committed sending claim.
+            # It is deliberately just as non-retryable as unknown.
+            nil
+          end
+
+          def mark_unknown(id, error)
+            OutboundDelivery.where(id: id, state: "sending").update_all(state: "unknown", error_class: error.class.name, updated_at: Time.now.utc)
+          rescue StandardError
+            nil
+          end
+
+          def response_outcomes(response, addresses)
+            raise ValidationError, "invalid provider response" unless response.is_a?(Response) && response.success?
+            outcomes = addresses.to_h { |address| [address, "unknown"] }
+            result = response.result
+            ids = [validated_message_id(result["message_id"])]
+            groups = { "delivered" => "delivered", "queued" => "queued", "permanent_bounces" => "bounced", "suppressed_recipients" => "suppressed" }
+            seen = {}
+            groups.each do |key, state|
+              entries = result.fetch(key, [])
+              raise ValidationError, "invalid recipient outcomes" unless entries.is_a?(Array)
+              entries.each do |entry|
+                ids << validated_message_id(entry["message_id"]) if entry.is_a?(Hash)
+                address = entry.is_a?(Hash) ? (entry["to"] || entry["email"] || entry["recipient"] || entry["address"]) : entry
+                address = normalize_recipient(address)
+                raise ValidationError, "unknown or conflicting provider recipient" unless addresses.include?(address) && !seen[address]
+                seen[address] = true
+                outcomes[address] = state
+              end
+            end
+            raise ValidationError, "multiple provider message IDs cannot be correlated to one operation" if ids.compact.uniq.size > 1
+            if seen.empty? && ids.compact.any?
+              outcomes.transform_values! { "accepted" }
+            end
+            [outcomes, ids.compact.first]
+          end
+
+          def validated_message_id(value)
+            return nil if value.nil?
+            unless value.is_a?(String)
+              raise ValidationError, "provider message ID must be a nonempty string"
+            end
+            normalized = MessageId.normalize(value)
+            if normalized.empty? || normalized.match?(/[\s<>]/)
+              raise ValidationError, "provider message ID must not contain whitespace or brackets"
+            end
+            normalized
+          end
+
+          def aggregate(states)
+            accepted = states.count { |state| %w[accepted delivered queued].include?(state) }
+            return "accepted" if accepted == states.size
+            return "partial" if accepted.positive?
+            return "rejected" if states.all? { |state| %w[bounced suppressed rejected not_sent].include?(state) }
+            "unknown"
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/cloudflare/email/active_record/outbox_notifications.rb
+++ b/lib/cloudflare/email/active_record/outbox_notifications.rb
@@ -1,0 +1,34 @@
+module Cloudflare
+  module Email
+    module ActiveRecord
+      module OutboxNotifications
+        def prepare(**options)
+          notify_outbox("prepare", account_id: options[:account_id], operation_key: options[:operation_key]) { super }
+        end
+
+        def deliver(delivery, **options)
+          notify_outbox("send", account_id: delivery.account_id, operation_key: delivery.operation_key) { super }
+        end
+
+        def reconcile(delivery, **options, &block)
+          notify_outbox("reconcile", account_id: delivery.account_id, operation_key: delivery.operation_key) { super }
+        end
+
+        private
+
+        def notify_outbox(action, **payload)
+          return yield unless defined?(::ActiveSupport::Notifications)
+
+          ::ActiveSupport::Notifications.instrument("cloudflare_email.outbox_#{action}", payload) do |details|
+            result = yield
+            details[:delivery_id] = result.id
+            details[:state] = result.state
+            result
+          end
+        end
+      end
+
+      Outbox.singleton_class.prepend(OutboxNotifications)
+    end
+  end
+end

--- a/lib/cloudflare/email/client.rb
+++ b/lib/cloudflare/email/client.rb
@@ -19,7 +19,7 @@ module Cloudflare
       ].freeze
       PRE_SEND_NETWORK = [Net::OpenTimeout, Errno::ECONNREFUSED, Errno::EHOSTUNREACH, SocketError].freeze
 
-      attr_reader :account_id, :base_url, :retries, :timeout
+      attr_reader :account_id, :base_url, :retries, :timeout, :retry_ambiguous
 
       def initialize(account_id:, api_token:, base_url: DEFAULT_BASE_URL,
                      retries: DEFAULT_RETRIES, timeout: DEFAULT_TIMEOUT,

--- a/lib/cloudflare/email/replay_events_job.rb
+++ b/lib/cloudflare/email/replay_events_job.rb
@@ -1,0 +1,18 @@
+require "active_job"
+require "cloudflare/email/active_record"
+
+module Cloudflare
+  module Email
+    class ReplayEventsJob < ::ActiveJob::Base
+      queue_as :mailers
+
+      def perform(account_id, message_id = nil)
+        handler = if defined?(Rails) && Rails.respond_to?(:application) && Rails.application
+          Rails.application.config.x.cloudflare_email.outbox_recipient_handler
+        end
+        ActiveRecord::DeliveryEvents.replay(account_id: account_id, message_id: message_id,
+          &(handler.method(:call) if handler.respond_to?(:call)))
+      end
+    end
+  end
+end

--- a/lib/cloudflare/email/send_job.rb
+++ b/lib/cloudflare/email/send_job.rb
@@ -1,0 +1,41 @@
+require "active_job"
+require "cloudflare/email/active_record"
+
+module Cloudflare
+  module Email
+    # Serialize only the durable operation identity, never MIME or credentials.
+    # The application's job backend controls scheduling/retries; uncertainty is
+    # never cleared by retrying this job.
+    class SendJob < ::ActiveJob::Base
+      queue_as :mailers
+
+      def perform(account_id, operation_key)
+        delivery = ActiveRecord::OutboundDelivery.find_by!(account_id: account_id, operation_key: operation_key)
+        options = settings&.outbox_client_options || {}
+        client = Client.new(**options.to_h.merge(account_id: Credentials.account_id,
+          api_token: Credentials.api_token, retry_ambiguous: false))
+        ActiveRecord::Outbox.deliver(delivery, client: client)
+        handler = settings&.outbox_delivery_handler
+        # This is product projection after the durable send result. If it fails,
+        # a retry sees the existing accepted operation and cannot send it again.
+        delivery.with_lock { handler.call(delivery) } if handler.respond_to?(:call)
+        recipient_handler = settings&.outbox_recipient_handler
+        if %w[accepted partial].include?(delivery.state) && delivery.provider_message_id
+          ActiveRecord::DeliveryEvents.replay(account_id: account_id,
+            message_id: delivery.provider_message_id,
+            &(recipient_handler.method(:call) if recipient_handler.respond_to?(:call)))
+        end
+        if delivery.state == "unknown"
+          raise ActiveRecord::Outbox::InvalidTransition, "delivery outcome is unknown; reconcile before retrying"
+        end
+        delivery
+      end
+
+      private
+
+      def settings
+        Rails.application.config.x.cloudflare_email if defined?(Rails) && Rails.respond_to?(:application) && Rails.application
+      end
+    end
+  end
+end

--- a/lib/generators/cloudflare/email/outbox/outbox_generator.rb
+++ b/lib/generators/cloudflare/email/outbox/outbox_generator.rb
@@ -1,0 +1,27 @@
+require "rails/generators"
+require "rails/generators/active_record"
+
+module Cloudflare
+  module Email
+    module Generators
+      class OutboxGenerator < ::Rails::Generators::Base
+        include ::ActiveRecord::Generators::Migration
+        namespace "cloudflare:email:outbox"
+        source_root File.expand_path("templates", __dir__)
+
+        def copy_outbox_migration
+          migration_template "create_cloudflare_email_outbox.rb", "db/migrate/create_cloudflare_email_outbox.rb"
+        end
+
+        def create_initializer
+          create_file "config/initializers/cloudflare_email_outbox.rb", <<~RUBY
+            # Opt in after running db:migrate. Never perform network delivery inside a database transaction.
+            require "cloudflare/email/active_record"
+            require "cloudflare/email/send_job"
+            require "cloudflare/email/replay_events_job"
+          RUBY
+        end
+      end
+    end
+  end
+end

--- a/lib/generators/cloudflare/email/outbox/templates/create_cloudflare_email_outbox.rb
+++ b/lib/generators/cloudflare/email/outbox/templates/create_cloudflare_email_outbox.rb
@@ -1,0 +1,48 @@
+class CreateCloudflareEmailOutbox < ActiveRecord::Migration[7.1]
+  def up
+    create_table :cloudflare_email_outbound_deliveries do |t|
+      t.string :account_id, null: false
+      t.string :operation_key, null: false
+      t.string :from_address, null: false
+      t.text :recipients_json, null: false
+      t.binary :mime_message, null: false
+      t.string :snapshot_digest, null: false
+      t.string :state, null: false, default: "prepared"
+      t.string :provider_message_id
+      t.text :response_json
+      t.string :error_class
+      t.datetime :request_started_at
+      t.datetime :completed_at
+      t.timestamps
+    end
+    add_index :cloudflare_email_outbound_deliveries, [:account_id, :operation_key], unique: true, name: "idx_cf_email_outbound_operation"
+    add_index :cloudflare_email_outbound_deliveries, [:account_id, :provider_message_id], name: "idx_cf_email_outbound_provider"
+    add_index :cloudflare_email_outbound_deliveries, [:state, :id], name: "idx_cf_email_outbound_pending"
+
+    create_table :cloudflare_email_outbound_recipients do |t|
+      t.references :outbound_delivery, null: false, index: false, foreign_key: { to_table: :cloudflare_email_outbound_deliveries }
+      t.string :recipient, null: false
+      t.string :state, null: false, default: "prepared"
+      t.string :acceptance_state, null: false, default: "prepared"
+      t.datetime :occurred_at
+      t.boolean :terminal, null: false, default: false
+      t.timestamps
+    end
+    add_index :cloudflare_email_outbound_recipients, [:outbound_delivery_id, :recipient], unique: true, name: "idx_cf_email_outbound_recipient"
+
+    create_table :cloudflare_email_outbound_reconciliations do |t|
+      t.references :outbound_delivery, null: false, index: { name: "idx_cf_email_reconciliation_delivery" }, foreign_key: { to_table: :cloudflare_email_outbound_deliveries }
+      t.string :actor, null: false
+      t.text :reason, null: false
+      t.text :evidence, null: false
+      t.string :outcome, null: false
+      t.string :provider_message_id
+      t.text :recipients_json
+      t.timestamps
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration, "Preserve delivery evidence; use a forward fix or a reconciled backup"
+  end
+end

--- a/lib/generators/cloudflare/email/tracking/templates/create_cloudflare_email_event_receipts.rb
+++ b/lib/generators/cloudflare/email/tracking/templates/create_cloudflare_email_event_receipts.rb
@@ -1,5 +1,5 @@
 class CreateCloudflareEmailEventReceipts < ActiveRecord::Migration[7.1]
-  def change
+  def up
     create_table :cloudflare_email_event_receipts do |t|
       t.string :account_id, null: false
       t.string :event_id, null: false
@@ -14,5 +14,9 @@ class CreateCloudflareEmailEventReceipts < ActiveRecord::Migration[7.1]
     add_index :cloudflare_email_event_receipts, [:account_id, :message_id],
       name: "idx_cf_email_receipts_account_message"
     add_index :cloudflare_email_event_receipts, [:state, :id], name: "idx_cf_email_receipts_replay"
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration, "Preserve event deduplication evidence; use a forward fix or a reconciled backup"
   end
 end

--- a/lib/tasks/cloudflare_email.rake
+++ b/lib/tasks/cloudflare_email.rake
@@ -52,5 +52,31 @@ namespace :cloudflare do
         batch_size: Integer(ENV.fetch("BATCH_SIZE", "5"), 10),
       )
     end
+
+    desc "Send a prepared durable operation using OPERATION_KEY (no new message is generated)"
+    task deliver: :environment do
+      require "cloudflare/email/send_job"
+      delivery = Cloudflare::Email::SendJob.perform_now(
+        Cloudflare::Email::Credentials.account_id, ENV.fetch("OPERATION_KEY"))
+      puts "operation=#{delivery.operation_key} state=#{delivery.state}"
+    end
+
+    desc "Replay durable outbound receipts for the configured account (optional MESSAGE_ID)"
+    task replay_events: :environment do
+      require "cloudflare/email/replay_events_job"
+      count = Cloudflare::Email::ReplayEventsJob.perform_now(
+        Cloudflare::Email::Credentials.account_id, ENV["MESSAGE_ID"])
+      puts "Replayed #{count} receipt(s)."
+    end
+
+    desc "List prepared or uncertain outbound operations requiring dispatch or operator review"
+    task pending_deliveries: :environment do
+      require "cloudflare/email/active_record"
+      Cloudflare::Email::ActiveRecord::OutboundDelivery.where(
+        account_id: Cloudflare::Email::Credentials.account_id,
+        state: %w[prepared sending unknown partial]).find_each do |delivery|
+        puts "operation=#{delivery.operation_key} state=#{delivery.state} updated_at=#{delivery.updated_at.iso8601}"
+      end
+    end
   end
 end

--- a/script/verify_package.rb
+++ b/script/verify_package.rb
@@ -59,4 +59,7 @@ Dir.mktmpdir("cloudflare-email-package-") do |temporary|
          File.join(root, "test/support/rails_app.rb"), mode, chdir: root)
   end
   puts "PASS: packaged Rails installation and ingress fixtures"
+  run!({ "CLOUDFLARE_EMAIL_TEST_GEM_ROOT" => extracted }, RbConfig.ruby,
+       File.join(root, "test/support/outbound_integration.rb"), chdir: root)
+  puts "PASS: packaged outbound snapshots, jobs, and delivery-event projection"
 end

--- a/script/verify_postgres_outbox.rb
+++ b/script/verify_postgres_outbox.rb
@@ -1,0 +1,254 @@
+# Run only against a disposable database. Each run uses and drops its own schema.
+# POSTGRES_TEST_URL=postgres://localhost/cloudflare_email_test \
+#   BUNDLE_GEMFILE=gemfiles/postgres.gemfile bundle exec ruby script/verify_postgres_outbox.rb
+require "securerandom"
+require "timeout"
+require "pg"
+require_relative "../test/test_helper"
+require "cloudflare/email/active_record/outbox"
+require "cloudflare/email/active_record/event_inbox"
+require "cloudflare/email/active_record/delivery_events"
+require_relative "../lib/generators/cloudflare/email/outbox/templates/create_cloudflare_email_outbox"
+require_relative "../lib/generators/cloudflare/email/tracking/templates/create_cloudflare_email_event_receipts"
+
+url = ENV.fetch("POSTGRES_TEST_URL")
+schema = "cf_email_verify_#{SecureRandom.hex(8)}"
+ActiveRecord::Base.establish_connection(url: url, pool: 12, checkout_timeout: 10)
+ActiveRecord::Base.connection.execute("CREATE SCHEMA #{schema}")
+ActiveRecord::Base.establish_connection(url: url, pool: 12, checkout_timeout: 10, schema_search_path: schema)
+Minitest.after_run do
+  ActiveRecord::Base.connection.execute("DROP SCHEMA #{schema} CASCADE")
+  ActiveRecord::Base.connection_pool.disconnect!
+end
+ActiveRecord::Migration.verbose = false
+CreateCloudflareEmailOutbox.new.migrate(:up)
+CreateCloudflareEmailEventReceipts.new.migrate(:up)
+ActiveRecord::Schema.define do
+  create_table :postgres_projection_effects do |table|
+    table.string :delivery_state
+  end
+end
+
+class PostgresProjectionEffect < ActiveRecord::Base
+end
+
+class PostgresOutboxTest < Minitest::Test
+  Outbox = Cloudflare::Email::ActiveRecord::Outbox
+  Delivery = Cloudflare::Email::ActiveRecord::OutboundDelivery
+  Inbox = Cloudflare::Email::ActiveRecord::EventInbox
+  Receipt = Cloudflare::Email::ActiveRecord::EventReceipt
+  Events = Cloudflare::Email::ActiveRecord::DeliveryEvents
+
+  # A barrier inside the provider proves different operations can send together,
+  # without relying on elapsed-time thresholds or accessing a remote provider.
+  class Client
+    attr_reader :account_id, :calls
+    def initialize(entered: nil, release: nil, error: nil, before_response: nil)
+      @account_id = "postgres-test-account"
+      @calls = Queue.new
+      @entered, @release, @error = entered, release, error
+      @before_response = before_response
+    end
+
+    def retry_ambiguous = false
+
+    def send_raw(**message)
+      @calls << message
+      @entered << true if @entered
+      Timeout.timeout(10) { @release.pop } if @release
+      @before_response&.call
+      raise @error if @error
+      Cloudflare::Email::Response.new({ "success" => true, "result" => {
+        "message_id" => "provider-#{SecureRandom.hex(8)}", "queued" => message.fetch(:recipients)
+      } })
+    end
+  end
+
+  def prepare(key = SecureRandom.uuid, body: "PostgreSQL verification")
+    Outbox.prepare(account_id: "postgres-test-account", operation_key: key,
+      from: "sender@example.test", recipients: ["receiver@example.test"],
+      mime_message: "From: sender@example.test\r\nTo: receiver@example.test\r\nSubject: verification\r\n\r\n#{body}")
+  end
+
+  def concurrent(count)
+    start = Queue.new
+    threads = count.times.map do |i|
+      Thread.new do
+        Thread.current.report_on_exception = false
+        ActiveRecord::Base.connection_pool.with_connection do
+          start.pop
+          yield i
+        end
+      end
+    end
+    count.times { start << true }
+    Timeout.timeout(20) { threads.map(&:value) }
+  ensure
+    threads&.each { |thread| thread.kill if thread.alive? }
+    threads&.each(&:join)
+  end
+
+  def test_concurrent_identical_operations_create_one_snapshot_and_send_once
+    key = SecureRandom.uuid
+    client = Client.new
+    results = concurrent(8) do
+      delivery = prepare(key)
+      begin
+        Outbox.deliver(delivery, client: client)
+      rescue Outbox::InvalidTransition
+        # Another worker already owns the committed sending claim.
+      end
+      delivery.id
+    end
+    assert_equal 1, results.uniq.size
+    assert_equal 1, Delivery.where(operation_key: key).count
+    assert_equal 1, client.calls.size
+    assert_equal "accepted", Delivery.find(results.first).state
+  end
+
+  def test_concurrent_conflicting_snapshots_cannot_replace_winner
+    key = SecureRandom.uuid
+    results = concurrent(2) do |i|
+      prepare(key, body: "body #{i}").id
+    rescue Outbox::SnapshotConflict
+      :conflict
+    end
+    assert_equal 1, results.count(:conflict)
+    assert_equal 1, Delivery.where(operation_key: key).count
+  end
+
+  def test_distinct_operations_do_not_hold_database_locks_during_provider_request
+    entered, release = Queue.new, Queue.new
+    client = Client.new(entered: entered, release: release)
+    deliveries = [prepare, prepare]
+    releaser = Thread.new do
+      Thread.current.report_on_exception = false
+      Timeout.timeout(10) { 2.times { entered.pop } }
+      2.times { release << true }
+    end
+    results = concurrent(2) { |i| Outbox.deliver(deliveries[i], client: client) }
+    releaser.value
+    assert_equal 2, results.size
+    assert_equal 2, client.calls.size
+    assert_equal ["accepted", "accepted"], deliveries.map { |row| row.reload.state }
+  ensure
+    releaser&.kill if releaser&.alive?
+    releaser&.join
+  end
+
+  def event
+    fixture = JSON.parse(File.read(File.expand_path("../test/fixtures/email_sending_queue_message.json", __dir__)))
+    raw = JSON.parse(fixture.fetch("body"))
+    raw["payload"]["eventId"] = SecureRandom.uuid
+    Cloudflare::Email::DeliveryEvent.new(raw)
+  end
+
+  def test_lost_database_connection_after_request_cannot_unlock_automatic_retry
+    delivery = prepare
+    client = Client.new(error: Net::ReadTimeout.new("provider response lost"), before_response: lambda {
+      # Kill only this test's own checked-out backend after the claim committed.
+      backend = ActiveRecord::Base.connection.select_value("SELECT pg_backend_pid()")
+      PG.connect(ENV.fetch("POSTGRES_TEST_URL")) do |connection|
+        assert_equal "t", connection.exec_params("SELECT pg_terminate_backend($1)", [backend]).getvalue(0, 0)
+      end
+    })
+    assert_raises(Net::ReadTimeout) { Outbox.deliver(delivery, client: client) }
+    ActiveRecord::Base.connection.reconnect!
+    assert_includes %w[sending unknown], delivery.reload.state
+    assert_raises(Outbox::InvalidTransition) { Outbox.deliver(delivery, client: client) }
+    assert_equal 1, client.calls.size
+  end
+
+  def test_duplicate_receipt_is_applied_once_with_postgres_row_lock
+    delivery_event = event
+    handled = Queue.new
+    results = concurrent(8) do
+      receipt = Inbox.record(delivery_event)
+      Inbox.apply(receipt) do
+        handled << true
+        :applied
+      end
+      receipt.id
+    end
+    assert_equal 1, results.uniq.size
+    assert_equal 1, handled.size
+    assert_equal "applied", Receipt.find(results.first).state
+  end
+
+  def projected_event(delivery, status: "delivered", at: Time.now.utc + 60, terminal: true, account: delivery.account_id)
+    raw = event.raw
+    raw["type"] = "cf.email.sending.message.#{status}"
+    raw["metadata"]["accountId"] = account
+    raw["metadata"]["eventTimestamp"] = at.iso8601(6)
+    raw["payload"]["messageId"] = "<#{delivery.provider_message_id}>"
+    raw["payload"]["recipient"] = delivery.recipients.first
+    raw["payload"]["terminal"] = terminal
+    Cloudflare::Email::DeliveryEvent.new(raw)
+  end
+
+  def test_different_concurrent_receipts_cannot_regress_terminal_recipient
+    delivery = Outbox.deliver(prepare, client: Client.new)
+    at = Time.now.utc + 60
+    delivered = projected_event(delivery, at: at)
+    deferred = projected_event(delivery, status: "deferred", at: at - 1, terminal: false)
+    # Reverse thread launch order for a second independent concurrent run.
+    [[delivered, deferred], [deferred, delivered]].each do |events|
+      recipient = delivery.outbound_recipients.first
+      recipient.update!(state: "queued", occurred_at: nil, terminal: false)
+      events.each { |entry| Receipt.where(event_id: entry.event_id).delete_all }
+      receipts = concurrent(2) { |i| Events.record(events[i]) }
+      assert_equal ["applied", "applied"], receipts.map { |receipt| receipt.reload.state }
+      assert_equal "delivered", recipient.reload.state
+      assert recipient.terminal?
+      assert_equal at.iso8601(6), recipient.occurred_at.utc.iso8601(6)
+      assert_equal "accepted", delivery.reload.state
+    end
+    # Even a newer nonterminal event cannot undo a terminal outcome.
+    receipt = Events.record(projected_event(delivery, status: "deferred", at: at + 1, terminal: false))
+    assert_equal "applied", receipt.state
+    assert_equal "delivered", delivery.outbound_recipients.first.state
+  end
+
+  def test_duplicate_projection_receipts_invoke_callback_once
+    delivery = Outbox.deliver(prepare, client: Client.new)
+    delivery_event = projected_event(delivery)
+    effects = Queue.new
+    receipts = concurrent(8) { Events.record(delivery_event) { effects << true } }
+    assert_equal 1, receipts.map(&:id).uniq.size
+    assert_equal 1, effects.size
+    assert_equal "delivered", delivery.outbound_recipients.first.state
+  end
+
+  def test_ambiguous_provider_id_and_wrong_account_remain_unmatched
+    delivery = Outbox.deliver(prepare, client: Client.new)
+    wrong_account = Events.record(projected_event(delivery, account: "different-account"))
+    assert_equal "unmatched", wrong_account.state
+    duplicate = Outbox.deliver(prepare, client: Client.new)
+    duplicate.update!(provider_message_id: delivery.provider_message_id)
+    ambiguous = Events.record(projected_event(delivery))
+    assert_equal "unmatched", ambiguous.state
+    assert_equal ["queued", "queued"], [delivery, duplicate].map { |row| row.outbound_recipients.first.state }
+  end
+
+  def test_projection_callback_failure_rolls_back_state_and_database_effect_then_replays_once
+    delivery = Outbox.deliver(prepare, client: Client.new)
+    delivery_event = projected_event(delivery)
+    before_count = PostgresProjectionEffect.count
+    assert_raises(RuntimeError) do
+      Events.record(delivery_event) do |_row, recipient|
+        PostgresProjectionEffect.create!(delivery_state: recipient.state)
+        raise "application projection failed"
+      end
+    end
+    assert_equal before_count, PostgresProjectionEffect.count
+    assert_equal "queued", delivery.outbound_recipients.first.state
+    receipt = Receipt.find_by!(event_id: delivery_event.event_id)
+    assert_equal "pending", receipt.state
+    callback = ->(_row, recipient) { PostgresProjectionEffect.create!(delivery_state: recipient.state) }
+    assert_equal 1, Events.replay(account_id: delivery.account_id, message_id: delivery_event.message_id, &callback)
+    assert_equal 0, Events.replay(account_id: delivery.account_id, message_id: delivery_event.message_id, &callback)
+    assert_equal before_count + 1, PostgresProjectionEffect.count
+    assert_equal "applied", receipt.reload.state
+    assert_equal "delivered", delivery.outbound_recipients.first.state
+  end
+end

--- a/test/active_record_outbox_test.rb
+++ b/test/active_record_outbox_test.rb
@@ -1,0 +1,10 @@
+require "test_helper"
+require "open3"
+require "rbconfig"
+
+class ActiveRecordOutboxIntegrationTest < Minitest::Test
+  def test_outbox_and_generated_migration
+    output, status = Open3.capture2e(RbConfig.ruby, File.expand_path("support/outbox.rb", __dir__))
+    assert status.success?, output
+  end
+end

--- a/test/outbound_integration_test.rb
+++ b/test/outbound_integration_test.rb
@@ -1,0 +1,10 @@
+require "test_helper"
+require "open3"
+require "rbconfig"
+
+class OutboundIntegrationTest < Minitest::Test
+  def test_mail_snapshot_jobs_and_event_projection
+    output, status = Open3.capture2e(RbConfig.ruby, File.expand_path("support/outbound_integration.rb", __dir__))
+    assert status.success?, output
+  end
+end

--- a/test/support/outbound_integration.rb
+++ b/test/support/outbound_integration.rb
@@ -1,0 +1,191 @@
+require_relative "../test_helper"
+require "tmpdir"
+require "fileutils"
+require "mail"
+require "cloudflare/email/active_record"
+require "cloudflare/email/send_job"
+require "cloudflare/email/replay_events_job"
+require "generators/cloudflare/email/outbox/templates/create_cloudflare_email_outbox"
+require "generators/cloudflare/email/tracking/templates/create_cloudflare_email_event_receipts"
+
+INTEGRATION_ROOT = Dir.mktmpdir("cloudflare-email-integration")
+Minitest.after_run { FileUtils.remove_entry(INTEGRATION_ROOT) }
+ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: File.join(INTEGRATION_ROOT, "test.sqlite3"))
+ActiveRecord::Migration.verbose = false
+CreateCloudflareEmailOutbox.new.migrate(:up)
+CreateCloudflareEmailEventReceipts.new.migrate(:up)
+ActiveRecord::Schema.define do
+  create_table(:outbox_projections) { |t| t.string :status }
+end
+class OutboxProjection < ActiveRecord::Base; end
+
+class OutboundIntegrationChecks < Minitest::Test
+  Outbox = Cloudflare::Email::ActiveRecord::Outbox
+  Delivery = Cloudflare::Email::ActiveRecord::OutboundDelivery
+  Recipient = Cloudflare::Email::ActiveRecord::OutboundRecipient
+  Receipt = Cloudflare::Email::ActiveRecord::EventReceipt
+  Events = Cloudflare::Email::ActiveRecord::DeliveryEvents
+  Reconciliation = Cloudflare::Email::ActiveRecord::OutboundReconciliation
+  Job = Cloudflare::Email::SendJob
+
+  def setup
+    Receipt.delete_all
+    Reconciliation.delete_all
+    Recipient.delete_all
+    Delivery.delete_all
+    OutboxProjection.delete_all
+    Job.logger = Logger.new(nil)
+  end
+
+  def prepare(key: "operation", recipients: ["Recipient@example.net"])
+    Outbox.prepare(account_id: ACCOUNT_ID, operation_key: key, from: "sender@example.com",
+      recipients: recipients, mime_message: "From: sender@example.com\r\n\r\nimmutable")
+  end
+
+  def event(id: "event-123", status: "delivered", account: ACCOUNT_ID, recipient: "Recipient@EXAMPLE.NET", time: "2026-09-10T00:00:00Z")
+    Cloudflare::Email::DeliveryEvent.new({
+      "type" => "cf.email.sending.message.#{status}",
+      "source" => { "type" => "email.sending", "domain" => "example.com" },
+      "metadata" => { "accountId" => account, "eventSchemaVersion" => 1, "eventTimestamp" => time },
+      "payload" => { "eventId" => id, "messageId" => "<provider@example.com>",
+        "recipient" => recipient, "terminal" => status != "deferred" },
+    })
+  end
+
+  def accept(delivery)
+    stub_request(:post, send_raw_endpoint).to_return(body: JSON.generate(success: true,
+      result: { message_id: "provider@example.com" }))
+    Outbox.deliver(delivery, client: make_client)
+  end
+
+  def test_snapshot_preserves_attachment_and_bcc_envelope_and_refuses_disabled_mail
+    mail = Mail.new do
+      from "sender@example.com"
+      to "visible@example.net"
+      bcc "hidden@example.net"
+      subject "snapshot"
+      body "unchanged"
+    end
+    mail.attachments["binary.bin"] = (0..255).to_a.pack("C*")
+    original = mail.encoded
+    delivery = Outbox.prepare_mail(account_id: ACCOUNT_ID, operation_key: "mail", mail: mail)
+    assert_equal original.b, delivery.mime_message
+    assert_equal ["visible@example.net", "hidden@example.net"], delivery.recipients
+    assert_equal (0..255).to_a.pack("C*"), Mail.read_from_string(delivery.mime_message).attachments.first.decoded
+    mail.perform_deliveries = false
+    assert_raises(Cloudflare::Email::ValidationError) { Outbox.prepare_mail(account_id: ACCOUNT_ID, operation_key: "disabled", mail: mail) }
+  end
+
+  def test_event_before_acceptance_replays_with_indexed_normalized_message_id
+    receipt = Events.record(event)
+    assert_equal "unmatched", receipt.state
+    assert_equal "provider@example.com", receipt.message_id
+    delivery = accept(prepare)
+    assert_nil delivery.outbound_recipients.first.occurred_at
+    calls = 0
+    assert_equal 1, Events.replay(account_id: ACCOUNT_ID, message_id: "<provider@example.com>") { calls += 1 }
+    assert_equal 1, calls
+    assert_equal "delivered", delivery.outbound_recipients.first.reload.state
+    assert_equal "applied", receipt.reload.state
+    assert_equal 0, Events.replay(account_id: ACCOUNT_ID, message_id: "provider@example.com")
+  end
+
+  def test_older_and_unknown_events_do_not_overwrite_terminal_state
+    delivery = accept(prepare)
+    Events.record(event)
+    calls = 0
+    receipt = Events.record(event(id: "deferred", status: "deferred", time: "2026-09-11T00:00:00Z")) { calls += 1 }
+    assert_equal "applied", receipt.state
+    assert_equal 0, calls
+    assert_equal "delivered", delivery.outbound_recipients.first.reload.state
+    assert_equal "unmatched", Events.record(event(id: "future", status: "future")).state
+    assert_raises(Cloudflare::Email::ValidationError) { Events.record(event(id: "bad", time: nil)) }
+    assert_nil Receipt.find_by(event_id: "bad")
+  end
+
+  def test_lifecycle_event_resolves_an_omitted_recipient_without_losing_acceptance_evidence
+    delivery = prepare(recipients: ["Recipient@example.net", "second@example.net"])
+    stub_request(:post, send_raw_endpoint).to_return(body: JSON.generate(success: true,
+      result: { message_id: "provider@example.com", queued: ["Recipient@example.net"] }))
+    Outbox.deliver(delivery, client: make_client)
+    assert_equal "partial", delivery.state
+    Events.record(event(recipient: "second@example.net", status: "bounced"))
+    assert_equal "accepted", delivery.reload.state
+    recipient = delivery.outbound_recipients.find_by!(recipient: "second@example.net")
+    assert_equal "accepted", recipient.acceptance_state
+    assert_equal "bounced", recipient.state
+    assert recipient.terminal?
+    Outbox.deliver(delivery, client: make_client)
+    assert_requested :post, send_raw_endpoint, times: 1
+  end
+
+  def test_generated_migrations_refuse_to_erase_delivery_and_deduplication_evidence
+    delivery = prepare
+    receipt = Events.record(event)
+    assert_raises(ActiveRecord::IrreversibleMigration) { CreateCloudflareEmailOutbox.new.migrate(:down) }
+    assert_raises(ActiveRecord::IrreversibleMigration) { CreateCloudflareEmailEventReceipts.new.migrate(:down) }
+    assert Delivery.exists?(delivery.id)
+    assert Receipt.exists?(receipt.id)
+  end
+
+  def test_callback_error_rolls_back_product_and_recipient_but_preserves_receipt
+    delivery = accept(prepare)
+    projection = OutboxProjection.create!(status: "accepted")
+    assert_raises(RuntimeError) do
+      Events.record(event) do
+        projection.update!(status: "delivered")
+        raise "product write failed"
+      end
+    end
+    assert_equal "accepted", projection.reload.status
+    assert_equal "accepted", delivery.outbound_recipients.first.reload.state
+    assert_equal "pending", Receipt.first.state
+    Events.replay(account_id: ACCOUNT_ID) { projection.update!(status: "delivered") }
+    assert_equal "delivered", projection.reload.status
+  end
+
+  def test_job_retry_repairs_failed_product_projection_without_resending
+    delivery = prepare
+    stub_request(:post, send_raw_endpoint).to_return(body: JSON.generate(success: true,
+      result: { message_id: "provider@example.com" }))
+    projection = OutboxProjection.create!(status: "draft")
+    settings = Struct.new(:outbox_delivery_handler, :outbox_client_options, :outbox_recipient_handler, keyword_init: true).new(outbox_delivery_handler: ->(_) {
+      projection.update!(status: "sent")
+      raise "projection unavailable"
+    })
+    job = Job.new
+    Cloudflare::Email::Credentials.stub(:account_id, ACCOUNT_ID) do
+      Cloudflare::Email::Credentials.stub(:api_token, API_TOKEN) do
+        job.stub(:settings, settings) { assert_raises(RuntimeError) { job.perform(ACCOUNT_ID, "operation") } }
+        assert_equal "accepted", delivery.reload.state
+        assert_equal "draft", projection.reload.status
+        settings.outbox_delivery_handler = ->(_) { projection.update!(status: "sent") }
+        job.stub(:settings, settings) { job.perform(ACCOUNT_ID, "operation") }
+      end
+    end
+    assert_equal "sent", projection.reload.status
+    assert_requested :post, send_raw_endpoint, times: 1
+  end
+
+  def test_job_arguments_only_contain_operation_identity
+    Job.queue_adapter = :test
+    Job.perform_later(ACCOUNT_ID, "operation")
+    data = Job.queue_adapter.enqueued_jobs.last
+    assert_equal [ACCOUNT_ID, "operation"], data[:args]
+    serialized = JSON.generate(Job.new(ACCOUNT_ID, "operation").serialize)
+    refute serialized.include?("mime_message")
+    refute serialized.include?(API_TOKEN)
+  end
+
+  def test_notifications_expose_operation_outcome_without_message_content
+    captured = []
+    subscriber = ActiveSupport::Notifications.subscribe(/cloudflare_email\.outbox_/) { |*args| captured << args.last }
+    delivery = accept(prepare)
+    assert_equal %w[prepared accepted], captured.map { |payload| payload[:state] }
+    assert_equal [delivery.id], captured.map { |payload| payload[:delivery_id] }.uniq
+    assert captured.all? { |payload| payload[:account_id] == ACCOUNT_ID }
+    refute captured.any? { |payload| payload.key?(:mime_message) || payload.key?(:recipients) || payload.key?(:api_token) }
+  ensure
+    ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
+  end
+end

--- a/test/support/outbox.rb
+++ b/test/support/outbox.rb
@@ -1,0 +1,297 @@
+require_relative "../test_helper"
+require "tmpdir"
+require "fileutils"
+require "cloudflare/email/active_record/outbox"
+require "generators/cloudflare/email/outbox/outbox_generator"
+
+OUTBOX_ROOT = Dir.mktmpdir("cloudflare-email-outbox")
+Minitest.after_run { FileUtils.remove_entry(OUTBOX_ROOT) }
+ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: File.join(OUTBOX_ROOT, "outbox.sqlite3"), timeout: 5000, pool: 5)
+ActiveRecord::Migration.verbose = false
+Cloudflare::Email::Generators::OutboxGenerator.new([], {}, destination_root: OUTBOX_ROOT).invoke_all
+require Dir[File.join(OUTBOX_ROOT, "db/migrate/*.rb")].fetch(0)
+CreateCloudflareEmailOutbox.new.migrate(:up)
+
+class OutboxTest < Minitest::Test
+  Outbox = Cloudflare::Email::ActiveRecord::Outbox
+  Delivery = Cloudflare::Email::ActiveRecord::OutboundDelivery
+  Recipient = Cloudflare::Email::ActiveRecord::OutboundRecipient
+  Reconciliation = Cloudflare::Email::ActiveRecord::OutboundReconciliation
+  Client = Struct.new(:account_id, :retry_ambiguous, :handler) do
+    def send_raw(**args)
+      handler.call(**args)
+    end
+  end
+
+  def setup
+    Reconciliation.delete_all
+    Recipient.delete_all
+    Delivery.delete_all
+  end
+
+  def prepare(**overrides)
+    Outbox.prepare(**{ account_id: ACCOUNT_ID, operation_key: "operation", from: "sender@example.com",
+      recipients: ["one@example.com", "two@example.com"], mime_message: "Subject: snapshot\r\n\r\nbody\xFF".b }.merge(overrides))
+  end
+
+  def client(&block)
+    Client.new(ACCOUNT_ID, false, block)
+  end
+
+  def response(**result)
+    Cloudflare::Email::Response.new(JSON.parse(JSON.generate({ "success" => true, "result" => result })))
+  end
+
+  def test_prepare_is_account_scoped_idempotent_and_binary_immutable
+    first = prepare
+    assert_equal first.id, prepare.id
+    assert_equal "\xFF".b, first.mime_message.byteslice(-1, 1)
+    assert_equal 2, first.outbound_recipients.count
+    assert_raises(Outbox::SnapshotConflict) { prepare(mime_message: "changed") }
+    refute_equal first.id, prepare(account_id: "other-account").id
+    first.mime_message = "changed"
+    begin
+      first.save!
+    rescue ActiveRecord::ReadonlyAttributeError
+      # Rails versions differ on raising versus silently omitting readonly fields.
+    end
+    assert_equal "\xFF".b, first.reload.mime_message.byteslice(-1, 1)
+  end
+
+  def test_prepare_rolls_back_with_application_transaction
+    Delivery.transaction do
+      prepare
+      raise ActiveRecord::Rollback
+    end
+    assert_equal 0, Delivery.count
+    assert_equal 0, Recipient.count
+  end
+
+  def test_network_is_never_called_in_ambient_transaction
+    delivery = prepare
+    Delivery.transaction do
+      assert_raises(ArgumentError) { Outbox.deliver(delivery, client: client { flunk "network" }) }
+    end
+    assert_equal "prepared", delivery.reload.state
+  end
+
+  def test_durable_claim_precedes_network_and_repeated_job_does_not_resend
+    delivery = prepare
+    calls = 0
+    provider = client do |**args|
+      calls += 1
+      refute Delivery.connection.transaction_open?
+      assert_equal "sending", Delivery.find(delivery.id).state
+      assert_equal delivery.mime_message, args[:mime_message]
+      response(message_id: "provider-1")
+    end
+    2.times { Outbox.deliver(delivery, client: provider) }
+    assert_equal 1, calls
+    assert_equal "accepted", delivery.reload.state
+    assert_equal "provider-1", delivery.provider_message_id
+  end
+
+  def test_partial_response_never_resends_successful_recipients
+    delivery = prepare
+    Outbox.deliver(delivery, client: client { response(delivered: ["one@example.com"], permanent_bounces: ["two@example.com"]) })
+    assert_equal "partial", delivery.state
+    assert_equal %w[delivered bounced], delivery.outbound_recipients.order(:id).pluck(:state)
+    Outbox.deliver(delivery, client: client { flunk "resent partial operation" })
+  end
+
+  def test_omitted_recipient_is_unknown_and_conflicting_outcomes_are_not_accepted
+    delivery = prepare
+    Outbox.deliver(delivery, client: client { response(queued: ["one@example.com"]) })
+    assert_equal "partial", delivery.state
+    assert_equal %w[queued unknown], delivery.outbound_recipients.order(:id).pluck(:state)
+    another = prepare(operation_key: "conflict")
+    assert_raises(Cloudflare::Email::ValidationError) do
+      Outbox.deliver(another, client: client { response(delivered: ["one@example.com"], permanent_bounces: ["one@example.com"]) })
+    end
+    assert_equal "unknown", another.reload.state
+  end
+
+  def test_network_and_untyped_validation_failures_block_resend
+    [Cloudflare::Email::NetworkError.new("lost response"), Cloudflare::Email::ValidationError.new("malformed success"),
+      Cloudflare::Email::ServerError.new("server failed", status: 503)].each_with_index do |error, index|
+      delivery = prepare(operation_key: "failure-#{index}")
+      assert_raises(error.class) { Outbox.deliver(delivery, client: client { raise error }) }
+      assert_equal "unknown", delivery.reload.state
+      assert_raises(Outbox::InvalidTransition) { Outbox.deliver(delivery, client: client { flunk "resent" }) }
+    end
+  end
+
+  def test_explicit_provider_rejection_is_terminal
+    delivery = prepare
+    assert_raises(Cloudflare::Email::ValidationError) do
+      Outbox.deliver(delivery, client: client { raise Cloudflare::Email::ValidationError.new("rejected", status: 400) })
+    end
+    assert_equal "rejected", delivery.reload.state
+    assert_raises(Outbox::InvalidTransition) { Outbox.deliver(delivery, client: client { flunk "resent" }) }
+  end
+
+  def test_wrong_account_and_ambiguous_retry_clients_are_refused_before_claim
+    delivery = prepare
+    [Client.new("other", false, nil), Client.new(ACCOUNT_ID, true, nil)].each do |provider|
+      assert_raises(Cloudflare::Email::ConfigurationError) { Outbox.deliver(delivery, client: provider) }
+    end
+    assert_equal "prepared", delivery.reload.state
+  end
+
+  def test_concurrent_jobs_only_one_network_call
+    delivery = prepare
+    entered, release = Queue.new, Queue.new
+    thread = Thread.new do
+      Delivery.connection_pool.with_connection do
+        Outbox.deliver(Delivery.find(delivery.id), client: client { entered << true; release.pop; response(message_id: "provider") })
+      end
+    end
+    entered.pop
+    assert_raises(Outbox::InvalidTransition) { Outbox.deliver(delivery, client: client { flunk "second network call" }) }
+    release << true
+    thread.value
+    assert_equal "accepted", delivery.reload.state
+  ensure
+    release << true if release && thread&.alive?
+    thread&.join
+  end
+
+  def test_process_death_keeps_durable_claim_and_requires_operator_evidence
+    delivery = prepare
+    pid = fork do
+      ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: File.join(OUTBOX_ROOT, "outbox.sqlite3"), timeout: 5000)
+      Outbox.deliver(Delivery.find(delivery.id), client: client { Process.kill("KILL", Process.pid) })
+    end
+    Process.wait(pid)
+    assert_equal "sending", delivery.reload.state
+    assert_raises(Outbox::InvalidTransition) { Outbox.deliver(delivery, client: client { flunk "resent after crash" }) }
+    args = { outcome: "not_sent", actor: "operator:1", reason: "checked provider", evidence: "provider logs and worker termination confirmed" }
+    assert_raises(Outbox::InvalidTransition) { Outbox.reconcile(delivery, **args, confirm_sender_stopped: true) }
+    delivery.update!(request_started_at: Time.now.utc - 901)
+    assert_raises(Outbox::InvalidTransition) { Outbox.reconcile(delivery, **args) }
+    Outbox.reconcile(delivery, **args, confirm_sender_stopped: true)
+    assert_equal "confirmed_not_sent", delivery.state
+    assert_raises(Outbox::InvalidTransition) { Outbox.deliver(delivery, client: client { flunk "old job resend" }) }
+  end
+
+  def test_local_persistence_failure_after_acceptance_remains_uncertain
+    delivery = prepare
+    delivery.define_singleton_method(:update!) { |**_attrs| raise ActiveRecord::StatementInvalid, "database unavailable" }
+    assert_raises(ActiveRecord::StatementInvalid) { Outbox.deliver(delivery, client: client { response(message_id: "accepted-provider") }) }
+    assert_equal "unknown", delivery.reload.state
+    assert_raises(Outbox::InvalidTransition) { Outbox.deliver(delivery, client: client { flunk "resent after accepted response" }) }
+  end
+
+  def test_reconciliation_is_audited_immutable_and_cannot_rewrite_known_recipients
+    delivery = prepare
+    delivery.update!(state: "unknown")
+    Outbox.reconcile(delivery, outcome: "accepted", actor: "operator:1", reason: "provider verified",
+      evidence: "ticket 123", provider_message_id: "provider-confirmed", recipients: ["one@example.com"])
+    assert_equal "partial", delivery.state
+    audit = delivery.outbound_reconciliations.first
+    assert_equal "ticket 123", audit.evidence
+    assert_raises(ActiveRecord::ReadOnlyRecord) { audit.update!(evidence: "rewrite") }
+    assert_raises(ActiveRecord::ReadOnlyRecord) { audit.destroy! }
+    assert_raises(ArgumentError) do
+      Outbox.reconcile(delivery, outcome: "not_sent", actor: "operator:2", reason: "conflict", evidence: "other ticket", recipients: ["one@example.com"])
+    end
+    assert_equal 1, Reconciliation.count
+  end
+
+  def test_reconciliation_and_application_projection_roll_back_together
+    delivery = prepare
+    delivery.update!(state: "unknown")
+    Delivery.transaction do
+      Outbox.reconcile(delivery, outcome: "accepted", actor: "operator", reason: "verified", evidence: "ticket", provider_message_id: "<provider>")
+      raise ActiveRecord::Rollback
+    end
+    assert_equal "unknown", delivery.reload.state
+    assert_equal 0, Reconciliation.count
+    assert_raises(RuntimeError) do
+      Outbox.reconcile(delivery, outcome: "accepted", actor: "operator", reason: "verified", evidence: "ticket", provider_message_id: "<provider>") { raise "app write failed" }
+    end
+    assert_equal "unknown", delivery.reload.state
+    assert_equal 0, Reconciliation.count
+  end
+
+  def test_case_normalization_preserves_local_part_and_does_not_invent_event_time
+    delivery = prepare(recipients: ["One@EXAMPLE.COM", "One@example.com"])
+    assert_equal ["One@example.com"], delivery.recipients
+    Outbox.deliver(delivery, client: client { response(delivered: ["One@EXAMPLE.COM"], message_id: "<provider>") })
+    assert_equal "accepted", delivery.state
+    assert_equal "provider", delivery.provider_message_id
+    assert_nil delivery.outbound_recipients.first.occurred_at
+    assert delivery.outbound_recipients.first.terminal
+  end
+
+  def test_real_client_outbox_request_and_ambiguous_response
+    delivery = prepare(mime_message: "Subject: real client\r\n\r\nbody")
+    stub_request(:post, send_raw_endpoint).to_return(status: 200, body: JSON.generate({ success: true, result: { message_id: "provider" } }), headers: { "Content-Type" => "application/json" })
+    Outbox.deliver(delivery, client: make_client)
+    assert_equal "accepted", delivery.state
+    assert_requested :post, send_raw_endpoint, times: 1
+  end
+
+  def test_malformed_provider_ids_never_prove_acceptance
+    [{}, true, 123, "", "<>", "bad id", "<nested<id>>"].each_with_index do |id, index|
+      delivery = prepare(operation_key: "bad-id-#{index}")
+      assert_raises(Cloudflare::Email::ValidationError) { Outbox.deliver(delivery, client: client { response(message_id: id) }) }
+      assert_equal "unknown", delivery.reload.state
+      assert_raises(Outbox::InvalidTransition) { Outbox.deliver(delivery, client: client { flunk "resent malformed response" }) }
+    end
+    delivery = prepare(operation_key: "recipient-proof")
+    Outbox.deliver(delivery, client: client { response(delivered: delivery.recipients, message_id: nil) })
+    assert_equal "accepted", delivery.state
+  end
+
+  def test_conflicting_provider_ids_do_not_cause_false_event_correlation
+    [ { delivered: [{ to: "one@example.com", message_id: "one" }, { to: "two@example.com", message_id: "two" }] },
+      { message_id: "top", queued: [{ to: "one@example.com", message_id: "other" }] } ].each_with_index do |result, index|
+      delivery = prepare(operation_key: "conflicting-ids-#{index}")
+      error = assert_raises(Cloudflare::Email::ValidationError) { Outbox.deliver(delivery, client: client { response(**result) }) }
+      assert_match(/multiple provider message IDs/, error.message)
+      assert_equal "unknown", delivery.reload.state
+      assert_nil delivery.provider_message_id
+    end
+  end
+
+  def test_partial_unknown_recipients_can_be_reconciled_without_rewriting_known_outcomes
+    delivery = prepare(recipients: ["one@example.com", "two@example.com", "three@example.com"])
+    Outbox.deliver(delivery, client: client { response(message_id: "provider", queued: ["one@example.com"]) })
+    audit = { actor: "operator", reason: "provider reviewed", evidence: "ticket" }
+    assert_raises(ArgumentError) do
+      Outbox.reconcile(delivery, **audit, outcome: "accepted", recipients: ["two@example.com"], provider_message_id: "different")
+    end
+    Outbox.reconcile(delivery, **audit, outcome: "accepted", recipients: ["two@example.com"], provider_message_id: "<provider>")
+    assert_equal %w[queued accepted unknown], delivery.outbound_recipients.order(:id).pluck(:state)
+    Outbox.reconcile(delivery, **audit, outcome: "not_sent")
+    assert_equal %w[queued accepted not_sent], delivery.outbound_recipients.order(:id).pluck(:state)
+    assert_equal "partial", delivery.state
+    assert_equal "provider", delivery.provider_message_id
+    assert_equal 2, delivery.outbound_reconciliations.count
+    assert_raises(ArgumentError) { Outbox.reconcile(delivery, **audit, outcome: "not_sent") }
+    Outbox.deliver(delivery, client: client { flunk "partial resent after reconciliation" })
+  end
+
+  def test_reconciliation_uses_acceptance_evidence_and_preserves_later_lifecycle
+    delivery = prepare
+    Outbox.deliver(delivery, client: client { response(message_id: "provider", queued: ["one@example.com"]) })
+    first = delivery.outbound_recipients.find_by!(recipient: "one@example.com")
+    first.update!(state: "complained", terminal: true, occurred_at: Time.now.utc)
+    Outbox.reconcile(delivery, outcome: "accepted", actor: "operator", reason: "verified", evidence: "ticket", provider_message_id: "provider")
+    assert_equal "accepted", delivery.state
+    assert_equal "complained", first.reload.state
+    assert_equal "queued", first.acceptance_state
+    assert first.terminal
+    assert_equal "accepted", delivery.outbound_recipients.find_by!(recipient: "two@example.com").acceptance_state
+  end
+
+  def test_provider_id_in_later_recipient_is_stored_for_event_correlation
+    delivery = prepare
+    Outbox.deliver(delivery, client: client do
+      response(delivered: [{ to: "one@example.com" }, { to: "two@example.com", message_id: "<provider>" }])
+    end)
+    assert_equal "accepted", delivery.state
+    assert_equal "provider", delivery.provider_message_id
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,4 +1,5 @@
-$LOAD_PATH.unshift File.expand_path("../lib", __dir__)
+gem_root = ENV.fetch("CLOUDFLARE_EMAIL_TEST_GEM_ROOT", File.expand_path("..", __dir__))
+$LOAD_PATH.unshift File.join(gem_root, "lib")
 
 require "minitest/autorun"
 require "webmock/minitest"


### PR DESCRIPTION
Mailbox applications currently implement their own send claims, immutable attempts, uncertain-outcome recovery and event-to-recipient matching. Add an optional Rails outbox that owns those workflows: save MIME/envelope once under an account-scoped operation key, commit a send claim before HTTP, retain per-recipient acceptance independently of lifecycle state, and require audited reconciliation before an uncertain operation can be retried deliberately under a new key.

Provide Mail/ActionMailer snapshot preparation, identity-only send jobs, replay jobs/tasks, transactional product callbacks, and built-in durable event correlation. Partial unknown recipients can be reconciled without changing confirmed outcomes. Malformed or conflicting provider IDs remain uncertain. Generated migrations refuse destructive rollback. Plain Ruby users keep the lightweight client and no ActiveRecord runtime dependency.

Validation: all 14 CI jobs pass, including PostgreSQL 16 and the Ruby/Rails matrix. Locally: 191 gem tests/637 assertions; nested SQLite suites include 21 outbox tests/112 assertions and 9 snapshot/job/event tests/45 assertions. Actual PostgreSQL 15 verification: 9 tests/45 assertions covering concurrent claims/projection and a terminated DB connection. Packaged verification: 57 tests/280 assertions. Real SIGKILL and post-acceptance persistence failures preserve blocked claims. No live mail, deployment or gem publication. Evidence: docs/verification/2026-09-11-outbound-ledger.md.

Stacked on #5. The Rails inbox adopts this exact implementation in cole-robertson/agentic-inbox-rails-full#30 with preserved attempts/audits and browser/recovery verification. Setup and API: docs/outbox.md.
