### PR TITLE
Harden email ingress, development tunnel and durable event handling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby: ["3.2", "3.3", "3.4"]
-        rails: ["7_1", "7_2", "8_0", "8_1"]
+        rails: ["7_2", "8_0", "8_1"]
         exclude:
           - ruby: "3.2"
             rails: "8_0"
@@ -37,6 +37,8 @@ jobs:
           ruby-version: "${{ matrix.ruby }}"
           bundler-cache: true
       - run: bundle exec rake test
+      - run: gem install bundler-audit --version 0.9.3 --no-document
+      - run: bundler-audit check --update --gemfile-lock "$BUNDLE_GEMFILE.lock"
       - run: bundle exec ruby script/verify_package.rb
         if: matrix.ruby == '3.4' && matrix.rails == '8_1'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
           bundler-cache: true
       - run: bundle exec rake test
       - run: gem install bundler-audit --version 0.9.3 --no-document
-      - run: bundler-audit check --update --gemfile-lock "$BUNDLE_GEMFILE.lock"
+      - run: bundler-audit check --update --gemfile-lock "gemfiles/rails_${{ matrix.rails }}.gemfile.lock"
       - run: bundle exec ruby script/verify_package.rb
         if: matrix.ruby == '3.4' && matrix.rails == '8_1'
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## 0.2.0 — Unreleased
 
+- Bound Rails and Worker inbound reads to 25 MiB by default; reject malformed or
+  stale signing headers before reading MIME. Require HTTPS remote endpoints.
+- Restrict the development tunnel to email ingress and require a running guard;
+  redact client inspection, retry logs, and generated mailbox logging.
+- Validate delivery-event schemas, preserve receipt evidence through ordinary
+  ActiveRecord updates, and tighten provider acceptance response handling.
+- Remove Rails 7.1 support, update patched Rails/SQLite test floors, and audit
+  resolved Ruby dependencies in CI. See the dated security verification report.
+
 - Add an optional durable Rails outbox: immutable MIME/envelope snapshots,
   account-scoped operation keys, committed send claims, per-recipient acceptance
   evidence, blocked uncertain retries, and audited subset reconciliation.

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,5 @@ source "https://rubygems.org"
 
 gemspec
 
