### PR TITLE
Add user-friendly email setup, feature and troubleshooting guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,37 @@ Ruby client for [Cloudflare Email Service](https://developers.cloudflare.com/ema
 
 Version **0.2.0** (release candidate). Ruby 3.2+, Rails 7.2–8.1; Ruby 4.0 is tested with Rails 8.1. Supported test floors are Rails 7.2.3.2, 8.0.5.1, and 8.1.3.1. Prefer a maintained Ruby/Rails release for new applications. The plain Ruby client uses Ruby's standard libraries plus the Base64 gem. Node is optional: Worker deployment also works through the included Ruby deployer. See [security guidance](SECURITY.md) for deployment responsibilities.
 
+## Start here
+
+**Sending email?** Start with the [step-by-step Rails guide](docs/getting-started.md).
+**Building a mailbox?** Follow the same guide through receiving, the SQLite-compatible outbox, and delivery tracking.
+**Using plain Ruby?** Jump to [Plain Ruby](#plain-ruby); Rails and a database are optional.
+
+| Guide | What you will learn |
+| --- | --- |
+| [Features at a glance](docs/features.md) | Everything the gem handles, and what your app supplies |
+| [Getting started](docs/getting-started.md) | Install, send your first email, receive replies, and save reliable send operations |
+| [Troubleshooting](docs/troubleshooting.md) | What to check when mail or delivery updates do not arrive |
+| [Durable outbox](docs/outbox.md) | Detailed setup, callbacks, retries, and recovery |
+| [Delivery events](docs/delivery-events.md) | Cloudflare Queue setup and recipient status tracking |
+| [Upgrading to 0.2](docs/upgrading-0.2.md) | Changes needed for an existing installation |
+
+The sections below are the configuration and API reference.
+
 ## Install and send from Rails
 
-```sh
-bundle add cloudflare-email
-bin/rails generate cloudflare:email:install --no-inbound
+Until 0.2.0 is published, add the reviewed security release-candidate commit to your Gemfile. RubyGems still serves 0.1.0, which does not include the features described here:
+
+```ruby
+gem "cloudflare-email",
+  git: "https://github.com/cole-robertson/cloudflare-email.git",
+  ref: "661cd2f483973c0f3e0cd4aa091562b009300419"
 ```
 
-Until 0.2.0 is published, pin a reviewed commit from this repository to try the new features; RubyGems still serves 0.1.0.
+```sh
+bundle install
+bin/rails generate cloudflare:email:install --no-inbound
+```
 
 Add Rails credentials (encrypted, per environment) or environment variables:
 
@@ -262,7 +285,7 @@ Errors inherit from `Cloudflare::Email::Error`: `ConfigurationError`, `Authentic
 
 ## Observability and permissions
 
-Notifications: `cloudflare_email.send` / `send_raw` include `account_id`, `path`, `status`, `message_id`, and all four recipient outcome arrays. `cloudflare_email.ingress` includes `bytes`, `result` (`ok`, `duplicate`, `bad_signature`, `stale`), and the stored `message_id` when available. `cloudflare_email.delivery_event` wraps handler execution with `event_id`, `message_id`, and lifecycle `status`; it does not report queue acknowledgement completion. Instrumentation errors include ActiveSupport's exception metadata.
+Notifications: `cloudflare_email.send` / `send_raw` include `account_id`, `path`, `status`, `message_id`, and all four recipient outcome arrays. `cloudflare_email.ingress` includes `bytes`, `result` (`ok`, `duplicate`, `bad_signature`, `stale`, `too_large`), and the stored `message_id` when available. `cloudflare_email.delivery_event` wraps handler execution with `event_id`, `message_id`, and lifecycle `status`; it does not report queue acknowledgement completion. Instrumentation errors include ActiveSupport's exception metadata.
 
 | Task | Purpose / credentials |
 |---|---|

--- a/docs/features.md
+++ b/docs/features.md
@@ -1,0 +1,101 @@
+# What cloudflare-email does
+
+cloudflare-email connects your Ruby or Rails application to Cloudflare's email
+services. You can use just the sending client, add incoming mail, or build a
+mailbox on top of the optional database-backed delivery tools.
+
+Start with [Getting started](getting-started.md) for working examples. These
+features describe the unreleased **0.2.0** code; use the commit pinned in that
+guide until the release is published.
+
+## Choose the pieces you need
+
+| You want to… | Use | What you get |
+| --- | --- | --- |
+| Send from an ordinary Ruby program | `Cloudflare::Email::Client` | Structured messages or complete raw MIME; no Rails/database required |
+| Send existing Rails mailers | ActionMailer delivery method | Your mailer templates, attachments, multipart bodies, cc/bcc and reply headers sent through Cloudflare |
+| Receive email in Rails | Email Worker + ActionMailbox | Unchanged raw MIME, attachments, authenticated SMTP envelope metadata and duplicate handling |
+| Develop against real incoming email locally | `cloudflare:email:dev` | A temporary tunnel restricted to your email ingress |
+| Save an email before sending it | Optional ActiveRecord outbox | Immutable message snapshot, saved recipients, a send claim, and per-recipient results |
+| Avoid accidentally resending after a crash or timeout | `SendJob` + outbox | Jobs use the saved operation identity; uncertain attempts stay blocked for review |
+| Track delivery, bounce or complaint updates | `EventConsumer` + Cloudflare Queue | Validated lifecycle events, account/domain checks and acknowledgement after successful handling |
+| Avoid building your own event ledger | Optional tracking tables | Durable receipts, duplicate/conflict detection, unmatched-event storage and replay |
+| Connect events to outbox recipients | `DeliveryEvents` | Account/message/recipient matching, event ordering and callbacks for your app's records |
+| Investigate an uncertain send | Recovery tasks + `Outbox.reconcile` | Operator-supplied evidence and an audit trail; no automatic resend based on elapsed time |
+| Match replies to earlier messages | Provider message IDs + `MessageId.normalize` | A consistent lookup key for your app's conversations |
+| Observe email processing | ActiveSupport notifications + `doctor` | Send/ingress/event/outbox instrumentation and configuration diagnostics |
+| Deploy receiving infrastructure | Ruby deployer and routing tasks | Environment-specific Workers, ingress secrets, address routes and DNS preflight checks |
+
+## SQLite works
+
+The optional receipt and outbox tables work with **SQLite**. Keep your existing
+Rails SQLite database; PostgreSQL is optional, and both adapters have concurrency
+coverage. The gem uses ActiveRecord and does not install a separate database
+service. You still choose a durable Rails job backend and run its workers.
+
+Database locking conflicts can require a job retry. A retry uses the existing
+outbox identity; it does not clear an uncertain send claim. Keep application
+writes and gem callbacks on the same database connection when they must commit
+together. See [outbox setup](outbox.md).
+
+## Understand the different kinds of success
+
+| Result | What it tells you |
+| --- | --- |
+| Successful API request | Cloudflare returned a successful response; inspect recipient outcomes too |
+| `response.accepted?` | There is evidence of acceptance for at least part of the send |
+| Outbox `accepted` | Every recipient has acceptance evidence |
+| Outbox `partial` | Some recipients have acceptance evidence; the others need individual attention |
+| Delivery event `delivered` | The recipient's server accepted the email; this is not a read receipt |
+| Ingress HTTP 200 | Rails stored the message or recognized a duplicate; mailbox processing happens separately |
+
+Sending, receiving and delivery tracking are separate Cloudflare setups. A
+working sending domain does not automatically enable incoming routes or queue
+subscriptions. The [getting-started guide](getting-started.md) walks through each.
+
+## Protections included
+
+Incoming requests use v2 HMAC signatures covering the timestamp, SMTP sender,
+SMTP recipient and raw message. Rails checks a five-minute timestamp window.
+Identical MIME retried for the same recipient is deduplicated; delivery to a
+different recipient is stored separately.
+
+Rails and the Worker default to a **25 MiB raw incoming message limit**. Both
+support a positive `MAX_EMAIL_BYTES` override. Remote endpoints require HTTPS,
+the Worker refuses redirects and limits its Rails request to 15 seconds, and
+the development tunnel only routes ingress POSTs. Client inspection and default
+retry/mailbox logging omit sensitive details.
+
+The outbox preserves the rendered message and acceptance evidence, blocks
+ambiguous resend attempts, and records reconciliation decisions. Delivery-event
+validation rejects malformed schema fields; original receipt identity and
+payload are read-only through normal ActiveRecord updates. These safeguards do
+not make database administrators untrusted or provide exactly-once delivery.
+
+## What belongs in your mailbox application
+
+The gem supplies the email and delivery infrastructure. Your app supplies users,
+mailbox permissions, conversation records, folders, search, compose screens,
+drafts and any AI review or approval workflow. It also decides unsubscribe and
+recipient eligibility policy. The gem does not supply an inbox UI or AI agent.
+
+An authenticated SMTP envelope tells your app which address Cloudflare received
+the message for. It does not prove the human sender's identity. Reply correlation
+also does not authorize access to a conversation. Apply your app's permissions
+before displaying mail or sending a reply.
+
+You configure Cloudflare domains/DNS, queue subscriptions, durable jobs,
+monitoring, storage protection and retention. Inbound mail is not durably
+buffered by the Worker during a Rails outage. See [architecture](architecture.md)
+for the full boundary and [security guidance](../SECURITY.md) for deployment.
+
+## Where to go next
+
+- [Build your first integration](getting-started.md)
+- [Use plain Ruby, attachments or raw MIME](../README.md#plain-ruby)
+- [Configure client retries and errors](../README.md#retry-and-configuration)
+- [Set up event polling and durable receipts](delivery-events.md)
+- [Recover saved outbound operations](outbox.md)
+- [Correlate replies](thread-correlation.md)
+- [Use Cloudflare SMTP instead of the HTTP delivery method](../README.md#smtp-alternative)
+- [Troubleshoot your setup](troubleshooting.md)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,300 @@
+# Get email working in your Rails app
+
+This guide takes you from your first outgoing email to receiving replies and
+tracking deliveries. Start with sending and add the other pieces as needed.
+For a mailbox app, follow all four parts. **SQLite is supported throughout.**
+
+You will need an existing Rails app, a Cloudflare account, and a domain you can
+configure in Cloudflare. Use Ruby 3.2+ and a patched supported Rails release:
+tested floors are 7.2.3.2, 8.0.5.1 and 8.1.3.1. Rails 8 requires Ruby 3.3+.
+Ruby 4 is tested with Rails 8.1. Plain Ruby users can use the
+[standalone client](../README.md#plain-ruby) instead.
+
+Example addresses below use `mail.example.com` for sending and
+`in.example.com` for receiving. Replace them with subdomains you own. They do
+not need to be the same domain as your Rails application's web address.
+
+## 1. Send your first email
+
+### Install the current code
+
+The new features are in the unreleased 0.2.0 code. RubyGems currently serves
+0.1.0. Add this reviewed commit to your app's `Gemfile`:
+
+```ruby
+gem "cloudflare-email",
+  git: "https://github.com/cole-robertson/cloudflare-email.git",
+  ref: "661cd2f483973c0f3e0cd4aa091562b009300419"
+```
+
+```sh
+bundle install
+bin/rails generate cloudflare:email:install --no-inbound
+```
+
+The generator creates an initializer that chooses `:cloudflare` as your
+ActionMailer delivery method. The `--no-inbound` option keeps this first step
+focused on sending; you can add receiving below.
+
+### Connect your sending domain
+
+In Cloudflare, open **Compute → Email Service → Email Sending** and onboard
+your sending domain. Complete Cloudflare's DNS instructions and wait for domain
+verification. A dedicated subdomain helps keep an existing mail provider's apex
+configuration separate. Do not replace existing apex mail records casually.
+
+Create an account-scoped token with permission to send email. Add these variables
+to the environment where Rails runs, or use the equivalent Rails credentials:
+
+```sh
+export CLOUDFLARE_ACCOUNT_ID=your-account-id
+export CLOUDFLARE_API_TOKEN=your-email-sending-token
+```
+
+Rails credentials use `cloudflare.account_id` and `cloudflare.api_token`.
+Nonempty Rails credentials take precedence over environment variables. Keep
+real tokens out of committed files. Restart Rails after changing configuration.
+
+### Check the setup and send
+
+```sh
+bin/rails cloudflare:email:doctor
+FROM=hello@mail.example.com TO=you@example.net bin/rails cloudflare:email:send_test
+```
+
+Use a destination inbox you control. `doctor` checks configuration and available
+read access; the second command actually sends mail. Confirm that it arrives,
+including checking spam. A diagnostics success alone does not prove delivery.
+
+### Use your regular mailers
+
+```ruby
+# app/mailers/hello_mailer.rb
+class HelloMailer < ApplicationMailer
+  def hello(address)
+    mail(from: "hello@mail.example.com", to: address, subject: "Hello from Rails") do |format|
+      format.text { render plain: "Your email integration is working." }
+    end
+  end
+end
+```
+
+From `bin/rails console`:
+
+```ruby
+HelloMailer.hello("you@example.net").deliver_now
+```
+
+Your existing HTML templates, multipart messages, attachments and cc/bcc work
+through ActionMailer. Use `deliver_later` with your app's job backend for ordinary
+background delivery. For saved send history and protection against ambiguous
+resends, use the outbox in part 3. Do not send the same message through both paths.
+
+## 2. Receive email and replies
+
+Incoming email follows this path:
+
+```text
+Sender → Cloudflare Email Routing → Email Worker → Rails ActionMailbox → your app
+```
+
+The Worker is a small program that forwards the email to Rails and signs it so
+Rails can verify the forwarding request. The installer supplies its code.
+
+### Install receiving support
+
+```sh
+bin/rails generate cloudflare:email:install
+bin/rails db:migrate
+```
+
+Follow the interactive prompts to install ActionMailbox and the default mailbox.
+If you already have custom mailbox routing or initializer changes, inspect the
+generator's overwrite prompts before accepting. The generated default mailbox
+only logs receipt; you will add your product's processing logic.
+
+Save the generated shared secret as `cloudflare.ingress_secret` in Rails
+credentials or `CLOUDFLARE_INGRESS_SECRET`. The deploy task copies that secret to
+the Worker. Use a separate deployment token as `cloudflare.management_token` or
+`CLOUDFLARE_MANAGEMENT_TOKEN`; [the permission table](../README.md#observability-and-permissions)
+lists the scopes needed for Worker deployment and routing.
+
+### Connect the receiving address
+
+In Cloudflare **Email Routing → your apex domain → Settings → Subdomains**, add
+your receiving subdomain, such as `in.example.com`, and finish its DNS setup.
+This is separate from verifying the sending domain.
+
+Deploy Rails with ActionMailbox storage and workers configured. Then run these
+commands in an environment with production configuration and deployment credentials:
+
+```sh
+RAILS_ENV=production bin/rails cloudflare:email:deploy_worker URL=https://app.example.com/rails/action_mailbox/cloudflare/inbound_emails
+RAILS_ENV=production bin/rails cloudflare:email:provision_route ADDRESS=support@in.example.com
+```
+
+The first command deploys the Worker; the second routes the address to it.
+Send a real test email to `support@in.example.com`, then check the ActionMailbox
+record and processing job. A web request accepted by Rails means storage worked;
+the mailbox job can still need attention.
+
+### Read the message in your mailbox
+
+Inside the generated `MainMailbox#process`, these values are available:
+
+```ruby
+envelope = Cloudflare::Email::Envelope.for(inbound_email)
+receiving_address = envelope&.fetch("to")
+subject = mail.subject
+text = mail.text_part&.body&.decoded || (mail.body.decoded unless mail.multipart?)
+attachments = mail.attachments
+raw_message = inbound_email.raw_email.download
+```
+
+Save or process those values using your application's models. For mailbox or
+tenant selection, use `receiving_address`, which comes from the authenticated
+SMTP envelope. MIME `To`/`Cc` headers may differ, especially for Bcc. The envelope
+can be absent for records from another ingress; handle that case explicitly.
+Treat message contents and attachments as untrusted input when displaying them.
+
+To direct replies to this address, add `reply_to: "support@in.example.com"` to
+your mailer's `mail(...)` call. For conversation matching, save the returned
+provider message ID and compare reply headers within your application's mailbox
+scope. The outbox saves this ID for you. See [thread correlation](thread-correlation.md).
+
+### Receive into a local Rails server
+
+Install `cloudflared`, configure development credentials and a separate development
+receiving route, then start Rails. In another terminal:
+
+```sh
+bin/rails cloudflare:email:deploy_worker
+bin/rails cloudflare:email:dev
+```
+
+The first command creates the development Worker; the second points it at a
+temporary tunnel to your local Rails server on port 3000. Keep the tunnel running
+while testing and stop it with Ctrl-C. Set `PORT=...` if Rails uses another port.
+The task checks that Rails has the ingress-only guard; restart Rails if asked.
+Use development test data. The tunnel URL is temporary and does not provide an
+offline mailbox when your local server is stopped.
+
+## 3. Add the durable outbox with SQLite
+
+An outbox saves the exact message before sending it. Background jobs reference
+that saved operation instead of re-rendering and resending mail on every retry.
+This is useful for compose, replies, invoices and approved drafts.
+
+If your Rails app already uses SQLite, keep its database configuration. Run:
+
+```sh
+bin/rails generate cloudflare:email:tracking
+bin/rails generate cloudflare:email:outbox
+bin/rails db:migrate
+```
+
+These add the receipt and delivery tables plus opt-in initializers. Skip a
+generator whose migration you already installed. Configure a durable ActiveJob
+backend and run a worker that processes the `mailers` queue; the gem does not
+install the backend for you.
+
+Try this from Rails console, outside an existing database transaction:
+
+```ruby
+account_id = Cloudflare::Email::Credentials.account_id
+operation = Cloudflare::Email::ActiveRecord::Outbox.prepare_mail(
+  account_id: account_id,
+  operation_key: "getting-started:hello:1",
+  mail: HelloMailer.hello("you@example.net").message,
+)
+Cloudflare::Email::SendJob.perform_later(account_id, operation.operation_key)
+```
+
+The operation key identifies **one intended send** in your account. Save it with
+your product record. For a genuinely new message use a new key; for a job retry
+reuse the saved identity. Do not re-render a mailer and call `prepare_mail` as
+your retry mechanism: generated MIME headers can change, causing a snapshot conflict.
+
+In an application transaction, prepare the operation alongside your business
+record, then enqueue only after the outer transaction commits. The detailed
+[outbox guide](outbox.md#prepare-once-dispatch-after-commit) shows that pattern.
+
+After the worker runs, inspect the result:
+
+```ruby
+operation.reload.state
+operation.provider_message_id
+operation.outbound_recipients.pluck(:recipient, :acceptance_state, :state)
+```
+
+`accepted` means all recipients have provider acceptance evidence; `partial`
+means only some do. Neither promises that a human received or read the message.
+`unknown` or a stuck `sending` operation needs investigation, not a new send key
+as a shortcut. See [states and recovery](outbox.md#states-and-retries).
+
+## 4. Track delivery, bounces and complaints
+
+Cloudflare sends later delivery updates through a Queue. You configure that
+Queue and its Email Sending subscription once; your app polls it regularly.
+Follow [the provisioning steps](delivery-events.md#provision-once), including an
+HTTP pull consumer, retries and a dead-letter queue for repeatedly failing events.
+
+Add a separate queue token and queue ID to your Rails environment:
+
+```sh
+export CLOUDFLARE_QUEUES_TOKEN=your-queues-read-write-token
+export CLOUDFLARE_EVENT_QUEUE_ID=your-queue-id
+```
+
+With the outbox installed, configure this initializer:
+
+```ruby
+# config/initializers/cloudflare_delivery_events.rb
+require "cloudflare/email/active_record"
+
+Rails.application.configure do
+  config.x.cloudflare_email.event_domains = ["mail.example.com"]
+  config.x.cloudflare_email.event_handler = ->(event) {
+    Cloudflare::Email::ActiveRecord::DeliveryEvents.record(event)
+  }
+end
+```
+
+Restart Rails and poll a batch:
+
+```sh
+bin/rails cloudflare:email:consume_events
+```
+
+This command processes **one batch and exits**. Schedule it repeatedly using
+your application's scheduler. Also schedule receipt replay for recovery:
+
+```sh
+bin/rails cloudflare:email:replay_events
+```
+
+The gem saves receipts before acknowledgement, handles duplicates, and matches
+updates to the account, provider message ID and recipient. If an event arrives
+before the send result is saved, it stays available for replay. Recipient state
+then reflects delivered, deferred, bounced, failed, rejected or complained events.
+Your app still decides what those outcomes mean for its UI and future sending.
+
+For custom product updates, use the [transactional callbacks](outbox.md#recover-dispatch-and-application-projections).
+If you only want events and have your own delivery models, use the lower-level
+[durable receipt adapter](delivery-events.md#durable-rails-receipts).
+
+## Before relying on it
+
+Send to an external inbox you control, reply back, verify stored attachments,
+and confirm a real queue event updates the intended recipient. Keep a durable
+job worker running and schedule recovery of `prepared` operations that might
+have committed before enqueueing. Monitor stuck operations and failed mailbox jobs.
+
+Protect stored MIME and attachments, choose retention and backup policies, and
+set proxy/server request limits. The default incoming raw message limit is
+25 MiB; set the same positive `MAX_EMAIL_BYTES` on Rails and the Worker if you
+override it. Cloudflare has separate [outgoing size and recipient limits](https://developers.cloudflare.com/email-service/platform/limits/).
+
+Use [troubleshooting](troubleshooting.md) when something does not arrive,
+[the feature overview](features.md) to explore more, and
+[the upgrade guide](upgrading-0.2.md) for an existing 0.1 installation.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,103 @@
+# When email does not behave as expected
+
+Start by identifying which step failed: sending, incoming storage, mailbox
+processing, or delivery tracking. Those are separate pieces. Use test addresses
+you control, and avoid pasting tokens, raw MIME or private provider responses
+into public logs or issues.
+
+## Sending
+
+| What you see | What to check next |
+| --- | --- |
+| New generator or API is missing | Check `Gemfile.lock`. The new features require the [0.2 commit](getting-started.md#install-the-current-code); published 0.1.0 lacks them. |
+| Credentials appear to be ignored | Nonempty Rails credentials override environment variables. Check the Rails environment and restart the app after changes. |
+| Authentication or domain error | Run `bin/rails cloudflare:email:doctor`; check account ID, token permissions and sending-domain verification. |
+| `doctor` reports limited read access | A send token may lack diagnostic read permissions. Review the specific result; diagnostics alone cannot prove whether sending works. |
+| API accepted the message but nothing arrives | Inspect queued, bounced and suppressed recipient outcomes, then delivery events and the destination's spam folder. Acceptance is not final delivery. |
+| `deliver_later` does nothing | Check your job backend, running workers and failed jobs. For the outbox's `SendJob`, make sure a worker processes `mailers`. |
+| Timeout or server error | Cloudflare might have accepted the message before the error. Investigate before resending. The outbox preserves this uncertainty. |
+| Some recipients received it | Inspect each recipient; do not resend the entire partial batch. See [outbox recovery](outbox.md#reconcile-uncertainty). |
+
+To perform a deliberate real-send check:
+
+```sh
+FROM=hello@mail.example.com TO=you@example.net bin/rails cloudflare:email:send_test
+```
+
+## Incoming email
+
+| What you see | What to check next |
+| --- | --- |
+| Address receives nothing | Verify receiving-subdomain onboarding and the address route's Worker. Sending-domain verification is separate. |
+| Route provisioning refuses a subdomain | Complete Email Routing subdomain setup and DNS preflight first. Do not enable or replace apex routing just to bypass the error. |
+| Worker reports 401 from Rails | Check matching ingress secrets and that Rails and Worker both use the v2 code. Upgrade both together. |
+| Worker reports 408 | Check clock accuracy and the five-minute signing window. |
+| Worker reports 413 or rejects size | Raw MIME exceeds the configured limit. Match `MAX_EMAIL_BYTES` on Rails and Worker and check upstream request limits. |
+| Worker reports 3xx | Point it directly at the final HTTPS ingress URL; redirects are intentionally rejected. |
+| Worker times out | Check Rails availability and request latency. Its upstream request limit is 15 seconds; there is no durable inbound buffer. |
+| Rails returns 200 but your product shows no message | Check ActionMailbox records, job workers, failed routing jobs and your mailbox's `process` method. The default mailbox only logs receipt. |
+| Retrying creates no new inbound record | Identical MIME for the same SMTP recipient is intentionally deduplicated. |
+| Bcc message appears routed to the wrong mailbox | Use `Envelope.for(inbound_email)["to"]` after checking the envelope exists; MIME `To` does not identify every SMTP recipient. |
+| Quoted or internationalized addresses are rejected | The v2 envelope currently supports ASCII dot-atom addresses, not every possible email address syntax. |
+
+## Local development
+
+Restart Rails after upgrading so the ingress-only guard is installed. Start
+Rails on the expected port before `cloudflare:email:dev`, install `cloudflared`,
+and use development credentials and a development receiving route.
+
+The tunnel only permits POSTs to the email ingress. Opening its root URL in a
+browser returning 404 is expected. When you stop the tunnel, its URL remains in
+the development Worker until the next update; it no longer reaches your app.
+
+## Saved outbox operations
+
+```sh
+bin/rails cloudflare:email:pending_deliveries
+```
+
+This lists operations requiring attention for the configured account. It does
+not dispatch or repair them automatically.
+
+| State or error | What to do |
+| --- | --- |
+| `prepared` | The message is saved and can be dispatched using its existing operation key. Check for an enqueue failure or stopped worker. |
+| `sending` | A process claimed the send. Verify its status; age alone does not prove it failed to send. |
+| `unknown` | Collect provider evidence before making a resend decision. |
+| `partial` | Review individual acceptance outcomes. Already accepted recipients must not receive a batch retry. |
+| `accepted` | Repeated delivery uses the existing record without another send. Look at recipient lifecycle for later delivery results. |
+| `rejected` | Correct the cause; a deliberate new attempt needs a new operation key. |
+| `SnapshotConflict` | The same key was used with different MIME/envelope data. Retry the saved identity; do not re-render it. |
+
+For a known `prepared` operation, dispatch the saved message with:
+
+```sh
+OPERATION_KEY='your-existing-operation-key' bin/rails cloudflare:email:deliver
+```
+
+For uncertainty, follow [audited reconciliation](outbox.md#reconcile-uncertainty).
+Never reset a row to `prepared` or delete the ledger to make a retry go through.
+Reconciliation requires an authorized operator and evidence; the gem records
+the actor you supply but does not authenticate that person.
+
+## Delivery updates
+
+| What you see | What to check next |
+| --- | --- |
+| Queue stays empty | Check the Email Sending subscription, sending domain, selected event types and a real send from that domain. |
+| Polling fails before processing | Check the queue ID, separate Queues Read/Write token, HTTP pull configuration and configured event handler. |
+| Events process once then stop | `consume_events` is a one-batch task. Schedule it to run repeatedly. |
+| Events stay unmatched | Check account, normalized provider message ID and recipient. Schedule replay; a receipt can arrive before the send result is saved. |
+| Acknowledged event did not update the UI | Durable receipt storage and product projection are separate. Check replay, callback failures and application correlation. |
+| Old delivery status does not replace a newer one | Ordering and terminal-state guards intentionally reject stale updates. |
+| One event repeatedly fails | Inspect validation/handler errors and dead-letter queue policy. Invalid events are not acknowledged by the consumer. |
+
+```sh
+bin/rails cloudflare:email:consume_events
+bin/rails cloudflare:email:replay_events
+```
+
+See [delivery events](delivery-events.md) for queue setup and
+[observability](../README.md#observability-and-permissions) for notifications you
+can connect to your monitoring. A delivery notification wraps handler execution;
+it is not proof that queue acknowledgement completed.


### PR DESCRIPTION
Add a practical documentation path from a first Rails send to incoming mail, a SQLite-compatible durable outbox, and delivery-event tracking. A feature overview explains what the gem supplies and what belongs in the mailbox app; troubleshooting connects common symptoms to the right checks and recovery guide.

The README now links to these guides and installs the reviewed 0.2 release-candidate commit instead of leading new users to the older published gem. It also documents the ingress `too_large` notification result.

Validation: all 50 local documentation links and anchors resolve, all 14 Ruby code snippets pass syntax checks, and `git diff --check` passes. Examples were checked against the existing generators, jobs, models, and API documentation. No runtime code changes or live email sends.