-# sqlite3 pin lives here (not in gemspec) so gemfiles/rails_7_1.gemfile
-# can override for older Rails compatibility.
-gem "sqlite3", ">= 2.0"
+# SQLite is optional for consumers; development uses a patched release.
+gem "sqlite3", ">= 2.9.6"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Ruby client for [Cloudflare Email Service](https://developers.cloudflare.com/email-service/), with ActionMailer, authenticated ActionMailbox ingress, a forwarding Worker, and optional durable Rails sending and delivery-event tracking.
 
-Version **0.2.0** (release candidate). Ruby 3.2+, Rails 7.1–8.1; Ruby 4.0 is tested with Rails 8.1. Prefer a maintained Ruby/Rails release for new applications. The plain Ruby client uses Ruby's standard libraries plus the Base64 gem. Node is optional: Worker deployment also works through the included Ruby deployer.
+Version **0.2.0** (release candidate). Ruby 3.2+, Rails 7.2–8.1; Ruby 4.0 is tested with Rails 8.1. Supported test floors are Rails 7.2.3.2, 8.0.5.1, and 8.1.3.1. Prefer a maintained Ruby/Rails release for new applications. The plain Ruby client uses Ruby's standard libraries plus the Base64 gem. Node is optional: Worker deployment also works through the included Ruby deployer. See [security guidance](SECURITY.md) for deployment responsibilities.
 
 ## Install and send from Rails
 
@@ -179,7 +179,7 @@ bin/rails cloudflare:email:deploy_worker
 bin/rails cloudflare:email:dev
 ```
 
-The dev task requires `cloudflared`, refuses environments other than development, and updates the existing development Worker's URL to a temporary tunnel. It sends a localhost Host header to Rails so the normal development host check accepts the request. Configure a separate development receiving address and route. Stopping the tunnel leaves that URL in the development Worker until the next update. A Worker deployed without a URL rejects mail until the tunnel sets it.
+The dev task requires `cloudflared`, refuses environments other than development, and updates the existing development Worker's URL to a temporary tunnel. It forces a dedicated origin Host; development middleware permits only POSTs to the email ingress on that Host. Restart Rails after upgrading: the task checks that the guard is running before opening the tunnel. Configure a separate development receiving address and route. Stopping the tunnel leaves that URL in the development Worker until the next update. A Worker deployed without a URL rejects mail until the tunnel sets it.
 
 For a custom installer `--worker-dir`, pass `SCRIPT=custom-directory/src/index.js` to the Ruby `deploy_worker` task. The installer prints the corresponding command.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,43 @@
+# Security
+
+The current hardening work targets the unreleased 0.2.0 branch. The published
+0.1.0 gem does not include it. Use a reviewed commit containing the fixes until
+a release is published, and redeploy the bundled Worker when upgrading.
+
+Rails integration is tested on patched Rails 7.2, 8.0, and 8.1; application
+owners must update their own Rails, database adapter, and other dependencies.
+The gem does not add Rails or SQLite as runtime dependencies.
+
+Report sensitive findings privately to the maintainer at cole@dscribeai.com.
+Include affected versions and impact; omit real credentials and private mail.
+Do not place secrets or private message data in public issues.
+
+## Deployment responsibilities
+
+- Keep API and management tokens least-privileged and separate. Store tokens and
+  a strong ingress secret in a secret manager or Rails encrypted credentials.
+  Rotate compromised secrets on Rails and the Worker together. HTTPS endpoint
+  overrides are trusted operator configuration; never derive them from mail.
+- Set request-size limits, timeouts and rate limits at the proxy/server. Rails
+  and the Worker bound MIME reads to 25 MiB by default (`MAX_EMAIL_BYTES`), but
+  cannot prevent upstream buffering or slow clients. Limits apply to raw MIME,
+  not just decoded attachments.
+- Treat mail and attachments as untrusted content. The gem authenticates Worker
+  transport and SMTP envelope metadata, not a human sender's identity. Rendering,
+  sanitization, malware scanning and application authorization belong to the app.
+- Protect raw MIME, attachments, outbox snapshots and event receipts with access
+  control, storage encryption, backups and retention policies. Avoid logging raw
+  responses/errors: provider details and application logs can contain private mail.
+- Restrict queue producers and consumers. Event account/domain checks are
+  validation, not cryptographic signatures. Monitor unacknowledged malformed
+  messages, processing failures and unmatched receipts.
+- Database administrators and direct SQL writes are trusted. ActiveRecord
+  read-only evidence fields do not provide tamper-proof storage. Keep tenant
+  authorization around outbox operations and receipt access in the application.
+- Development tunnels expose the ingress to the internet. Use the bundled task,
+  dedicated development mail routes and test data; stop tunnels when finished.
+  The Host guard restricts routing but is not a sandbox for the development app
+  or a replacement for safe error pages and request logging.
+
+See [the September 11 security review](docs/verification/2026-09-11-security.md)
+for findings, verification, and remaining limits.

--- a/app/controllers/cloudflare/email/ingress_controller.rb
+++ b/app/controllers/cloudflare/email/ingress_controller.rb
@@ -16,13 +16,28 @@ module Cloudflare
     # (or in the CLOUDFLARE_INGRESS_SECRET env var) and as the Worker secret
     # INGRESS_SECRET via `wrangler secret put INGRESS_SECRET`.
     class IngressController < ActionMailbox::BaseController
+      DEFAULT_MAX_EMAIL_BYTES = 25 * 1024 * 1024
       param_encoding :create, "raw_email", Encoding::ASCII_8BIT
 
       def create
         ActiveSupport::Notifications.instrument(
           "cloudflare_email.ingress",
-          bytes: raw_body.bytesize,
+          bytes: 0,
         ) do |payload|
+          preflight = Cloudflare::Email::Verification.verify_headers(secret: secret,
+            timestamp: request.headers["X-CF-Email-Timestamp"],
+            signature: request.headers["X-CF-Email-Signature"],
+            version: request.headers["X-CF-Email-Signature-Version"],
+            envelope: request.headers["X-CF-Email-Envelope"])
+          unless preflight == :ok
+            payload[:result] = preflight
+            next head(preflight == :stale ? :request_timeout : :unauthorized)
+          end
+          if request.content_length.to_i > max_email_bytes || raw_body.bytesize > max_email_bytes
+            payload[:result] = :too_large
+            next head(:payload_too_large)
+          end
+          payload[:bytes] = raw_body.bytesize
           case Cloudflare::Email::Verification.verify(
                 secret:    secret,
                 body:      raw_body,
@@ -75,7 +90,15 @@ module Cloudflare
       def raw_body
         @raw_body ||= begin
           request.body.rewind if request.body.respond_to?(:rewind)
-          request.body.read
+          request.body.read(max_email_bytes + 1).to_s
+        end
+      end
+
+      def max_email_bytes
+        @max_email_bytes ||= begin
+          value = Integer(ENV.fetch("MAX_EMAIL_BYTES", DEFAULT_MAX_EMAIL_BYTES.to_s), 10)
+          raise ArgumentError, "MAX_EMAIL_BYTES must be positive" unless value.positive?
+          value
         end
       end
 

--- a/cloudflare-email.gemspec
+++ b/cloudflare-email.gemspec
@@ -33,6 +33,7 @@ Gem::Specification.new do |spec|
     "templates/worker/src/*.js",
     "templates/worker/test/*.test.ts",
     "README.md",
+    "SECURITY.md",
     "docs/**/*.md",
     "examples/*.rb",
     "CHANGELOG.md",
@@ -46,9 +47,9 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "minitest", "~> 5.20"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "webmock", "~> 3.20"
-  spec.add_development_dependency "rails", ">= 7.1", "< 9.0"
-  # sqlite3 version pin is deferred to Gemfile + gemfiles/rails_*.gemfile
-  # variants because Rails 7.1 needs ~> 1.4 while 7.2+ needs >= 2.0.
+  spec.add_development_dependency "rails", ">= 7.2.3.2", "< 9.0"
+  # SQLite is optional runtime infrastructure; development/test bounds live
+  # in the Gemfile variants and include the current security fixes.
   spec.add_development_dependency "rack-test", "~> 2.1"
   # Rails through 8.1 passes a positional options hash to JSON.parse.
   spec.add_development_dependency "json", ">= 2.0", "< 3.0"

--- a/docs/upgrading-0.2.md
+++ b/docs/upgrading-0.2.md
@@ -44,7 +44,16 @@ up to 254 bytes, with a 64-byte local part, and an empty SMTP sender for bounces
 - Both deployment paths now target `cloudflare-email-ingress-<environment>`. Existing unsuffixed Workers are not deleted. Set both secrets on the new Worker, deploy, verify, then deliberately update the corresponding route.
 - The forwarding Worker now times out after 15 seconds and refuses redirects. Ensure the Rails URL is the final HTTPS endpoint. Both deployment paths use compatibility date 2026-09-10.
 - For an installer `--worker-dir` other than the default, pass `SCRIPT=your-directory/src/index.js` to the Ruby deploy task.
-- The development tunnel sets the origin Host to localhost, preserving Rails' normal development host authorization.
+- The development tunnel forces a dedicated origin Host and permits only POSTs to the email ingress. Restart the Rails development server after upgrading; the tunnel task verifies the ingress guard before starting.
+
+## Security hardening
+
+- Upgrade host applications to patched Rails: tested floors are 7.2.3.2, 8.0.5.1, and 8.1.3.1, with SQLite 2.9.6 in the test stacks. Rails 7.1 is no longer supported. These are development/test constraints, not runtime dependency enforcement in your application.
+- Redeploy the bundled Worker after updating the gem. Rails and the Worker now default to a 25 MiB raw-email limit. Set `MAX_EMAIL_BYTES` to the same positive integer on both sides when overriding it. Configure upstream request limits and deadlines too.
+- API and ingress endpoints require HTTPS, with HTTP allowed only for literal loopback development hosts. Remove URL credentials, fragments, and query options from configured Ruby endpoints.
+- Delivery events require recipient, ISO8601 timestamp, a boolean `terminal`, valid identifiers, and object-shaped optional details. Invalid messages remain unacknowledged; monitor and quarantine poison messages through your queue operations.
+- Event receipt identity and original payload are read-only through normal ActiveRecord updates. Privileged database access remains trusted.
+- See [the security review](verification/2026-09-11-security.md) for evidence and limits.
 - Subdomain routes require separately onboarded routing DNS and DNS Read access for preflight. The provisioner no longer enables the parent apex to make a subdomain work.
 - Catch-all provisioning is explicitly zone-wide. A request for a subdomain that resolves to a parent zone fails rather than replacing the parent's catch-all.
 - Apex enablement uses the current routing DNS API. Permission/setup errors stop provisioning; they are no longer ignored.

--- a/docs/verification/2026-09-11-security.md
+++ b/docs/verification/2026-09-11-security.md
@@ -1,0 +1,76 @@
+# Security review — 2026-09-11
+
+Reviewed the 0.2.0 gem at baseline `bd83e067938d5c8df5a7a2ced2cf2a74c3f58e06`
+and applied the hardening described below on `security/gem-hardening`.
+This was a defensive source review, dependency audit and local verification.
+No live penetration testing was performed and no production compromise was
+demonstrated. Prior live test reports describe different revisions.
+
+## Findings and fixes
+
+Priorities are contextual review judgments, not CVSS scores.
+
+| Priority | Finding and prerequisite | Remediation |
+| --- | --- | --- |
+| High | The development tunnel exposed the full Rails origin when enabled, including routes unrelated to email. | Force a dedicated origin Host and install a first-position development middleware that permits only the ingress POST. Refuse to start the tunnel unless the running server has the guard. |
+| High | The old Rails 7.1 test stack resolved dependencies with 12 advisory hits, including ActiveStorage CVE-2026-66066. Application exposure depends on its resolved dependencies and feature use. | Remove that unsupported matrix variant; raise Rails/SQLite test floors and audit resolved Ruby matrix locks in CI. Applications must update their own dependencies. |
+| Medium | Inbound MIME was read without an application bound, allowing large requests/messages to consume memory. Upstream limits determine reachability. | Default 25 MiB bound in Rails and Worker, declared-size checks and bounded stream reads. Reject malformed/stale signing headers before Rails reads the body. Full HMAC verification still follows the read. |
+| Medium | Operator-configured remote HTTP endpoints could transmit credentials or mail without TLS. | Require HTTPS for API and ingress endpoints, except literal loopback development hosts. Validate deploy configuration before remote mutations. Endpoint configuration remains trusted. |
+| Medium | Delivery-event validation omitted important field types; original receipt identity/payload could be changed through ordinary model updates. Requires malformed queue input or application writes. | Validate identifiers, recipient, timestamp, terminal boolean and optional detail objects; mark receipt evidence fields read-only. Preserve unknown schema-1 future event types without projecting an unknown lifecycle state. |
+| Low | Client inspection, retry warnings and generated mailbox logs could disclose tokens or private provider/mail details. | Redact client inspection and remove sensitive fields from those default logging paths. Raw errors/responses remain available to applications. |
+| Low | Provider acceptance helpers treated some malformed success fields or message IDs permissively. | Require explicit boolean success when present, successful HTTP status, valid string IDs and array-shaped recipient outcomes. |
+
+Reviewed HMAC v2/envelope handling, recipient-scoped deduplication, transport
+retries, event account/domain checks and ACK ordering, durable outbox claims,
+tenant/account correlation, evidence storage, deployment/generator behavior,
+package contents and CI permissions. No additional concrete authentication or
+claim-bypass finding was established in these paths; this is not proof that
+all defects are absent.
+
+## Verification
+
+Final Ruby behavior checks used Ruby 3.4.1 and Rails 8.1.3.1:
+
+- `bundle exec rake test`: **205 tests, 751 assertions**, no failures/errors/skips.
+  Includes real Rails subprocesses, SQLite receipts/outbox and development guard.
+- Worker `npm test`: **28 tests passed**, Node 22.23.1.
+- Worker `npm run check`: Wrangler deployment dry-run passed.
+- `script/verify_package.rb`: isolated plain Ruby consumer, packaged Rails
+  installation/ingress and durable outbound checks passed.
+- `script/verify_local_ingress.rb`: actual local workerd-to-Rails verification
+  passed, including exact MIME/binary attachment preservation, trusted envelope,
+  deduplication and separate recipients, routing, invalid/missing credentials,
+  refused redirects and a stalled upstream aborted after 15 seconds.
+  No real email was sent and no Worker was deployed by this run.
+- `bundler-audit 0.9.3`: no known vulnerabilities in the six supported locally
+  resolved lockfiles (default, local ingress, PostgreSQL, Rails 7.2/8.0/8.1).
+  Advisory database commit: `93b32f641f84282183ce58ab1d7204bee50885bd`.
+- `npm audit --audit-level=low`: **zero known vulnerabilities**.
+- `git diff --check`: passed.
+
+Ruby lockfiles are not committed; audits describe these resolutions and the
+advisory database at review time. CI audits newly resolved Ruby matrix stacks.
+PostgreSQL concurrency execution and the broader Ruby matrix are delegated to
+the PR's CI; their results should be checked separately from the local results.
+
+## Remaining boundaries and rollout
+
+See [SECURITY.md](../../SECURITY.md) for application and deployment controls.
+Upstream request buffering, rate limiting and read deadlines remain external.
+Mail rendering, malware scanning, tenant authorization, encryption and retention
+are application responsibilities. Queue write access is an authenticity boundary;
+account labels are not signatures. Read-only ActiveRecord attributes do not
+prevent privileged SQL changes. Inbound deduplication intentionally keys identical
+MIME by SMTP recipient, retaining the first authenticated envelope sender.
+
+The development Host guard restricts routes, but the allowed ingress still runs
+inside the development application: safe error handling and test-only data are
+required. CI action references use version tags rather than immutable commits;
+pinning them is additional supply-chain hardening still available.
+
+These changes are not yet a RubyGems release or a deployed Worker upgrade. The
+dogfood inbox has not been repinned or live-tested against this security branch.
+Rollout requires updating the gem revision, redeploying the Worker, aligning any
+`MAX_EMAIL_BYTES` override, updating application dependencies and restarting Rails
+before opening a development tunnel. Do not equate the earlier dogfood results
+with verification of this revision in a deployed application.

--- a/gemfiles/rails_7_1.gemfile
+++ b/gemfiles/rails_7_1.gemfile
@@ -1,6 +1,0 @@
-source "https://rubygems.org"
-
-gemspec path: ".."
-
-gem "rails", "~> 7.1.0"
-gem "sqlite3", "~> 1.4"

--- a/gemfiles/rails_7_2.gemfile
+++ b/gemfiles/rails_7_2.gemfile
@@ -2,5 +2,5 @@ source "https://rubygems.org"
 
 gemspec path: ".."
 
-gem "rails", "~> 7.2.0"
-gem "sqlite3", "~> 2.0"
+gem "rails", "~> 7.2.0", ">= 7.2.3.2"
+gem "sqlite3", "~> 2.0", ">= 2.9.6"

--- a/gemfiles/rails_8_0.gemfile
+++ b/gemfiles/rails_8_0.gemfile
@@ -2,5 +2,5 @@ source "https://rubygems.org"
 
 gemspec path: ".."
 
-gem "rails", "~> 8.0.0"
-gem "sqlite3", ">= 2.1"
+gem "rails", "~> 8.0.0", ">= 8.0.5.1"
+gem "sqlite3", ">= 2.9.6"

--- a/gemfiles/rails_8_1.gemfile
+++ b/gemfiles/rails_8_1.gemfile
@@ -2,5 +2,5 @@ source "https://rubygems.org"
 
 gemspec path: ".."
 
-gem "rails", "~> 8.1.0"
-gem "sqlite3", ">= 2.1"
+gem "rails", "~> 8.1.0", ">= 8.1.3.1"
+gem "sqlite3", ">= 2.9.6"

--- a/lib/cloudflare/email/active_record/event_receipt.rb
+++ b/lib/cloudflare/email/active_record/event_receipt.rb
@@ -3,6 +3,7 @@ module Cloudflare
     module ActiveRecord
       class EventReceipt < ::ActiveRecord::Base
         self.table_name = "cloudflare_email_event_receipts"
+        attr_readonly :account_id, :event_id, :message_id, :payload_json
 
         # JSON text avoids a dependency on database-specific JSON column types.
         def event

--- a/lib/cloudflare/email/client.rb
+++ b/lib/cloudflare/email/client.rb
@@ -2,6 +2,7 @@ require "net/http"
 require "json"
 require "uri"
 require "time"
+require "cloudflare/email/endpoint"
 
 module Cloudflare
   module Email
@@ -25,18 +26,26 @@ module Cloudflare
                      retries: DEFAULT_RETRIES, timeout: DEFAULT_TIMEOUT,
                      initial_backoff: DEFAULT_BACKOFF, max_retry_after: MAX_RETRY_AFTER,
                      retry_ambiguous: false, logger: nil)
-        raise ConfigurationError, "account_id is required" if account_id.nil? || account_id.to_s.empty?
-        raise ConfigurationError, "api_token is required"  if api_token.nil?  || api_token.to_s.empty?
+        unless account_id.is_a?(String) && account_id.match?(/\A[a-zA-Z0-9_-]+\z/)
+          raise ConfigurationError, "account_id is required and must be a single account identifier"
+        end
+        unless api_token.is_a?(String) && !api_token.empty? && !api_token.match?(/\s/)
+          raise ConfigurationError, "api_token is required and must not contain whitespace"
+        end
 
         @account_id      = account_id
         @api_token       = api_token
-        @base_url        = base_url
+        @base_url        = Endpoint.parse(base_url).to_s.delete_suffix("/")
         @retries         = retries
         @timeout         = timeout
         @initial_backoff = initial_backoff
         @max_retry_after = max_retry_after
         @logger          = logger
         @retry_ambiguous = retry_ambiguous
+      end
+
+      def inspect
+        "#<#{self.class.name} account_id=#{@account_id.inspect} api_token=[REDACTED]>"
       end
 
       def send(from:, subject:, to: nil, text: nil, html: nil, cc: nil, bcc: nil,
@@ -199,7 +208,7 @@ module Cloudflare
 
         case status
         when 200..299
-          if body.is_a?(Hash) && body["success"] == false
+          if body.is_a?(Hash) && body.key?("success") && body["success"] != true
             raise Error.new(extract_message(body), status: status, response: body)
           end
           unless body.is_a?(Hash) && body["result"].is_a?(Hash)
@@ -239,7 +248,8 @@ module Cloudflare
 
       def log_retry(attempt, error)
         return unless @logger
-        @logger.warn("[cloudflare-email] retry #{attempt}: #{error.class}: #{error.message}")
+        # Provider messages can echo message content or other sensitive data.
+        @logger.warn("[cloudflare-email] retry #{attempt}: #{error.class}")
       end
     end
   end

--- a/lib/cloudflare/email/delivery_event.rb
+++ b/lib/cloudflare/email/delivery_event.rb
@@ -17,9 +17,17 @@ module Cloudflare
                raw["payload"].is_a?(Hash) && raw["source"].is_a?(Hash) &&
                raw["source"]["type"] == "email.sending" && raw["metadata"].is_a?(Hash) &&
                raw["metadata"]["eventSchemaVersion"] == 1 &&
-               [event_id, message_id, account_id, domain].all? { |value| value.is_a?(String) && !value.empty? }
+               [event_id, message_id, account_id, domain, recipient].all? { |value| valid_identifier?(value) } &&
+               [true, false].include?(payload["terminal"]) &&
+               %w[delivery bounce complaint rejection failure].all? { |key| !payload.key?(key) || payload[key].is_a?(Hash) }
           raise ValidationError, "invalid Email Sending event or unsupported schema version"
         end
+        unless occurred_at.is_a?(String) && valid_identifier?(occurred_at)
+          raise ValidationError, "delivery event timestamp must be ISO8601"
+        end
+        Time.iso8601(occurred_at)
+      rescue ArgumentError
+        raise ValidationError, "delivery event timestamp must be ISO8601"
       end
 
       def type = raw["type"]
@@ -50,6 +58,12 @@ module Cloudflare
         incoming = Time.iso8601(self.occurred_at.to_s)
         previous = occurred_at.is_a?(Time) ? occurred_at : Time.iso8601(occurred_at.to_s) unless occurred_at.nil?
         previous.nil? || incoming > previous
+      end
+
+      private
+
+      def valid_identifier?(value)
+        value.is_a?(String) && !value.strip.empty? && !value.match?(/[[:cntrl:]]/)
       end
     end
   end

--- a/lib/cloudflare/email/deploy_worker_task.rb
+++ b/lib/cloudflare/email/deploy_worker_task.rb
@@ -20,6 +20,9 @@ module Cloudflare
         path = script_path
         raise "Worker script not found at #{path} — re-run `bin/rails g cloudflare:email:install`" unless File.exist?(path)
 
+        # Validate before uploading code or rotating any deployed secrets.
+        Endpoint.parse(url) unless url.to_s.empty?
+
         deployer = Cloudflare::Email::WorkerDeployer.new(
           account_id: account_id, api_token: management_token,
         )

--- a/lib/cloudflare/email/dev_ingress_guard.rb
+++ b/lib/cloudflare/email/dev_ingress_guard.rb
@@ -1,0 +1,27 @@
+module Cloudflare
+  module Email
+    # cloudflared forces this origin Host. Restrict tunnel traffic before Rails
+    # routing, debug middleware and normal host authorization execute.
+    class DevIngressGuard
+      HOST = "cloudflare-email-ingress.localhost".freeze
+      PATH = "/rails/action_mailbox/cloudflare/inbound_emails".freeze
+      RESPONSE_HEADER = "x-cloudflare-email-ingress-only".freeze
+
+      def initialize(app)
+        @app = app
+      end
+
+      def call(env)
+        return @app.call(env) unless env["HTTP_HOST"].to_s.downcase.split(":", 2).first == HOST
+        unless env["REQUEST_METHOD"] == "POST" && env["PATH_INFO"] == PATH
+          return [404, { "content-type" => "text/plain", "content-length" => "0", RESPONSE_HEADER => "1" }, []]
+        end
+        forwarded = env.dup
+        forwarded["HTTP_HOST"] = "localhost"
+        forwarded.delete("HTTP_X_FORWARDED_HOST")
+        forwarded.delete("HTTP_FORWARDED")
+        @app.call(forwarded)
+      end
+    end
+  end
+end

--- a/lib/cloudflare/email/dev_tunnel.rb
+++ b/lib/cloudflare/email/dev_tunnel.rb
@@ -1,5 +1,6 @@
 require "cloudflare/email/worker_deployer"
 require "tempfile"
+require "cloudflare/email/dev_ingress_guard"
 
 module Cloudflare
   module Email
@@ -14,6 +15,7 @@ module Cloudflare
       end
 
       def initialize(port:, io: $stdout)
+        raise ArgumentError, "port must be between 1 and 65535" unless port.is_a?(Integer) && (1..65_535).cover?(port)
         @port       = port
         @io         = io
         @tunnel_pid = nil
@@ -64,11 +66,25 @@ module Cloudflare
           raise "cloudflared not found in PATH — install from https://developers.cloudflare.com/cloudflared/"
         end
         require "cloudflare/email/credentials"
-        if Cloudflare::Email::Credentials.account_id.empty? ||
-           Cloudflare::Email::Credentials.management_token.empty?
+        if Cloudflare::Email::Credentials.account_id.to_s.empty? ||
+           Cloudflare::Email::Credentials.management_token.to_s.empty?
           raise "Missing cloudflare.account_id or cloudflare.api_token in credentials " \
                 "(or CLOUDFLARE_ACCOUNT_ID / CLOUDFLARE_API_TOKEN env vars)"
         end
+        verify_ingress_guard!
+      end
+
+      def verify_ingress_guard!
+        http = Net::HTTP.new("127.0.0.1", @port, nil)
+        http.open_timeout = http.read_timeout = 2
+        request = Net::HTTP::Get.new("/")
+        request["Host"] = DevIngressGuard::HOST
+        response = http.request(request)
+        unless response.code == "404" && response[DevIngressGuard::RESPONSE_HEADER] == "1"
+          raise "Restart the development Rails server with the ingress-only middleware before opening a tunnel"
+        end
+      rescue SystemCallError, IOError, Timeout::Error
+        raise "Start the development Rails server with the ingress-only middleware before opening a tunnel"
       end
 
       def start_tunnel
@@ -76,7 +92,7 @@ module Cloudflare
         @tunnel_log = Tempfile.new(["cloudflare-email-dev-tunnel", ".log"])
         @tunnel_pid = spawn(
           "cloudflared", "tunnel", "--url", "http://127.0.0.1:#{@port}",
-          "--http-host-header", "localhost",
+          "--http-host-header", DevIngressGuard::HOST,
           out: @tunnel_log, err: @tunnel_log,
         )
       end

--- a/lib/cloudflare/email/endpoint.rb
+++ b/lib/cloudflare/email/endpoint.rb
@@ -1,0 +1,24 @@
+require "uri"
+require "cloudflare/email/error"
+
+module Cloudflare
+  module Email
+    # Endpoints are trusted operator configuration, never message-derived URLs.
+    # Plain HTTP is only suitable for literal loopback development fixtures.
+    module Endpoint
+      LOOPBACK_HOSTS = %w[localhost 127.0.0.1 ::1].freeze
+
+      def self.parse(value, allow_loopback: true)
+        uri = URI.parse(value.to_s)
+        secure = uri.is_a?(URI::HTTPS)
+        local = allow_loopback && uri.is_a?(URI::HTTP) && LOOPBACK_HOSTS.include?(uri.hostname.to_s.downcase)
+        unless (secure || local) && !uri.hostname.to_s.empty? && !uri.userinfo && !uri.query && !uri.fragment
+          raise ConfigurationError, "endpoint must use HTTPS (HTTP only on literal loopback), without credentials, query or fragment"
+        end
+        uri
+      rescue URI::InvalidURIError
+        raise ConfigurationError, "endpoint must be a valid HTTPS URL"
+      end
+    end
+  end
+end

--- a/lib/cloudflare/email/engine.rb
+++ b/lib/cloudflare/email/engine.rb
@@ -1,4 +1,5 @@
 require "rails/engine"
+require "cloudflare/email/dev_ingress_guard"
 
 # Register the delivery method at engine load time (not inside an initializer)
 # so the `cloudflare_settings=` accessor exists before Rails' own
@@ -12,6 +13,10 @@ module Cloudflare
   module Email
     class Engine < ::Rails::Engine
       isolate_namespace Cloudflare::Email
+
+      initializer "cloudflare-email.development_ingress_guard" do |app|
+        app.middleware.insert_before 0, DevIngressGuard if Rails.env.development?
+      end
 
       config.before_initialize do
         unless defined?(::ActionMailbox::Engine)

--- a/lib/cloudflare/email/response.rb
+++ b/lib/cloudflare/email/response.rb
@@ -1,3 +1,5 @@
+require "cloudflare/email/message_id"
+
 module Cloudflare
   module Email
     class Response
@@ -9,8 +11,9 @@ module Cloudflare
       end
 
       def success?
-        return !!@raw["success"] if @raw.key?("success") && !@raw["success"].nil?
-        @status >= 200 && @status < 300
+        return false unless @status.is_a?(Integer) && @status >= 200 && @status < 300
+        return @raw["success"] == true if @raw.key?("success")
+        true
       end
 
       def result
@@ -20,14 +23,18 @@ module Cloudflare
       # Provider acceptance is not final delivery. A partial acceptance is true;
       # inspect recipient outcomes before retrying any rejected recipients.
       def accepted?
+        return false if %w[delivered queued permanent_bounces suppressed_recipients].any? { |key| result.key?(key) && !result[key].is_a?(Array) }
         success? && (delivered.any? || queued.any? ||
           (!message_id.to_s.strip.empty? && permanent_bounces.empty? && suppressed_recipients.empty?))
       end
 
       def message_id
-        result["message_id"] ||
+        value = result["message_id"] ||
           dig_message_id(result["delivered"]) ||
           dig_message_id(result["queued"])
+        return nil unless value.is_a?(String)
+        normalized = MessageId.normalize(value)
+        value unless normalized.empty? || normalized.match?(/[\s<>[:cntrl:]]/)
       end
 
       def delivered

--- a/lib/cloudflare/email/routing_provisioner.rb
+++ b/lib/cloudflare/email/routing_provisioner.rb
@@ -1,6 +1,7 @@
 require "net/http"
 require "json"
 require "uri"
+require "cloudflare/email/endpoint"
 
 module Cloudflare
   module Email
@@ -30,7 +31,7 @@ module Cloudflare
       def initialize(api_token:, api_base: API_BASE)
         raise ArgumentError, "api_token is required" if api_token.to_s.empty?
         @api_token = api_token
-        @api_base  = api_base
+        @api_base  = Endpoint.parse(api_base).to_s.delete_suffix("/")
       end
 
       # High-level: given an address + Worker name, do everything needed to

--- a/lib/cloudflare/email/verification.rb
+++ b/lib/cloudflare/email/verification.rb
@@ -20,7 +20,24 @@ module Cloudflare
       # Returns :ok, :bad_signature, or :stale.
       # Returns :bad_signature for any malformed input.
       def self.verify(secret:, body:, timestamp:, signature:, version: nil, envelope: nil, window: DEFAULT_WINDOW, now: Time.now.to_i)
-        return :bad_signature if blank?(secret) || blank?(body) || blank?(timestamp) || blank?(signature)
+        return :bad_signature if blank?(body)
+        timestamp = timestamp.to_s if timestamp.is_a?(Integer)
+        preflight = verify_headers(secret: secret, timestamp: timestamp, signature: signature,
+          version: version, envelope: envelope, window: window, now: now)
+        return preflight unless preflight == :ok
+
+        expected = sign(secret: secret, body: body, timestamp: Integer(timestamp, 10), version: version, envelope: envelope)
+        return :bad_signature unless Signing.secure_compare(expected, signature)
+
+        :ok
+      end
+
+      # Reject malformed/stale requests before the controller reads MIME bytes.
+      # This is only a preflight: authentication still requires verify(body: ...).
+      def self.verify_headers(secret:, timestamp:, signature:, version:, envelope:, window: DEFAULT_WINDOW, now: Time.now.to_i)
+        return :bad_signature if blank?(secret)
+        return :bad_signature unless timestamp.is_a?(String) && /\A[0-9]{1,20}\z/.match?(timestamp)
+        return :bad_signature unless signature.is_a?(String) && /\A[0-9a-f]{64}\z/.match?(signature)
         return :bad_signature unless version == "2" && Envelope.decode(envelope)
 
         ts = begin
@@ -30,9 +47,6 @@ module Cloudflare
         end
 
         return :stale if (now - ts).abs > window
-
-        expected = sign(secret: secret, body: body, timestamp: ts, version: version, envelope: envelope)
-        return :bad_signature unless Signing.secure_compare(expected, signature.to_s)
 
         :ok
       end

--- a/lib/cloudflare/email/worker_deployer.rb
+++ b/lib/cloudflare/email/worker_deployer.rb
@@ -1,6 +1,7 @@
 require "net/http"
 require "json"
 require "securerandom"
+require "cloudflare/email/endpoint"
 
 module Cloudflare
   module Email
@@ -49,7 +50,7 @@ module Cloudflare
         @api_token          = api_token
         @script_name        = script_name
         @compatibility_date = compatibility_date
-        @api_base           = api_base
+        @api_base           = Endpoint.parse(api_base).to_s.delete_suffix("/")
       end
 
       # Uploads/updates the Worker script. Accepts either `script_path:` (a
@@ -71,6 +72,7 @@ module Cloudflare
 
       # Set/update a Worker secret.
       def put_secret(name, value)
+        Endpoint.parse(value) if name.to_s == "RAILS_INGRESS_URL"
         request(
           method: :put,
           path:   "/accounts/#{@account_id}/workers/scripts/#{@script_name}/secrets",

--- a/lib/generators/cloudflare/email/install_generator.rb
+++ b/lib/generators/cloudflare/email/install_generator.rb
@@ -129,6 +129,9 @@ module Cloudflare
                 return
               end
 
+              require "cloudflare/email/endpoint"
+              Cloudflare::Email::Endpoint.parse(ingress_url.strip)
+
               run "npm run deploy -- --env production", abort_on_failure: true
               run_with_stdin("npx --no-install wrangler secret put RAILS_INGRESS_URL --env production", ingress_url.strip)
               run_with_stdin("npx --no-install wrangler secret put INGRESS_SECRET --env production", @ingress_secret)

--- a/lib/generators/cloudflare/email/templates/main_mailbox.rb
+++ b/lib/generators/cloudflare/email/templates/main_mailbox.rb
@@ -6,13 +6,8 @@
 # ActionMailbox API (mail is a Mail::Message, inbound_email is the AR record).
 class MainMailbox < ApplicationMailbox
   def process
-    Rails.logger.info(
-      "[cloudflare-email] inbound received: " \
-      "from=#{mail.from&.first.inspect} " \
-      "to=#{Array(mail.to).inspect} " \
-      "subject=#{mail.subject.inspect} " \
-      "message_id=#{mail.message_id.inspect}"
-    )
+    # Keep message content and personal addresses out of application logs.
+    Rails.logger.info("[cloudflare-email] inbound received: inbound_email_id=#{inbound_email.id}")
 
     # Example ways to pull content out of the incoming message:
     #

--- a/templates/worker/README.md
+++ b/templates/worker/README.md
@@ -22,6 +22,16 @@ for each environment you use. For local development, run
 `npm run dev -- --env development`, with secrets in `.dev.vars.development`.
 Never put secrets into `wrangler.toml` or version control.
 
+The Worker refuses non-HTTPS destinations, URL credentials, and fragments.
+HTTP is allowed only for `localhost`, `127.0.0.1`, or `[::1]` local verification.
+The Worker and Rails ingress each default to a 25 MiB MIME size limit. Set
+`MAX_EMAIL_BYTES` to the same positive integer in both environments to change
+that limit. Both check actual body bytes; declared sizes alone are not trusted.
+Rails returns HTTP 413 for oversized mail and rejects malformed or stale signing
+headers before reading the body. Configure request size/rate limits and read
+timeouts at your reverse proxy as well: application limits do not bound earlier
+server buffering or the time spent receiving an HTTP request.
+
 Then in the Cloudflare dashboard:
 
 1. **Email Routing → Routes**

--- a/templates/worker/src/index.js
+++ b/templates/worker/src/index.js
@@ -44,10 +44,55 @@ function validAddress(address, allowEmpty = false) {
     domain.split(".").every(label => /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?$/.test(label));
 }
 
+function validIngressUrl(value) {
+  try {
+    const url = new URL(value);
+    const loopback = ["localhost", "127.0.0.1", "[::1]"].includes(url.hostname);
+    return !url.username && !url.password && !url.hash &&
+      (url.protocol === "https:" || (url.protocol === "http:" && loopback));
+  } catch { return false; }
+}
+
+async function readBounded(stream, limit) {
+  const reader = stream.getReader();
+  const chunks = [];
+  let size = 0;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      size += value.byteLength;
+      if (size > limit) {
+        await reader.cancel();
+        throw new Error("message exceeds size limit");
+      }
+      chunks.push(value);
+    }
+  } finally { reader.releaseLock(); }
+  const raw = new Uint8Array(size);
+  let offset = 0;
+  for (const chunk of chunks) { raw.set(chunk, offset); offset += chunk.byteLength; }
+  return raw;
+}
+
 export default {
   async email(message, env) {
     if (!env.RAILS_INGRESS_URL || !env.INGRESS_SECRET) {
       message.setReject("worker missing RAILS_INGRESS_URL or INGRESS_SECRET");
+      return;
+    }
+
+    if (!validIngressUrl(env.RAILS_INGRESS_URL)) {
+      message.setReject("worker requires an HTTPS ingress URL (HTTP allowed only for loopback)");
+      return;
+    }
+    const limit = env.MAX_EMAIL_BYTES === undefined ? 25 * 1024 * 1024 : Number(env.MAX_EMAIL_BYTES);
+    if (!Number.isSafeInteger(limit) || limit <= 0) {
+      message.setReject("worker MAX_EMAIL_BYTES must be a positive integer");
+      return;
+    }
+    if (message.rawSize > limit) {
+      message.setReject("message exceeds size limit");
       return;
     }
 
@@ -59,7 +104,13 @@ export default {
     const envelope = btoa(JSON.stringify({ from: message.from, to: message.to }))
       .replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
 
-    const raw = new Uint8Array(await new Response(message.raw).arrayBuffer());
+    let raw;
+    try {
+      raw = await readBounded(message.raw, limit);
+    } catch {
+      message.setReject("message exceeds size limit or could not be read");
+      return;
+    }
     const ts = Math.floor(Date.now() / 1000).toString();
 
     const tsBytes = new TextEncoder().encode(`v2.${ts}.${envelope}.`);

--- a/templates/worker/test/index.test.ts
+++ b/templates/worker/test/index.test.ts
@@ -90,6 +90,46 @@ describe("cloudflare-email Worker", () => {
     expect(ok).toBe(true);
   });
 
+  it.each(["http://rails.test/inbound", "https://user:password@rails.test/inbound", "https://rails.test/inbound#fragment", "invalid"])(
+    "rejects invalid ingress URL %j before reading mail", async (url) => {
+      const { message, rejects } = makeMessage(RAW);
+      await worker.email(message as any, { RAILS_INGRESS_URL: url, INGRESS_SECRET: SECRET });
+      expect(rejects).toHaveLength(1);
+      expect(fetchSpy).not.toHaveBeenCalled();
+      expect(message.raw.locked).toBe(false);
+    },
+  );
+
+  it("allows loopback HTTP for local verification", async () => {
+    const { message, rejects } = makeMessage(RAW);
+    await worker.email(message as any, { RAILS_INGRESS_URL: "http://127.0.0.1:3000/inbound", INGRESS_SECRET: SECRET });
+    expect(rejects).toEqual([]);
+    expect(fetchSpy).toHaveBeenCalledOnce();
+  });
+
+  it("accepts mail at the configured size boundary", async () => {
+    const { message, rejects } = makeMessage(RAW);
+    await worker.email(message as any, { RAILS_INGRESS_URL: URL_, INGRESS_SECRET: SECRET, MAX_EMAIL_BYTES: String(message.rawSize) });
+    expect(rejects).toEqual([]);
+    expect(fetchSpy).toHaveBeenCalledOnce();
+  });
+
+  it.each([true, false])("enforces size limit with accurate rawSize=%j", async (accurate) => {
+    const { message, rejects } = makeMessage(RAW);
+    if (!accurate) message.rawSize = 0;
+    await worker.email(message as any, { RAILS_INGRESS_URL: URL_, INGRESS_SECRET: SECRET, MAX_EMAIL_BYTES: "16" });
+    expect(rejects).toHaveLength(1);
+    expect(rejects[0]).toMatch(/size limit/);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("rejects invalid size configuration", async () => {
+    const { message, rejects } = makeMessage(RAW);
+    await worker.email(message as any, { RAILS_INGRESS_URL: URL_, INGRESS_SECRET: SECRET, MAX_EMAIL_BYTES: "0" });
+    expect(rejects).toHaveLength(1);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
   it("rejects the message when upstream returns non-2xx", async () => {
     fetchSpy.mockResolvedValueOnce(new Response("server error", { status: 503 }));
     const env = { RAILS_INGRESS_URL: URL_, INGRESS_SECRET: SECRET };

--- a/test/delivery_event_test.rb
+++ b/test/delivery_event_test.rb
@@ -88,4 +88,28 @@ class DeliveryEventTest < Minitest::Test
       end
     end
   end
+
+  def test_rejects_malformed_projection_fields
+    invalid = {
+      ["payload", "recipient"] => [nil, "", "  ", [], "user\n@example.net"],
+      ["payload", "terminal"] => [nil, "false", "true", 0, 1],
+      ["metadata", "eventTimestamp"] => [nil, "", "tomorrow", 123, "2026-06-01T02:48:57Z\n"],
+      ["payload", "eventId"] => ["  ", "event\0id"],
+      ["payload", "messageId"] => ["  ", "message\rid"],
+      ["metadata", "accountId"] => ["  ", "account\nid"],
+      ["source", "domain"] => ["  ", "domain\tid"],
+    }
+    %w[delivery bounce complaint rejection failure].each do |field|
+      invalid[["payload", field]] = [nil, false, "detail", []]
+    end
+    invalid.each do |(section, key), values|
+      values.each do |value|
+        raw = event_data
+        raw[section][key] = value
+        assert_raises(Cloudflare::Email::ValidationError, "accepted malformed #{section}.#{key}") do
+          Cloudflare::Email::DeliveryEvent.new(raw)
+        end
+      end
+    end
+  end
 end

--- a/test/event_consumer_test.rb
+++ b/test/event_consumer_test.rb
@@ -17,8 +17,8 @@ class EventConsumerTest < Minitest::Test
     {
       "type" => "cf.email.sending.message.delivered",
       "source" => { "type" => "email.sending", "domain" => "send.example.com" },
-      "payload" => { "eventId" => "event-123", "messageId" => "message-456", "terminal" => true },
-      "metadata" => { "accountId" => ACCOUNT_ID, "eventSchemaVersion" => 1 },
+      "payload" => { "eventId" => "event-123", "messageId" => "message-456", "terminal" => true, "recipient" => "user@example.net" },
+      "metadata" => { "accountId" => ACCOUNT_ID, "eventSchemaVersion" => 1, "eventTimestamp" => "2026-06-01T02:48:57Z" },
     }
   end
 
@@ -144,6 +144,14 @@ class EventConsumerTest < Minitest::Test
     assert_raises(Cloudflare::Email::Error) { @consumer.poll { handled += 1 } }
     assert_equal 1, handled
     assert_requested ack, times: 1
+  end
+
+  def test_malformed_event_schema_never_reaches_handler_or_ack
+    raw = event_data
+    raw["payload"]["terminal"] = "true"
+    stub_pull([queue_message(raw)])
+    assert_raises(Cloudflare::Email::ValidationError) { @consumer.poll { flunk "invalid schema yielded" } }
+    assert_not_requested :post, endpoint("ack")
   end
 
   def test_successful_http_response_with_no_acknowledged_message_is_failure

--- a/test/rails_integration_test.rb
+++ b/test/rails_integration_test.rb
@@ -3,6 +3,11 @@ require "open3"
 require "rbconfig"
 
 class RailsIntegrationTest < Minitest::Test
+  def test_development_tunnel_guard_boot
+    output, status = Open3.capture2e(RbConfig.ruby, File.expand_path("support/development_guard.rb", __dir__))
+    assert status.success?, output
+  end
+
   %w[inbound send_only fresh_inbound].each do |mode|
     define_method("test_#{mode}_application") do
       output, status = Open3.capture2e(

--- a/test/routing_provisioner_test.rb
+++ b/test/routing_provisioner_test.rb
@@ -19,6 +19,13 @@ class RoutingProvisionerTest < Minitest::Test
     end
   end
 
+  def test_rejects_insecure_remote_api_endpoint_before_sending_credentials
+    assert_raises(Cloudflare::Email::ConfigurationError) do
+      Cloudflare::Email::RoutingProvisioner.new(api_token: TOKEN, api_base: "http://api.example.test/client/v4")
+    end
+    assert_not_requested :any, %r{api.example.test}
+  end
+
   def test_expand_parent_domains
     p = make
     assert_equal ["a.b.example.com", "b.example.com", "example.com"],

--- a/test/security_defaults_test.rb
+++ b/test/security_defaults_test.rb
@@ -1,0 +1,79 @@
+require "test_helper"
+require "cloudflare/email/endpoint"
+require "cloudflare/email/dev_ingress_guard"
+require "cloudflare/email/dev_tunnel"
+
+class SecurityDefaultsTest < Minitest::Test
+  def test_endpoint_policy_preserves_https_and_loopback_only
+    ["https://api.example.test/v4", "http://localhost:3000", "http://127.0.0.1:3000", "http://[::1]:3000"].each do |value|
+      assert_equal value, Cloudflare::Email::Endpoint.parse(value).to_s
+    end
+    ["http://app.example.test", "https://user:password@app.example.test", "https://app.example.test/#section", "https://app.example.test/?option=1", "relative-path"].each do |value|
+      assert_raises(Cloudflare::Email::ConfigurationError) { Cloudflare::Email::Endpoint.parse(value) }
+    end
+    assert_raises(Cloudflare::Email::ConfigurationError) { Cloudflare::Email::Endpoint.parse("http://localhost:3000", allow_loopback: false) }
+  end
+
+  def test_client_rejects_non_identifier_accounts_and_insecure_remote_endpoints_before_requests
+    assert_raises(Cloudflare::Email::ConfigurationError) { make_client(account_id: "two accounts") }
+    assert_raises(Cloudflare::Email::ConfigurationError) { make_client(base_url: "http://app.example.test") }
+    assert_equal "https://api.example.test/v4", make_client(base_url: "https://api.example.test/v4/").base_url
+    refute_includes make_client.inspect, API_TOKEN
+  end
+
+  def test_retry_logging_does_not_include_provider_message_text
+    warnings = []
+    logger = Object.new
+    logger.define_singleton_method(:warn) { |message| warnings << message }
+    stub_request(:post, send_endpoint).to_return(status: 429,
+      body: JSON.generate(success: false, errors: [{ message: "private email details" }]))
+      .then.to_return(body: JSON.generate(cloudflare_success_body))
+    make_client(retries: 1, logger: logger).send(from: "sender@example.com", to: "user@example.com", subject: "hello", text: "body")
+    assert_equal 1, warnings.length
+    refute_includes warnings.first, "private email details"
+  end
+
+  def test_explicit_success_flags_must_be_boolean_and_http_status_successful
+    [nil, "true", "false", 1].each do |flag|
+      refute Cloudflare::Email::Response.new({ "success" => flag }).success?
+      stub_request(:post, send_endpoint).to_return(body: JSON.generate(success: flag, result: { message_id: "message" }))
+      assert_raises(Cloudflare::Email::Error) { make_client.send(from: "a@example.com", to: "b@example.com", subject: "s", text: "t") }
+    end
+    refute Cloudflare::Email::Response.new({ "success" => true }, status: 500).success?
+    [true, {}, 1, ""].each do |id|
+      response = Cloudflare::Email::Response.new({ "success" => true, "result" => { "message_id" => id } })
+      assert_nil response.message_id
+      refute response.accepted?
+    end
+    refute Cloudflare::Email::Response.new({ "success" => true, "result" => { "queued" => "unexpected scalar" } }).accepted?
+  end
+
+  def test_tunnel_host_restricts_path_and_method_before_application
+    calls = []
+    guard = Cloudflare::Email::DevIngressGuard
+    app = guard.new(->(env) { calls << env; [200, {}, ["application"]] })
+    ["/", "/other"].each do |path|
+      response = app.call("HTTP_HOST" => guard::HOST, "REQUEST_METHOD" => "GET", "PATH_INFO" => path)
+      assert_equal 404, response.first
+      assert_equal "1", response[1][guard::RESPONSE_HEADER]
+    end
+    assert_equal 404, app.call("HTTP_HOST" => guard::HOST, "REQUEST_METHOD" => "GET", "PATH_INFO" => guard::PATH).first
+    assert_empty calls
+    assert_equal 200, app.call("HTTP_HOST" => guard::HOST, "REQUEST_METHOD" => "POST", "PATH_INFO" => guard::PATH,
+      "HTTP_X_FORWARDED_HOST" => "public.example.test", "HTTP_FORWARDED" => "host=public.example.test").first
+    assert_equal "localhost", calls.last["HTTP_HOST"]
+    refute calls.last.key?("HTTP_X_FORWARDED_HOST")
+    refute calls.last.key?("HTTP_FORWARDED")
+    assert_equal 200, app.call("HTTP_HOST" => "localhost", "REQUEST_METHOD" => "GET", "PATH_INFO" => "/").first
+  end
+
+  def test_tunnel_requires_running_guard_before_public_exposure
+    tunnel = Cloudflare::Email::DevTunnel.new(port: 3456)
+    stub_request(:get, "http://127.0.0.1:3456/").with(headers: { "Host" => Cloudflare::Email::DevIngressGuard::HOST })
+      .to_return(status: 404)
+    assert_raises(RuntimeError) { tunnel.send(:verify_ingress_guard!) }
+    stub_request(:get, "http://127.0.0.1:3456/").with(headers: { "Host" => Cloudflare::Email::DevIngressGuard::HOST })
+      .to_return(status: 404, headers: { Cloudflare::Email::DevIngressGuard::RESPONSE_HEADER => "1" })
+    tunnel.send(:verify_ingress_guard!)
+  end
+end

--- a/test/support/development_guard.rb
+++ b/test/support/development_guard.rb
@@ -1,0 +1,40 @@
+ENV["RAILS_ENV"] = "development"
+require "tmpdir"
+require "fileutils"
+require "minitest/autorun"
+require "rails"
+require "action_controller/railtie"
+gem_root = ENV.fetch("CLOUDFLARE_EMAIL_TEST_GEM_ROOT", File.expand_path("../..", __dir__))
+$LOAD_PATH.unshift File.join(gem_root, "lib")
+require "cloudflare-email"
+require "rack/mock"
+
+GUARD_ROOT = Dir.mktmpdir("cloudflare-email-guard")
+Minitest.after_run { FileUtils.remove_entry(GUARD_ROOT) }
+class GuardDevelopmentApp < Rails::Application
+  config.root = GUARD_ROOT
+  config.eager_load = false
+  config.secret_key_base = "x" * 64
+  config.hosts = ["localhost"]
+  config.logger = Logger.new(File::NULL)
+end
+GuardDevelopmentApp.initialize!
+Rails.application.routes.draw do
+  get "/", to: ->(_env) { [200, { "content-type" => "text/plain" }, ["local development"]] }
+  post Cloudflare::Email::DevIngressGuard::PATH, to: ->(_env) { [204, {}, []] }
+end
+
+class DevelopmentGuardTest < Minitest::Test
+  def test_guard_is_installed_before_host_authorization_and_routing
+    request = Rack::MockRequest.new(Rails.application)
+    guard = Cloudflare::Email::DevIngressGuard
+    hidden = request.get("/", "HTTP_HOST" => guard::HOST)
+    assert_equal 404, hidden.status
+    assert_equal "1", hidden[guard::RESPONSE_HEADER]
+    assert_empty hidden.body
+    assert_equal 200, request.get("/", "HTTP_HOST" => "localhost").status
+    accepted = request.post(guard::PATH, "HTTP_HOST" => guard::HOST,
+      "HTTP_X_FORWARDED_HOST" => "public.example.test")
+    assert_equal 204, accepted.status
+  end
+end

--- a/test/support/event_inbox.rb
+++ b/test/support/event_inbox.rb
@@ -65,6 +65,23 @@ class EventInboxTest < Minitest::Test
     assert_equal "message-456", receipt.event.message_id
   end
 
+  def test_receipt_identity_and_payload_remain_immutable_after_recording
+    receipt = Inbox.record(event)
+    original = receipt.attributes.slice("account_id", "event_id", "message_id", "payload_json")
+    original.each_key do |field|
+      begin
+        receipt.public_send("#{field}=", "changed")
+        receipt.save!
+      rescue ActiveRecord::ReadonlyAttributeError
+        # Rails versions either reject assignment or omit readonly updates.
+      end
+      assert_equal original, receipt.reload.attributes.slice(*original.keys)
+    end
+    Inbox.apply(receipt) { :applied }
+    assert_equal "applied", receipt.reload.state
+    assert_equal original, receipt.attributes.slice(*original.keys)
+  end
+
   def test_concurrent_duplicate_recording_uses_database_unique_constraint
     results = Queue.new
     threads = 4.times.map do

--- a/test/support/rails_app.rb
+++ b/test/support/rails_app.rb
@@ -157,6 +157,7 @@ class RailsAppTest < Minitest::Test
         WebMock.reset!
         tunnel = Cloudflare::Email::DevTunnel.new(port: 3456, io: StringIO.new)
         tunnel.define_singleton_method(:system) { |*| true }
+        tunnel.define_singleton_method(:verify_ingress_guard!) { true }
         tunnel.define_singleton_method(:spawn) { |*, **| 12345 }
         tunnel.define_singleton_method(:wait_for_tunnel_url) do
           raise "Tunnel discovery timed out" if failure == :discovery
@@ -213,6 +214,34 @@ class RailsAppTest < Minitest::Test
       assert_equal observed, Cloudflare::Email::Envelope.for(inbound.reload)
       assert_equal body, inbound.raw_email.download
       assert_equal ["unrelated@example.com"], inbound.mail.to
+    end
+
+    def test_ingress_enforces_configured_mime_limit
+      previous = ENV["MAX_EMAIL_BYTES"]
+      body = "From: sender@example.com\r\nTo: receiver@example.com\r\nMessage-ID: <size-limit@example.com>\r\n\r\nBody\r\n"
+      ENV["MAX_EMAIL_BYTES"] = (body.bytesize - 1).to_s
+      before = ActionMailbox::InboundEmail.count
+      signed_post(body)
+      assert_equal 413, last_response.status
+      assert_equal before, ActionMailbox::InboundEmail.count
+      ENV["MAX_EMAIL_BYTES"] = body.bytesize.to_s
+      signed_post(body)
+      assert_equal 200, last_response.status
+      assert_equal before + 1, ActionMailbox::InboundEmail.count
+    ensure
+      ENV["MAX_EMAIL_BYTES"] = previous
+    end
+
+    def test_ingress_bounds_body_reads_even_without_content_length
+      previous = ENV["MAX_EMAIL_BYTES"]
+      ENV["MAX_EMAIL_BYTES"] = "16"
+      stream = StringIO.new("example MIME body bytes")
+      controller = Cloudflare::Email::IngressController.new
+      controller.define_singleton_method(:request) { Struct.new(:body).new(stream) }
+      assert_equal 17, controller.send(:raw_body).bytesize
+      assert_equal 17, stream.pos
+    ensure
+      ENV["MAX_EMAIL_BYTES"] = previous
     end
 
     def test_v2_deduplication_is_scoped_to_exact_smtp_recipient
@@ -327,7 +356,7 @@ class RailsAppTest < Minitest::Test
     arguments = nil
     tunnel.define_singleton_method(:spawn) { |*args, **_options| arguments = args; nil }
     tunnel.send(:start_tunnel)
-    assert_equal ["cloudflared", "tunnel", "--url", "http://127.0.0.1:3456", "--http-host-header", "localhost"], arguments
+    assert_equal ["cloudflared", "tunnel", "--url", "http://127.0.0.1:3456", "--http-host-header", Cloudflare::Email::DevIngressGuard::HOST], arguments
   ensure
     tunnel&.send(:cleanup)
   end

--- a/test/task_orchestration_test.rb
+++ b/test/task_orchestration_test.rb
@@ -68,6 +68,12 @@ class TaskOrchestrationTest < Minitest::Test
     refute_includes @io.string, "script deployed"
   end
 
+  def test_invalid_ingress_url_fails_before_upload_or_secret_rotation
+    assert_equal 1, deploy(ingress_url: "http://app.example.test/ingress")
+    assert_not_requested :any, %r{api.cloudflare.com}
+    refute_includes @io.string, "script deployed"
+  end
+
   def test_first_secret_failure_stops_before_ingress_url_update
     management_request(:put, script_path).to_return(success)
     secret = management_request(:put, "#{script_path}/secrets").with { |r| JSON.parse(r.body)["name"] == "INGRESS_SECRET" }
@@ -165,8 +171,8 @@ class TaskOrchestrationTest < Minitest::Test
 
   def test_event_handler_and_ack_failures_return_nonzero_without_claiming_success
     event = { "type" => "cf.email.sending.message.delivered", "source" => { "type" => "email.sending", "domain" => "example.test" },
-      "payload" => { "eventId" => "event", "messageId" => "message", "terminal" => true },
-      "metadata" => { "accountId" => ACCOUNT_ID, "eventSchemaVersion" => 1 } }
+      "payload" => { "eventId" => "event", "messageId" => "message", "terminal" => true, "recipient" => "user@example.net" },
+      "metadata" => { "accountId" => ACCOUNT_ID, "eventSchemaVersion" => 1, "eventTimestamp" => "2026-06-01T02:48:57Z" } }
     pull_url = "#{API}/accounts/#{ACCOUNT_ID}/queues/events/messages/pull"
     ack_url = "#{API}/accounts/#{ACCOUNT_ID}/queues/events/messages/ack"
     [:handler, :ack].each do |failure|

--- a/test/verification_edge_cases_test.rb
+++ b/test/verification_edge_cases_test.rb
@@ -19,6 +19,20 @@ class VerificationEdgeCasesTest < Minitest::Test
     )
   end
 
+  def test_header_preflight_requires_bounded_well_formed_fields
+    options = { secret: SECRET, timestamp: "1750000000", signature: "a" * 64,
+      version: "2", envelope: ENVELOPE, now: 1_750_000_000 }
+    # Preflight does not claim authentication: a well-formed signature still
+    # must be checked against the body by verify.
+    assert_equal :ok, Cloudflare::Email::Verification.verify_headers(**options)
+    [{ signature: nil }, { signature: "short" }, { signature: "A" * 64 },
+      { timestamp: "1" * 21 }, { timestamp: " 1750000000" },
+      { version: nil }, { envelope: "invalid" }].each do |invalid|
+      assert_equal :bad_signature, Cloudflare::Email::Verification.verify_headers(**options.merge(invalid))
+    end
+    assert_equal :stale, Cloudflare::Email::Verification.verify_headers(**options.merge(timestamp: "1"))
+  end
+
   def test_unicode_body
     body = "Café résumé 日本語 🔥"
     ts = "1750000000"

--- a/test/worker_deployer_test.rb
+++ b/test/worker_deployer_test.rb
@@ -40,6 +40,20 @@ class WorkerDeployerTest < Minitest::Test
     end
   end
 
+  def test_rejects_insecure_remote_api_endpoint_before_sending_credentials
+    assert_raises(Cloudflare::Email::ConfigurationError) do
+      make_deployer(api_base: "http://api.example.test/client/v4")
+    end
+    assert_not_requested :any, %r{api.example.test}
+  end
+
+  def test_rejects_insecure_ingress_secret_url_without_api_mutation
+    assert_raises(Cloudflare::Email::ConfigurationError) do
+      make_deployer.put_secret("RAILS_INGRESS_URL", "http://app.example.test/ingress")
+    end
+    assert_not_requested :any, %r{api.cloudflare.com}
+  end
+
   def test_deploy_uploads_script_as_multipart
     stub = stub_request(:put, script_url)
       .with { |req|


### PR DESCRIPTION
Inbound MIME reads were unbounded, the development tunnel exposed unrelated Rails routes, and configurable remote HTTP endpoints could disclose credentials or mail. Bound inbound reads, require HTTPS outside loopback, restrict the bundled tunnel to ingress, and preflight the running guard before public exposure.

Also tighten delivery-event and provider-response validation, preserve original event receipt evidence through normal ActiveRecord updates, redact sensitive default logging, and replace the vulnerable Rails 7.1 test stack with patched Rails/SQLite floors and Ruby dependency audits in CI.

Validation: 205 Ruby tests / 751 assertions; 28 Worker tests; packaged Ruby/Rails install and outbox checks; actual local workerd-to-Rails delivery and error handling; Wrangler dry-run; six supported Ruby dependency resolutions and npm audit report no known vulnerabilities. Broader Ruby/Rails and PostgreSQL checks run in this PR's CI.

Review scope, findings, operational boundaries and upgrade instructions are in `docs/verification/2026-09-11-security.md` and `SECURITY.md`. This is local/source verification; no live penetration test, Worker deployment, RubyGems publication, or dogfood inbox upgrade was performed. Existing Worker installations must be redeployed and development Rails servers restarted to adopt the protections.
