### PR TITLE
Add optional managed mailboxes and SQLite tenant support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,21 @@ jobs:
       - run: bundle exec ruby script/verify_package.rb
         if: matrix.ruby == '3.4' && matrix.rails == '8_1'
 
+  activerecord-tenanted:
+    name: SQLite activerecord-tenanted integration
+    runs-on: ubuntu-latest
+    env:
+      BUNDLE_GEMFILE: "${{ github.workspace }}/gemfiles/tenanted.gemfile"
+    steps:
+      - uses: actions/checkout@v7
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.4"
+          bundler-cache: true
+      - run: bundle exec ruby test/support/activerecord_tenanted.rb
+      - run: gem install bundler-audit --version 0.9.3 --no-document
+      - run: bundler-audit check --update --gemfile-lock gemfiles/tenanted.gemfile.lock
+
   postgres-outbox:
     name: PostgreSQL durable outbound concurrency
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.2.0 — Unreleased
+## 0.2.0 — 2026-09-11
 
 - Add optional managed mailboxes: domain directory, addresses/aliases, lifecycle,
   incoming memberships, read/archive/purge APIs and raw-mail retention.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## 0.2.0 — Unreleased
 
+- Add optional managed mailboxes: domain directory, addresses/aliases, lifecycle,
+  incoming memberships, read/archive/purge APIs and raw-mail retention.
+- Add explicit tenant connections, tenant-aware framework and mailbox jobs,
+  mailbox-authorized outbox sends, shared event intake/correlation and recovery.
+  Verify separate SQLite databases and actual `activerecord-tenanted` integration;
+  no new runtime dependency for plain Ruby consumers.
+- Add a mailbox generator with separate shared/tenant migration paths and
+  user guides for mailbox management and database tenancy.
+
 - Bound Rails and Worker inbound reads to 25 MiB by default; reject malformed or
   stale signing headers before reading MIME. Require HTTPS remote endpoints.
 - Restrict the development tunnel to email ingress and require a running guard;

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Until 0.2.0 is published, add the reviewed security release-candidate commit to 
 ```ruby
 gem "cloudflare-email",
   git: "https://github.com/cole-robertson/cloudflare-email.git",
-  ref: "661cd2f483973c0f3e0cd4aa091562b009300419"
+  ref: "4273c5ac10cb87d5e5610acc6a4e69c55d94a42f"
 ```
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Version **0.2.0** (release candidate). Ruby 3.2+, Rails 7.2–8.1; Ruby 4.0 is t
 | [Features at a glance](docs/features.md) | Everything the gem handles, and what your app supplies |
 | [Getting started](docs/getting-started.md) | Install, send your first email, receive replies, and save reliable send operations |
 | [Troubleshooting](docs/troubleshooting.md) | What to check when mail or delivery updates do not arrive |
+| [Managed mailboxes](docs/mailboxes.md) | Create inboxes and aliases, read/archive mail, and send from a mailbox |
+| [SQLite tenant databases](docs/activerecord-tenanted.md) | Give each organization its own SQLite database with `activerecord-tenanted` |
 | [Durable outbox](docs/outbox.md) | Detailed setup, callbacks, retries, and recovery |
 | [Delivery events](docs/delivery-events.md) | Cloudflare Queue setup and recipient status tracking |
 | [Upgrading to 0.2](docs/upgrading-0.2.md) | Changes needed for an existing installation |
@@ -77,6 +79,34 @@ WelcomeMailer.welcome(user).deliver_later
 ```
 
 Multipart, attachments, cc/bcc, and threading headers are serialized through `send_raw`. Cloudflare still controls final delivery and header acceptance.
+
+## Managed mailboxes and optional tenancy
+
+Create mailboxes in code with the optional mailbox module. It includes named
+mailboxes, aliases, ownership references, read/archive state, retained raw mail,
+mailbox-authorized sends, and tenant-aware delivery-event recovery:
+
+```sh
+bin/rails generate cloudflare:email:mailboxes
+bin/rails db:migrate
+```
+
+After registering and verifying a receiving domain:
+
+```ruby
+Cloudflare::Email::Mailboxes.for_tenant("organization-123") do |inboxes|
+  mailbox = inboxes.create(name: "Support", address: "support@acme.example.com",
+    owner_ref: "team:42")
+  # Provision and activate its address route before receiving or sending mail.
+end
+```
+
+Use one database or an application-provided tenant base class. The optional
+`activerecord-tenanted` integration is tested with separate SQLite databases,
+including jobs and overlapping record IDs. Your app still authorizes users and
+provides the UI. Start with [the mailbox guide](docs/mailboxes.md), and configure
+[tenant connections](docs/activerecord-tenanted.md) before loading models when
+using separate databases. Plain Ruby users do not load this module.
 
 ## Durable mailbox delivery from Rails
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Ruby client for [Cloudflare Email Service](https://developers.cloudflare.com/email-service/), with ActionMailer, authenticated ActionMailbox ingress, a forwarding Worker, and optional durable Rails sending and delivery-event tracking.
 
-Version **0.2.0** (release candidate). Ruby 3.2+, Rails 7.2–8.1; Ruby 4.0 is tested with Rails 8.1. Supported test floors are Rails 7.2.3.2, 8.0.5.1, and 8.1.3.1. Prefer a maintained Ruby/Rails release for new applications. The plain Ruby client uses Ruby's standard libraries plus the Base64 gem. Node is optional: Worker deployment also works through the included Ruby deployer. See [security guidance](SECURITY.md) for deployment responsibilities.
+Version **0.2.0**. Ruby 3.2+, Rails 7.2–8.1; Ruby 4.0 is tested with Rails 8.1. Supported test floors are Rails 7.2.3.2, 8.0.5.1, and 8.1.3.1. Prefer a maintained Ruby/Rails release for new applications. The plain Ruby client uses Ruby's standard libraries plus the Base64 gem. Node is optional: Worker deployment also works through the included Ruby deployer. See [security guidance](SECURITY.md) for deployment responsibilities.
 
 ## Start here
 
@@ -25,12 +25,10 @@ The sections below are the configuration and API reference.
 
 ## Install and send from Rails
 
-Until 0.2.0 is published, add the reviewed security release-candidate commit to your Gemfile. RubyGems still serves 0.1.0, which does not include the features described here:
+Add version 0.2 to your Gemfile. Existing 0.1 users should follow the [upgrade guide](docs/upgrading-0.2.md), including the coordinated Rails/Worker update:
 
 ```ruby
-gem "cloudflare-email",
-  git: "https://github.com/cole-robertson/cloudflare-email.git",
-  ref: "4273c5ac10cb87d5e5610acc6a4e69c55d94a42f"
+gem "cloudflare-email", "~> 0.2.0"
 ```
 
 ```sh
@@ -81,6 +79,19 @@ WelcomeMailer.welcome(user).deliver_later
 Multipart, attachments, cc/bcc, and threading headers are serialized through `send_raw`. Cloudflare still controls final delivery and header acceptance.
 
 ## Managed mailboxes and optional tenancy
+
+**Multi-tenancy is off by default.** Installing the gem does not create tenant
+databases, install a tenancy library, or change your application's database routing.
+
+| Setup | What you explicitly enable |
+| --- | --- |
+| Plain Ruby sending | Nothing extra; no Rails/database required |
+| Managed mailboxes in one database | Run the mailbox generator and load the optional module |
+| Separate tenant databases | Configure `Tenancy.configure(...)` with your application's base class and switching adapter before loading models |
+
+The mailbox API uses a tenant key to group and scope records even in one database.
+That key alone does not enable database switching. `activerecord-tenanted` is an
+optional application dependency, not a runtime dependency of this gem.
 
 Create mailboxes in code with the optional mailbox module. It includes named
 mailboxes, aliases, ownership references, read/archive state, retained raw mail,

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,8 +1,8 @@
 # Security
 
-The current hardening work targets the unreleased 0.2.0 branch. The published
-0.1.0 gem does not include it. Use a reviewed commit containing the fixes until
-a release is published, and redeploy the bundled Worker when upgrading.
+The hardening described here is included in 0.2.0. Version 0.1.0 does not include
+these fixes. Upgrade Rails and the bundled Worker together using the
+[upgrade guide](docs/upgrading-0.2.md).
 
 Rails integration is tested on patched Rails 7.2, 8.0, and 8.1; application
 owners must update their own Rails, database adapter, and other dependencies.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -34,6 +34,14 @@ Do not place secrets or private message data in public issues.
 - Database administrators and direct SQL writes are trusted. ActiveRecord
   read-only evidence fields do not provide tamper-proof storage. Keep tenant
   authorization around outbox operations and receipt access in the application.
+- The optional mailbox session scopes tenant and mailbox access, but does not
+  authenticate users. Keep domain registration/activation administrative, verify
+  ownership externally, and use your access resolver to choose tenant keys.
+  Ingress selects a registered tenant only after full signature verification.
+  Raw ActiveRecord access remains privileged, especially in shared-database mode.
+  Private tenant storage, consistent migrations and trusted job payloads are
+  required. Drain old framework jobs before enabling database tenancy; jobs
+  without the new tenant metadata are rejected rather than guessing a tenant.
 - Development tunnels expose the ingress to the internet. Use the bundled task,
   dedicated development mail routes and test data; stop tunnels when finished.
   The Host guard restricts routing but is not a sandbox for the development app

--- a/app/controllers/cloudflare/email/ingress_controller.rb
+++ b/app/controllers/cloudflare/email/ingress_controller.rb
@@ -53,7 +53,17 @@ module Cloudflare
             payload[:result] = :bad_signature
             head :unauthorized
           when :ok
-            inbound = persist_inbound
+            inbound = if defined?(Cloudflare::Email::Mailboxes) && Cloudflare::Email::Mailboxes.enabled?
+              recipient = Cloudflare::Email::Envelope.decode(request.headers["X-CF-Email-Envelope"]).fetch("to")
+              begin
+                Cloudflare::Email::Mailboxes.receive(recipient: recipient) { persist_inbound }
+              rescue Cloudflare::Email::Mailboxes::Unavailable
+                payload[:result] = :unavailable_mailbox
+                next head(:unprocessable_entity)
+              end
+            else
+              persist_inbound
+            end
             payload[:result]     = inbound ? :ok : :duplicate
             payload[:message_id] = inbound&.message_id
             head :ok

--- a/docs/activerecord-tenanted.md
+++ b/docs/activerecord-tenanted.md
@@ -1,0 +1,132 @@
+# SQLite mailboxes with activerecord-tenanted
+
+Use this setup when each organization has its own SQLite database. The shared database holds receiving domains and delivery-event routing. Mailboxes, messages, and the outbox live in the organization's database.
+
+`activerecord-tenanted` is an optional application dependency. The gem's integration test uses version 0.8 on Rails 8.1; you do not need it for a single database or another tenant adapter.
+
+## 1. Configure your databases
+
+Add `gem "activerecord-tenanted", "~> 0.8.0"` to your application's Gemfile and run `bundle install`.
+
+For example, in `config/database.yml`:
+
+```yaml
+production:
+  primary:
+    adapter: sqlite3
+    database: storage/directory.sqlite3
+    migrations_paths: db/migrate
+  tenant:
+    adapter: sqlite3
+    tenanted: true
+    database: storage/tenants/%{tenant}/db.sqlite3
+    migrations_paths: db/tenant_migrate
+```
+
+Use equivalent entries for development and test. Keep tenant keys stable, such as an organization's internal identifier. Customer-supplied hostnames are not tenant authorization.
+
+Generate the mailbox migrations in the correct directories:
+
+```sh
+bin/rails generate cloudflare:email:mailboxes \
+  --directory-migrations-path=db/migrate \
+  --tenant-migrations-path=db/tenant_migrate
+```
+
+Put Action Mailbox and Active Storage migrations in the tenant migration directory too. Apply the shared migrations and the tenant migrations using your application's database provisioning workflow. Keep every existing tenant's schema current before starting workers against a new release.
+
+## 2. Load stable connection classes before the mailbox models
+
+The optional gem models inherit from your tenant base. That base must keep the same Ruby class identity across Rails development reloads. Define it in a file you explicitly require, outside reloadable model directories. If your app already has these bases, use those same classes; do not create competing versions.
+
+For example, `lib/email_database_records.rb`:
+
+```ruby
+class TenantRecord < ActiveRecord::Base
+  self.abstract_class = true
+  tenanted "tenant"
+end
+
+class DirectoryRecord < ActiveRecord::Base
+  self.abstract_class = true
+  connects_to database: { writing: :primary }
+end
+```
+
+Keep this file outside any paths your application configures for reloadable autoloading. Require it during application initialization after `activerecord-tenanted` has installed its Active Record support, and before the generated mailbox initializer loads the optional models. Add this inside your application class in `config/application.rb`:
+
+```ruby
+config.active_record_tenanted.connection_class = "TenantRecord"
+config.active_record_tenanted.tenanted_rails_records = true
+
+config.active_record_tenanted.tenant_resolver = ->(request) do
+  if request.path == "/rails/action_mailbox/cloudflare/inbound_emails"
+    nil
+  else
+    request.subdomain # Replace with your existing authorized tenant resolver.
+  end
+end
+
+initializer "my_app.cloudflare_email_tenancy",
+    after: "active_record_tenanted.active_record_base",
+    before: :load_config_initializers do
+  require Rails.root.join("lib/email_database_records").to_s
+  require "cloudflare/email/tenancy"
+  require "cloudflare/email/mailboxes/configuration"
+
+  Cloudflare::Email::Tenancy.configure(
+    base_class: TenantRecord,
+    current: -> { TenantRecord.current_tenant },
+    switch: ->(key, &block) {
+      unless TenantRecord.tenant_exist?(key)
+        raise Cloudflare::Email::Mailboxes::Unavailable,
+          "tenant is not provisioned"
+      end
+      TenantRecord.with_tenant(key, &block)
+    }
+  )
+  Cloudflare::Email::Mailboxes.configure(directory_base: DirectoryRecord)
+end
+```
+
+Leave the generated `cloudflare_email_mailboxes.rb` initializer to require `cloudflare/email/mailboxes`. Remove any duplicate tenancy configuration from other initializers.
+
+The ingress exception in the resolver matters: `activerecord-tenanted` normally locks a request to the tenant selected from its hostname. Email ingress must select its tenant from the verified recipient and shared domain directory, after the gem verifies the complete message signature. Returning `nil` lets that signed-recipient lookup select the correct database.
+
+`tenanted_rails_records = true` puts Action Mailbox and Active Storage on the configured tenant connection. Include their tables in tenant migrations and configure private storage. The gem restores its tenant context for its supported email and attachment jobs. For your own jobs that serialize tenant model arguments, prepend `Cloudflare::Email::TenantJobContext` and enqueue them inside `Cloudflare::Email::Tenancy.with(key)`; ordinary host tenant context alone does not establish the gem's context.
+
+## 3. Provision organizations separately from mailboxes
+
+Create tenant databases in your trusted organization-provisioning workflow:
+
+```ruby
+TenantRecord.create_tenant("organization-123")
+```
+
+The switch adapter above refuses missing tenants. Receiving mail or replaying a delivery event will never create a new tenant database implicitly.
+
+After registering and activating the organization's receiving domain, use the mailbox API within its context:
+
+```ruby
+Cloudflare::Email::Mailboxes.for_tenant("organization-123") do |inboxes|
+  mailbox = inboxes.create(
+    name: "Support",
+    address: "support@customer.example.com",
+    owner_ref: "team:42"
+  )
+  # Provision and activate the address before receiving or sending mail.
+end
+```
+
+See the [mailbox guide](mailboxes.md) for domain activation, address provisioning, sending, and event replay. Your application still authorizes which organization, mailbox, and message each user can access.
+
+## What is verified
+
+The optional CI job boots a real Rails application with `activerecord-tenanted`, runs the gem's tenant migrations in two SQLite databases, and checks identical numeric IDs remain isolated. It also verifies context restoration, refusal to create unknown tenant databases, and GlobalID's missing/wrong-tenant rejection. Separate integration tests exercise mailbox ingress, sending, jobs, and delivery-event replay.
+
+Run the library-specific smoke test locally with:
+
+```sh
+BUNDLE_GEMFILE=gemfiles/tenanted.gemfile bundle install
+BUNDLE_GEMFILE=gemfiles/tenanted.gemfile bundle exec ruby test/support/activerecord_tenanted.rb
+```

--- a/docs/activerecord-tenanted.md
+++ b/docs/activerecord-tenanted.md
@@ -2,6 +2,9 @@
 
 Use this setup when each organization has its own SQLite database. The shared database holds receiving domains and delivery-event routing. Mailboxes, messages, and the outbox live in the organization's database.
 
+This setup is entirely opt-in. Skip this guide for a single database: installing
+the gem or running the mailbox generator does not enable database tenancy.
+
 `activerecord-tenanted` is an optional application dependency. The gem's integration test uses version 0.8 on Rails 8.1; you do not need it for a single database or another tenant adapter.
 
 ## 1. Configure your databases

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -9,6 +9,9 @@ durable infrastructure without copying the reference inbox's models and services
 
 | Gem capability | Application responsibility |
 | --- | --- |
+| Optional mailbox/address directory and tenant connection adapter | Authorize domain ownership, provision tenant databases and grant user access |
+| Mailbox memberships, read/archive state and retained raw mail | Inbox UI, retention schedule and explicit purge policy |
+| Shared event intake, tenant correlation and tenant-aware jobs | Durable queue workers, scheduled recovery and schema rollout to every tenant |
 | Structured/raw sending and ActionMailer transport | Compose UI, recipients and send authorization |
 | `Response#accepted?`, plus individual recipient outcomes | Handle partial acceptance without resending accepted recipients |
 | Authenticated v2 ingress and recipient-scoped deduplication | Map trusted recipient to an authorized mailbox |
@@ -86,6 +89,7 @@ operator permissions also stay there. Suppression/unsubscribe requirements depen
 on message purpose and application policy; expose provider outcomes, but do not
 silently impose a marketing subscription model on transactional mail.
 
-A reusable inbox Rails engine or starter can later package common product setup.
-It should consume these gem APIs instead of maintaining another transport/receipt
-implementation. A new separate gem is unnecessary for the current optional adapter.
+The optional [mailbox module](mailboxes.md) now packages mailbox persistence and
+address management over the existing transport/receipt APIs. It includes a
+[tenant adapter](activerecord-tenanted.md), without adding a tenant library to
+the plain Ruby client. A future inbox UI or starter should consume these APIs.

--- a/docs/features.md
+++ b/docs/features.md
@@ -5,8 +5,9 @@ services. You can use just the sending client, add incoming mail, or build a
 mailbox on top of the optional database-backed delivery tools.
 
 Start with [Getting started](getting-started.md) for working examples. These
-features describe the unreleased **0.2.0** code; use the commit pinned in that
-guide until the release is published.
+features are available in **0.2.0**. Database multi-tenancy is **off by default**:
+the optional mailbox module works in one database unless you explicitly configure
+a tenant connection adapter. A mailbox tenant key alone does not switch databases.
 
 ## Choose the pieces you need
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -12,6 +12,8 @@ guide until the release is published.
 
 | You want to… | Use | What you get |
 | --- | --- | --- |
+| Create managed inboxes in code | Optional `Mailboxes` module | Named mailboxes, aliases, ownership references, read/archive state and retained raw mail |
+| Isolate organizations in separate databases | Optional `Tenancy` adapter | Configurable ActiveRecord base, tenant-aware jobs and shared-to-tenant event replay; tested with SQLite and `activerecord-tenanted` |
 | Send from an ordinary Ruby program | `Cloudflare::Email::Client` | Structured messages or complete raw MIME; no Rails/database required |
 | Send existing Rails mailers | ActionMailer delivery method | Your mailer templates, attachments, multipart bodies, cc/bcc and reply headers sent through Cloudflare |
 | Receive email in Rails | Email Worker + ActionMailbox | Unchanged raw MIME, attachments, authenticated SMTP envelope metadata and duplicate handling |
@@ -72,10 +74,13 @@ validation rejects malformed schema fields; original receipt identity and
 payload are read-only through normal ActiveRecord updates. These safeguards do
 not make database administrators untrusted or provide exactly-once delivery.
 
+See [managed mailbox setup](mailboxes.md) for the application-facing API and
+[activerecord-tenanted](activerecord-tenanted.md) for separate SQLite databases.
+
 ## What belongs in your mailbox application
 
-The gem supplies the email and delivery infrastructure. Your app supplies users,
-mailbox permissions, conversation records, folders, search, compose screens,
+The gem supplies email infrastructure and optional managed mailbox records.
+Your app supplies users, mailbox permissions, conversation records, custom folders, search, compose screens,
 drafts and any AI review or approval workflow. It also decides unsubscribe and
 recipient eligibility policy. The gem does not supply an inbox UI or AI agent.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -24,7 +24,7 @@ The new features are in the unreleased 0.2.0 code. RubyGems currently serves
 ```ruby
 gem "cloudflare-email",
   git: "https://github.com/cole-robertson/cloudflare-email.git",
-  ref: "661cd2f483973c0f3e0cd4aa091562b009300419"
+  ref: "4273c5ac10cb87d5e5610acc6a4e69c55d94a42f"
 ```
 
 ```sh

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -18,13 +18,11 @@ not need to be the same domain as your Rails application's web address.
 
 ### Install the current code
 
-The new features are in the unreleased 0.2.0 code. RubyGems currently serves
-0.1.0. Add this reviewed commit to your app's `Gemfile`:
+Add version 0.2 to your app's `Gemfile`. If upgrading from 0.1, read the
+[upgrade guide](upgrading-0.2.md) before changing an existing Worker deployment:
 
 ```ruby
-gem "cloudflare-email",
-  git: "https://github.com/cole-robertson/cloudflare-email.git",
-  ref: "4273c5ac10cb87d5e5610acc6a4e69c55d94a42f"
+gem "cloudflare-email", "~> 0.2.0"
 ```
 
 ```sh

--- a/docs/mailboxes.md
+++ b/docs/mailboxes.md
@@ -5,8 +5,13 @@ mail into them, track read/archive state, and send through the durable outbox.
 It works in one SQLite database or with a separate database per organization.
 It supplies models and services; your app supplies permissions and the UI.
 
-This module is new unreleased code. Use a reviewed commit containing this module,
-not the published 0.1.0 gem or the earlier security-only 0.2 commit.
+This module is available in version 0.2.0. Install `gem "cloudflare-email", "~> 0.2.0"`.
+
+**Database multi-tenancy is off by default.** The mailbox generator works with
+one ordinary database. Calling `for_tenant` groups and scopes mailbox records;
+it does not create databases or install a tenant adapter. Separate databases
+require explicit `Tenancy.configure(...)` before models load. Neither Rails nor
+`activerecord-tenanted` is added to plain Ruby applications by this module.
 
 ## Install
 

--- a/docs/mailboxes.md
+++ b/docs/mailboxes.md
@@ -1,0 +1,294 @@
+# Create and manage mailboxes from Rails
+
+The optional mailbox module lets your app create mailboxes and aliases, receive
+mail into them, track read/archive state, and send through the durable outbox.
+It works in one SQLite database or with a separate database per organization.
+It supplies models and services; your app supplies permissions and the UI.
+
+This module is new unreleased code. Use a reviewed commit containing this module,
+not the published 0.1.0 gem or the earlier security-only 0.2 commit.
+
+## Install
+
+First configure [sending and receiving](getting-started.md). Then run:
+
+```sh
+bin/rails generate cloudflare:email:mailboxes
+bin/rails db:migrate
+```
+
+The generator includes the outbox and tracking generators. Do not generate those
+migrations a second time if you already installed them; inspect existing
+generator conflicts and retain your installed migrations. Restart Rails after
+configuration changes. The generated initializer explicitly loads:
+
+```ruby
+require "cloudflare/email/mailboxes"
+```
+
+Loading this module enables mailbox lookup on the gem's Cloudflare ingress.
+Existing receiving addresses must be registered and activated before switching
+an existing application over. Unregistered or suspended destinations return
+HTTP 422 and the Worker rejects the delivery; there is no default-mailbox fallback.
+
+For separate organization databases, follow the
+[activerecord-tenanted setup](activerecord-tenanted.md) **before loading the
+models**. It covers shared versus tenant migrations, tenant-specific framework
+storage, early initialization and background jobs. Rails and ActiveStorage must
+use the same tenant connection as the mailbox tables for atomic incoming storage.
+
+## Register an organization's domain
+
+Run directory management from your authorized administration/provisioning code.
+Do not expose arbitrary domain claims to customers without ownership checks.
+
+```ruby
+inboxes = Cloudflare::Email::Mailboxes
+domain = inboxes.register_domain(
+  domain: "acme.example.com",
+  tenant_key: "organization-123",
+  account_id: Cloudflare::Email::Credentials.account_id,
+)
+```
+
+This creates a **pending directory entry**, not DNS records. Set up the receiving
+subdomain in Cloudflare and deploy the Worker. Then record your verification:
+
+```ruby
+inboxes.activate_domain!(domain.id,
+  evidence: "Receiving DNS and the development Worker verified in setup ticket 42",
+  sending_enabled: false,
+)
+```
+
+Activation records an operator assertion; the gem does not independently verify
+domain ownership from this string. Set `sending_enabled: true` only after
+Cloudflare has also verified this sending domain. Incoming routing and outgoing
+domain verification are separate setup steps. An address's route is activated
+separately below.
+
+Each exact domain belongs to one tenant. Domain ownership, tenant key and
+Cloudflare account identity cannot be reassigned through normal model updates.
+Keep tenant keys stable and resolve them to provisioned databases through your
+trusted tenant adapter. Use customer/organization IDs rather than deriving a
+database filename directly from an email address.
+
+## Create a mailbox and activate its route
+
+Even in a single database, use an explicit tenant key and the scoped session:
+
+```ruby
+inboxes.for_tenant("organization-123") do |account|
+  mailbox = account.create(
+    name: "Customer support",
+    address: "support@acme.example.com",
+    owner_ref: "team:42",
+  )
+  address = account.addresses(mailbox.id).first
+
+  provisioner = Cloudflare::Email::RoutingProvisioner.new(
+    api_token: Cloudflare::Email::Credentials.management_token,
+  )
+  account.provision_address!(address.id,
+    provisioner: provisioner,
+    worker_name: "cloudflare-email-ingress-development",
+  )
+end
+```
+
+`owner_ref` is your application's optional stable reference to a user, site,
+team or customer. The gem stores it; it does not load that record or authorize
+the person using it. Authorize the organization and mailbox in your app first.
+
+The address stays pending if provisioning fails. The provisioner upserts an
+individual address rule, so you can retry setup. Run provisioning outside a
+database transaction. DNS propagation and an actual inbound test are still
+needed after the API succeeds.
+
+If you already configured a route separately, record that explicitly:
+
+```ruby
+account.activate_address!(address.id, evidence: "Existing route verified in ticket 43")
+```
+
+This example assumes the same `for_tenant` block and local variables as above.
+The gem does not change a zone-wide catch-all while creating a mailbox.
+
+## Aliases, suspension and ownership
+
+An alias is another address attached to the same mailbox:
+
+```ruby
+inboxes.for_tenant("organization-123") do |account|
+  mailbox = account.mailboxes.find_by!(owner_ref: "team:42")
+  alias_address = account.add_address(mailbox.id, address: "help@acme.example.com")
+  # Provision alias_address exactly as you provisioned the first address.
+
+  account.suspend(mailbox.id) # Stops new ingress and queued mailbox sends.
+  account.resume(mailbox.id)
+  # To suspend only one address:
+  account.suspend_address(mailbox.id, alias_address.id)
+end
+```
+
+Suspension is enforced by Rails; it does not delete the Cloudflare route. Mail
+already accepted and stored remains available for processing and inspection.
+Use `activate_address!` with new evidence to reactivate an address. Domain-wide
+suspension is an administrative update of `ReceivingDomain#state` to `suspended`.
+
+Addresses use lowercase ASCII dot-atom local parts and domains. Alias addresses
+are explicit: the module does not automatically strip `+tags` or invent address
+fallbacks. Reserve application-specific names such as Rebulk's `tracking` in
+your mailbox-management policy before creation.
+
+## Read incoming mail
+
+The Worker signs the SMTP recipient. Rails verifies the whole request, resolves
+the domain, enters its tenant context and stores raw mail plus a mailbox
+membership in one database transaction. MIME To/Cc headers do not select the
+tenant. Retries for the same raw message and exact SMTP recipient are deduplicated.
+
+Inside your authenticated application's mailbox view/service:
+
+```ruby
+inboxes.for_tenant("organization-123") do |account|
+  mailbox = account.mailboxes.find_by!(owner_ref: "team:42")
+  account.messages(mailbox.id).inbox.unread.order(id: :desc).limit(25).each do |entry|
+    inbound = account.inbound_email(mailbox.id, entry.id)
+    subject = inbound.mail.subject
+    raw_mime = inbound.raw_email.download
+    # Build your authorized UI response here; sanitize rendered mail content.
+  end
+end
+```
+
+Perform tenant record access inside the block, rather than retaining lazy
+relations or framework records for use under another tenant. Numeric record IDs
+can overlap in separate tenant databases.
+
+For a message entry you have already authorized:
+
+```ruby
+account.mark_read(mailbox.id, entry.id)
+account.mark_read(mailbox.id, entry.id, read: false)
+account.archive(mailbox.id, entry.id)
+account.archive(mailbox.id, entry.id, archived: false)
+```
+
+These calls also belong inside the tenant block. Raw mail with a mailbox
+membership is protected from ActionMailbox's normal automatic incineration.
+Archive hides it from the inbox scope but retains the content. For deliberate
+permanent deletion, use `account.purge_message(mailbox.id, entry.id)`; it deletes
+the raw inbound record only when no other mailbox membership references it.
+ActiveStorage schedules its attachment cleanup jobs. Apply your own retention,
+encryption and backup policies; archive is not a retention policy.
+
+## Send from the mailbox
+
+Use a rendered ActionMailer message whose From and SMTP envelope sender are an
+active address belonging to the mailbox. The domain must be enabled for sending.
+`ReplyMailer` below is your application's mailer, not a generated gem class.
+
+```ruby
+inboxes.for_tenant("organization-123") do |account|
+  mailbox = account.mailboxes.find_by!(owner_ref: "team:42")
+  operation = account.prepare(mailbox.id,
+    operation_key: "draft:789:revision:1",
+    mail: ReplyMailer.reply(draft).message,
+  )
+  account.enqueue(mailbox.id, operation_key: operation.operation_key)
+end
+```
+
+Authorize the send before preparation. If preparation is part of an application
+transaction, enqueue only after its **outer commit**. The job queue must process
+`mailers`. Do not also call `deliver_later` on the mailer.
+
+The caller's operation key is namespaced by tenant and mailbox. Save the returned
+operation key and reuse it when enqueueing a retry. Re-rendering an already
+prepared operation may change MIME headers and raises a snapshot conflict.
+The job serializes tenant, mailbox ID and operation key—not MIME or credentials.
+It checks the current mailbox/address/domain state again before sending.
+
+Inspect `account.outbound_messages(mailbox.id)` and each link's
+`outbound_delivery` for the saved operation, provider ID and recipient outcomes.
+Accepted or partial attempts are never automatically resent. Uncertain attempts
+need [audited reconciliation](outbox.md#reconcile-uncertainty), available through
+`account.reconcile(mailbox.id, operation_key: saved_key, **evidence)`.
+
+For several Cloudflare accounts, configure a runtime client resolver **before
+loading mailbox models**:
+
+```ruby
+Cloudflare::Email::Mailboxes.configure(
+  directory_base: DirectoryRecord,
+  client_resolver: ->(tenant_key, account_id) {
+    Cloudflare::Email::Client.new(account_id: account_id,
+      api_token: YourSecretStore.email_token(tenant_key, account_id),
+      retry_ambiguous: false)
+  },
+)
+```
+
+`DirectoryRecord` and `YourSecretStore` are application examples. For one account,
+the default resolver uses the existing gem credentials and verifies the account
+matches. Cloudflare account IDs and your tenant keys are separate identities.
+
+## Delivery events and recovery
+
+Configure the [Cloudflare Queue subscription and token](delivery-events.md).
+Use shared intake for tenant mailboxes, rather than selecting a tenant from the
+event's recipient or Cloudflare account:
+
+```ruby
+Rails.application.config.x.cloudflare_email.event_domains = ["acme.example.com"]
+Rails.application.config.x.cloudflare_email.event_handler = ->(event) {
+  Cloudflare::Email::Mailboxes::Events.record(event)
+}
+```
+
+Schedule `cloudflare:email:consume_events` to poll batches. Also schedule these
+jobs regularly, starting at the beginning of each scan:
+
+```ruby
+Cloudflare::Email::Mailboxes::ReplayEventsJob.perform_later
+Cloudflare::Email::Mailboxes::RecoverJob.perform_later("organization-123")
+```
+
+Schedule recovery for each provisioned organization in your own directory. Each
+job processes a bounded page and enqueues its continuation. Recovery dispatches
+prepared operations, repairs accepted-result callbacks and registers provider
+correlation; it does not clear uncertain send claims. Domain suspension leaves
+events retained for later projection.
+
+Shared event intake commits before queue acknowledgement. After an accepted
+send, the gem registers account/message/recipient correlation to the tenant's
+outbox record. Events arriving first remain unmatched until replay. Tenant
+projection commits before shared completion; a crash between those commits
+causes safe redelivery to the tenant's deduplicating receipt ledger. Ambiguous
+correlations remain unprojected.
+
+The existing `config.x.cloudflare_email.outbox_delivery_handler` and
+`outbox_recipient_handler` callbacks work here too. Keep them idempotent and on
+the same tenant connection when atomicity is required. External effects cannot
+be rolled back. Provider acceptance, shared storage and tenant storage are not
+one transaction; this is not exactly-once delivery.
+
+## Isolation and rollout
+
+The scoped session API checks tenant/mailbox ownership and sender addresses.
+It does not authenticate Rails users. Protect admin directory APIs, choose the
+tenant through your access resolver, and authorize every mailbox operation.
+Direct/unscoped ActiveRecord access is an application-level privileged interface,
+particularly in shared-database mode; it is not a row-level authorization system.
+
+For database tenancy, configure all framework storage on the tenant connection
+and exclude ingress from hostname/session tenant selection. New framework jobs
+capture tenant context before serialization and restore it before GlobalID
+lookup. Drain existing ActionMailbox/ActiveStorage queues before enabling this
+mode: previously serialized jobs without the new metadata are rejected.
+
+The gem does not create organizations/users, verify customer domain ownership,
+provide IMAP/POP, or supply an inbox UI. The original Rebulk document-processing
+Worker contract and sender-review policy still need a separate application
+migration; installing this module does not replace that live pipeline.

--- a/docs/tenant-mailboxes-plan.md
+++ b/docs/tenant-mailboxes-plan.md
@@ -1,0 +1,149 @@
+# Tenant-aware mailbox layer — implementation proposal
+
+Status: original design record. The reusable mailbox module and tenant adapter
+are implemented on the feature branch; see [mailboxes](mailboxes.md) and
+[tenant setup](activerecord-tenanted.md) for the actual API. Rebulk application
+migration and live customer rollout remain separate work. Based on the gem's merged 0.2
+code and Rebulk/rebulk-system main at
+`17ffafccb69968dae022acdbb4620b84c65bedfb`.
+
+## Product goal
+
+Let a Rails application create, suspend and manage named mailboxes for its
+organizations, sites or users. Support organization subdomains such as
+`houston@venezia.rebulk.com`. Reuse the gem's transport, outbox and receipts;
+do not create another delivery ledger. SQLite remains the default integration
+target, including separate SQLite databases with `activerecord-tenanted`.
+
+## Rebulk already has the foundations
+
+- `Organization` is shared and carries `email_subdomain`.
+- `TenantRecord` uses `activerecord-tenanted` and requires a tenant context.
+- Sites have per-organization email local parts. `tracking@<org>.rebulk.com`
+  is an existing reserved organization-level destination.
+- `Customer` is a buyer within an organization, not the tenant root. A customer
+  mailbox can belong to that record without creating another tenant database.
+- ActiveStorage is tenant-specific. Mail must resolve its tenant before blob
+  access, persistence or job deserialization that needs tenant records.
+- `InboundEmail` records document-processing outcomes inside the tenant.
+  `CommunicationMessage` is a shared, encrypted cross-channel operational view.
+  Preserve these product roles instead of replacing them with duplicate models.
+- Existing ingest has its own Worker contract, sender authentication and
+  authorization, raw archive and document processing. It is not currently the
+  gem's ActionMailbox pipeline. Its policy cannot be discarded during migration.
+- `OrganizationEmailDomain` supports sign-in auto-join. Receiving-domain
+  ownership must be separate; creating a receiving domain must never grant users
+  membership or change login policy.
+
+## Database and routing boundary
+
+Keep a minimal shared receiving-domain directory: exact canonical domain,
+immutable tenant identity, tenant connection key, lifecycle state and provisioning
+evidence. Enforce domain ownership with a database uniqueness constraint. Never
+construct a SQLite path from an arbitrary recipient string or request parameter.
+
+Keep mailbox definitions, address aliases, message memberships, outbox records
+and tenant receipts in the tenant database. Support an application-selected
+ActiveRecord base class so every related gem model uses the intended connection.
+Merely wrapping today's hardcoded `ActiveRecord::Base` models in `with_tenant`
+does not establish that connection contract.
+
+The ingress sequence must be:
+
+1. Bound the body and verify the complete Worker signature and envelope.
+2. Resolve the exact signed recipient domain in the shared active directory.
+3. Enter the mapped tenant context, without creating a tenant implicitly.
+4. Resolve the registered active mailbox/alias inside that tenant.
+5. Persist raw mail and mailbox membership idempotently, then schedule processing.
+6. Restore tenant context even when processing raises.
+
+No MIME To/Cc, browser session fallback, sender domain or guessed organization
+slug may select the receiving tenant. Unknown/suspended domains and addresses
+must have explicit rejection or restricted quarantine outcomes, with no fallback
+to an arbitrary tenant/mailbox. Directory changes and mailbox suspension must
+also be checked when deferred work resumes; never silently reassign old mail.
+
+## Optional mailbox module
+
+Add explicit opt-in loading and a generator. The initial contract should cover:
+
+- Tenant/domain registration and verified provisioning state.
+- Mailbox creation, aliases, suspension and lookup by registered address.
+- Application ownership links for user/site/customer mailboxes, checked within
+  the resolved tenant; authenticated actor authorization stays in the host app.
+- Incoming message membership and deduplication without another copy of MIME.
+- Outgoing preparation through an active mailbox with an allowed From address,
+  linked to the existing outbox. A customer cannot select another tenant's
+  sender merely because both share the same Cloudflare account token.
+- An explicit tenant context adapter and connection-class configuration;
+  `activerecord-tenanted` is an optional integration, not a plain-Ruby dependency.
+
+Do not claim a finished inbox UI, IMAP/POP service, thread model, AI workflow,
+search engine or membership system. Rebulk supplies those product decisions.
+Document local-part case policy, reserved names and alias behavior before schema
+implementation; normalization must agree across directory, mailbox and send APIs.
+
+## Jobs, events and cross-database commits
+
+Jobs carry stable tenant and operation/mailbox identities. Establish tenant
+context before loading records. Never rely on a previous request's `Current`
+state, a naked numeric record ID or a Cloudflare account ID as a tenant key.
+Cloudflare account identity and application tenant identity are different.
+
+Queue events arrive without a Rails tenant context and may precede a saved send
+response. Use a shared durable receipt intake and a provider correlation
+directory populated by tenant outbox results. Retain unmatched events and retry
+when correlation becomes available; do not infer tenant ownership solely from
+the recipient's external domain. Ambiguous mappings remain unprojected.
+
+Delivery from shared intake to tenant projection is at least once. A tenant
+receipt deduplicates it. Mark shared processing complete only after tenant commit;
+crashes between commits cause safe replay. Writes to the shared directory,
+tenant SQLite and job queue are not one transaction. Recovery must cover each
+gap without allowing another send or prematurely acknowledging an event.
+
+## Customer subdomains and Cloudflare
+
+An organization may use a Rebulk-owned subdomain or, later, an explicitly verified
+customer-owned domain. Track receive readiness and send-domain verification
+separately. A Rails database record or wildcard DNS entry alone does not enable
+Cloudflare email routing or sending.
+
+Prefer explicit address rules for the first supported provisioner. Reconcile
+desired state with Cloudflare and retain failures for retry rather than marking
+a mailbox active before its route is ready. Multiple tenants may share a Worker
+and ingress secret within one application/environment; tenant routing stays in
+Rails. Separate Cloudflare accounts require account-aware credentials/jobs.
+
+The current catch-all task operates at zone scope. Do not alter the Rebulk apex
+catch-all or promise automatic subdomain catch-alls as part of mailbox creation.
+Verify provider support and limits for the exact subdomain topology before a
+live rollout. Custom domains need ownership verification and safe offboarding.
+
+## Implementation slices and acceptance checks
+
+1. **Tenant foundation:** configurable model connections, tenant-aware job
+   wrappers and migrations in the tenant migration path. Test two real SQLite
+   tenant databases with overlapping IDs, missing context, retries and cleanup.
+2. **Mailbox registry:** shared domain mapping plus tenant mailboxes/aliases,
+   lifecycle and ownership APIs. Test exact matching, uniqueness races,
+   suspension, reserved addresses and isolation for lookup and sending.
+3. **Tenant ingress:** authenticated envelope resolution before ActionMailbox
+   storage. Test Bcc routing, raw bytes, duplicate delivery, unknown destinations,
+   tenant-specific blob access and processing jobs after process restart.
+4. **Outbound/event integration:** reuse saved MIME/claims, enforce mailbox sender
+   identity, add durable shared-to-tenant event dispatch and repair scans. Test
+   event-before-response, duplicate receipts and crashes at each commit boundary.
+5. **Rebulk adoption:** map existing org/site addresses, preserve tracking and
+   sender-review policies, link existing communication/ingest records, and add
+   mailbox management through Rebulk's access resolver. Start behind a feature
+   flag on an isolated development address; keep current production routes intact.
+6. **Provisioning and live verification:** test domain/route setup with bounded
+   retries, then a real send/reply/attachment/event flow for two test tenants.
+   Verify the deployed revision and preserve a dated report before customer rollout.
+
+Required regressions include existing plain-Ruby, single-database SQLite and
+PostgreSQL behavior. Do not call the integration complete merely because a
+single-tenant send works. Existing Rebulk sender-authentication metadata must
+remain authenticated through the new Worker contract before its old ingress
+can be retired; the gem's v2 envelope alone does not supply that policy evidence.

--- a/docs/upgrading-0.2.md
+++ b/docs/upgrading-0.2.md
@@ -1,6 +1,8 @@
 # Upgrade from 0.1.0 to 0.2.0
 
-0.2.0 adds delivery events and changes defaults where 0.1.0 could resend mail or misconfigure routing. It is prepared as a release candidate; publishing the gem is a separate step.
+0.2.0 adds delivery events, optional managed mailboxes and opt-in tenant adapters,
+and changes defaults where 0.1.0 could resend mail or misconfigure routing.
+Database multi-tenancy remains off unless explicitly configured.
 
 ## Application changes
 

--- a/docs/verification/2026-09-11-tenant-mailboxes.md
+++ b/docs/verification/2026-09-11-tenant-mailboxes.md
@@ -1,0 +1,75 @@
+# Optional mailboxes and tenant support — 2026-09-11
+
+Implementation source: `4273c5ac10cb87d5e5610acc6a4e69c55d94a42f`.
+The guides and installation pin may receive subsequent documentation-only updates.
+
+## Implemented
+
+- Explicit optional tenant adapter and configurable model base for the existing
+  outbox/receipt models and new tenant mailbox models. Plain Ruby remains independent.
+- Shared receiving-domain directory and tenant mailboxes, aliases, owner references,
+  lifecycle, inbound memberships, read/archive state and explicit purge.
+- Full HMAC verification before recipient-to-tenant resolution, followed by
+  same-connection ActionMailbox/ActiveStorage persistence and membership storage.
+- Scoped mailbox sender checks and identity-only send jobs using the existing
+  immutable outbox, callbacks, reconciliation and conservative retry behavior.
+- Shared event intake before ACK, account/message/recipient correlation to a
+  tenant outbox, tenant commit before shared completion, and bounded recovery jobs.
+- Tenant serialization before framework GlobalID lookup; missing/conflicting
+  tenant metadata rejected. Managed raw mail retained against normal incineration.
+- Composed generator with separate tenant/shared migration paths and optional
+  `activerecord-tenanted` integration guide/bundle/CI job.
+
+## Local verification
+
+Ruby 3.4.1 / Rails 8.1.3.1 unless noted:
+
+| Check | Result |
+| --- | --- |
+| Full `bundle exec rake test` | 212 tests, 758 assertions, no failures/errors/skips |
+| Tenant connection and job subprocess | 11 tests, 54 assertions; physical SQLite shards with overlapping IDs, host-only framework job capture and context restoration |
+| Default job-context subprocess | 3 tests, 7 assertions; ordinary untagged jobs preserved without database tenancy |
+| Mailbox service subprocess | 16 tests, 92 assertions; two fixed SQLite tenant pools plus shared directory |
+| Shared event subprocess | 8 tests, 28 assertions; also checked on Rails 7.2 |
+| Real Rails mailbox ingress subprocess | 4 tests, 29 assertions; signed recipient routing, raw storage, jobs, aliases, deduplication, unavailable destinations, retention and purge |
+| Actual `activerecord-tenanted` 0.8 integration | 3 tests, 23 assertions; real tenant provisioning/migrations, isolation, context and GlobalID checks |
+| Generator checks | Fresh single-DB and separate shared/tenant SQLite installs, migration ordering and initializer syntax |
+| Packaged gem | Isolated Ruby consumer; Rails install/ingress/outbox checks; new tenant ingress, jobs, retention and all mailbox migrations from extracted package |
+| Local workerd → Rails | Existing real runtime fixture passed, including raw bytes, routing, duplicates, invalid credentials, redirects and timeout |
+
+Top-level test totals include subprocess wrapper assertions; detailed subprocess
+counts above describe their internal checks and are not additional top-level tests.
+The service suite includes concurrent claims producing one provider request,
+callback rollback, retry/recovery without resending, reconcile rollback, pagination,
+suspension after enqueue, caller operation-key isolation and sender/account checks.
+Event tests include event-before-response, conflicting identities, cross-tenant
+correlation ambiguity, tenant-commit/shared-failure replay, and callback rollback.
+
+The optional tenant dependency resolution passed bundler-audit. CI additionally
+runs the supported Ruby/Rails matrix, PostgreSQL outbox checks and Worker checks.
+Check the PR's CI for results on its latest revision.
+
+## Operational boundaries
+
+No production Worker, domain/DNS, inbox or Rebulk deployment changed. No real
+email was sent by these checks. The new Worker-to-mailbox path uses the existing
+v2 signature contract; live customer subdomain provisioning was not exercised.
+Rebulk's existing ingest/communication records and sender-authentication policy
+still require a separate, explicit application adoption project.
+
+Directory activation records authorized operator evidence, not independent
+domain verification. Application permissions select tenant and mailbox access;
+raw ActiveRecord and administrative directory methods are privileged interfaces.
+Database keys and queue payloads must come from trusted application state.
+
+Framework records must share the configured tenant connection. Drain old
+ActionMailbox/ActiveStorage jobs before enabling database tenancy because old
+payloads without the new metadata cannot safely be guessed. Mailbox memberships
+retain raw mail until explicit purge, so applications must define a retention
+policy and monitor storage usage.
+
+Queue intake and tenant projection use separate commits with idempotent recovery,
+not a distributed transaction. Schedule polling, shared replay and per-tenant
+recovery. Unknown provider outcomes stay blocked; no exactly-once guarantee or
+automatic resend is added. Existing outbox PostgreSQL behavior remains covered;
+the new mailbox/tenant integration's direct database evidence is SQLite.

--- a/gemfiles/tenanted.gemfile
+++ b/gemfiles/tenanted.gemfile
@@ -1,0 +1,7 @@
+source "https://rubygems.org"
+
+gemspec path: ".."
+
+gem "rails", "~> 8.1.0", ">= 8.1.3.1"
+gem "sqlite3", ">= 2.9.6"
+gem "activerecord-tenanted", "~> 0.8.0"

--- a/lib/cloudflare/email/active_record/base.rb
+++ b/lib/cloudflare/email/active_record/base.rb
@@ -1,0 +1,48 @@
+require "active_record"
+require "cloudflare/email/tenancy"
+
+module Cloudflare
+  module Email
+    module ActiveRecord
+      # Uses the host's abstract tenant connection owner when explicitly configured.
+      class Base < Tenancy.model_base(::ActiveRecord::Base)
+        self.abstract_class = true
+
+        class << self
+          def connection_pool
+            Tenancy.require_context! if Tenancy.enabled?
+            super
+          end
+        end
+
+        before_validation :verify_cloudflare_email_tenant!
+        before_save :verify_cloudflare_email_tenant!
+        before_destroy :verify_cloudflare_email_tenant!
+
+        # These methods can bypass callbacks or load a different row with the same ID.
+        %i[reload update_columns delete touch increment! decrement! association].each do |method_name|
+          define_method(method_name) do |*args, **kwargs, &block|
+            verify_cloudflare_email_tenant!
+            super(*args, **kwargs, &block)
+          end
+        end
+
+        private
+
+        # Both new construction and persisted-row instantiation call this before
+        # assigning inverse associations (which precede after_initialize).
+        def init_internals
+          super
+          @cloudflare_email_tenant_key = Tenancy.require_context! if Tenancy.enabled?
+        end
+
+        def verify_cloudflare_email_tenant!
+          return unless Tenancy.enabled?
+          unless @cloudflare_email_tenant_key == Tenancy.require_context!
+            raise ConfigurationError, "record belongs to a different tenant context"
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/cloudflare/email/active_record/event_receipt.rb
+++ b/lib/cloudflare/email/active_record/event_receipt.rb
@@ -1,7 +1,9 @@
+require "cloudflare/email/active_record/base"
+
 module Cloudflare
   module Email
     module ActiveRecord
-      class EventReceipt < ::ActiveRecord::Base
+      class EventReceipt < Base
         self.table_name = "cloudflare_email_event_receipts"
         attr_readonly :account_id, :event_id, :message_id, :payload_json
 

--- a/lib/cloudflare/email/active_record/outbound_delivery.rb
+++ b/lib/cloudflare/email/active_record/outbound_delivery.rb
@@ -1,7 +1,9 @@
+require "cloudflare/email/active_record/base"
+
 module Cloudflare
   module Email
     module ActiveRecord
-      class OutboundDelivery < ::ActiveRecord::Base
+      class OutboundDelivery < Base
         self.table_name = "cloudflare_email_outbound_deliveries"
         has_many :outbound_recipients, class_name: "Cloudflare::Email::ActiveRecord::OutboundRecipient", dependent: :restrict_with_exception
         has_many :outbound_reconciliations, class_name: "Cloudflare::Email::ActiveRecord::OutboundReconciliation", dependent: :restrict_with_exception

--- a/lib/cloudflare/email/active_record/outbound_recipient.rb
+++ b/lib/cloudflare/email/active_record/outbound_recipient.rb
@@ -1,7 +1,9 @@
+require "cloudflare/email/active_record/base"
+
 module Cloudflare
   module Email
     module ActiveRecord
-      class OutboundRecipient < ::ActiveRecord::Base
+      class OutboundRecipient < Base
         self.table_name = "cloudflare_email_outbound_recipients"
         belongs_to :outbound_delivery, class_name: "Cloudflare::Email::ActiveRecord::OutboundDelivery"
         attr_readonly :outbound_delivery_id, :recipient

--- a/lib/cloudflare/email/active_record/outbound_reconciliation.rb
+++ b/lib/cloudflare/email/active_record/outbound_reconciliation.rb
@@ -1,7 +1,9 @@
+require "cloudflare/email/active_record/base"
+
 module Cloudflare
   module Email
     module ActiveRecord
-      class OutboundReconciliation < ::ActiveRecord::Base
+      class OutboundReconciliation < Base
         self.table_name = "cloudflare_email_outbound_reconciliations"
         belongs_to :outbound_delivery, class_name: "Cloudflare::Email::ActiveRecord::OutboundDelivery"
         def readonly?

--- a/lib/cloudflare/email/engine.rb
+++ b/lib/cloudflare/email/engine.rb
@@ -18,6 +18,19 @@ module Cloudflare
         app.middleware.insert_before 0, DevIngressGuard if Rails.env.development?
       end
 
+      config.to_prepare do
+        if (defined?(Cloudflare::Email::Tenancy) && Cloudflare::Email::Tenancy.enabled?) ||
+            (defined?(Cloudflare::Email::Mailboxes) && Cloudflare::Email::Mailboxes.enabled?)
+          require "cloudflare/email/tenant_job_context"
+          Cloudflare::Email::TenantJobContext.install_framework_jobs!
+        end
+        if defined?(Cloudflare::Email::Mailboxes) && Cloudflare::Email::Mailboxes.enabled? && defined?(::ActionMailbox::Engine)
+          require "cloudflare/email/mailboxes/inbound_retention"
+          ::ActionMailbox::InboundEmail.prepend(Cloudflare::Email::Mailboxes::InboundRetention) unless
+            ::ActionMailbox::InboundEmail.ancestors.include?(Cloudflare::Email::Mailboxes::InboundRetention)
+        end
+      end
+
       config.before_initialize do
         unless defined?(::ActionMailbox::Engine)
           Rails.autoloaders.main.ignore(

--- a/lib/cloudflare/email/mailboxes.rb
+++ b/lib/cloudflare/email/mailboxes.rb
@@ -1,0 +1,11 @@
+# Explicit opt-in. Configure Tenancy and Mailboxes before loading this file.
+require "cloudflare-email"
+require "cloudflare/email/tenancy"
+require "cloudflare/email/mailboxes/configuration"
+require "cloudflare/email/active_record"
+require "cloudflare/email/mailboxes/models"
+require "cloudflare/email/mailboxes/events"
+require "cloudflare/email/mailboxes/service"
+require "cloudflare/email/mailboxes/jobs"
+
+Cloudflare::Email::Mailboxes.enable!

--- a/lib/cloudflare/email/mailboxes/configuration.rb
+++ b/lib/cloudflare/email/mailboxes/configuration.rb
@@ -1,0 +1,58 @@
+require "active_record"
+require "cloudflare/email/error"
+
+module Cloudflare
+  module Email
+    module Mailboxes
+      class Unavailable < Cloudflare::Email::Error; end
+
+      class << self
+        def configure(directory_base: ::ActiveRecord::Base, client_resolver: nil)
+          if const_defined?(:ReceivingDomain, false)
+            raise ConfigurationError, "configure mailboxes before loading mailbox models"
+          end
+          unless directory_base.is_a?(Class) && directory_base <= ::ActiveRecord::Base
+            raise ConfigurationError, "directory_base must be an ActiveRecord base class"
+          end
+          if client_resolver && !client_resolver.respond_to?(:call)
+            raise ConfigurationError, "client_resolver must be callable"
+          end
+          @directory_base = directory_base
+          @client_resolver = client_resolver
+        end
+
+        def directory_base = @directory_base || ::ActiveRecord::Base
+
+        def delivery_handler = rails_setting(:outbox_delivery_handler)
+        def recipient_handler = rails_setting(:outbox_recipient_handler)
+
+        def client_for(tenant_key, account_id)
+          client = if @client_resolver
+            @client_resolver.call(tenant_key, account_id)
+          else
+            require "cloudflare/email/credentials"
+            unless Credentials.account_id == account_id
+              raise ConfigurationError, "configure a tenant/account client_resolver for this sending account"
+            end
+            Client.new(account_id: account_id, api_token: Credentials.api_token, retry_ambiguous: false)
+          end
+          unless client.account_id == account_id && client.retry_ambiguous == false
+            raise ConfigurationError, "mailbox client must match account and disable ambiguous retries"
+          end
+          client
+        end
+
+        def enabled? = @enabled == true
+        def enable! = @enabled = true
+
+        private
+
+        def rails_setting(name)
+          if defined?(::Rails) && ::Rails.respond_to?(:application) && ::Rails.application
+            ::Rails.application.config.x.cloudflare_email.public_send(name)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/cloudflare/email/mailboxes/events.rb
+++ b/lib/cloudflare/email/mailboxes/events.rb
@@ -1,0 +1,112 @@
+require "cloudflare/email/active_record/delivery_events"
+require "cloudflare/email/mailboxes/shared_event_receipt"
+require "cloudflare/email/mailboxes/provider_correlation"
+
+module Cloudflare
+  module Email
+    module Mailboxes
+      # Queue ACK follows shared intake. Projection is separately replayable:
+      # a crash between tenant commit and shared completion simply replays the
+      # tenant's idempotent receipt. No distributed transaction is assumed.
+      class Events
+        class << self
+          def record(event)
+            outside_shared_transaction!
+            event = DeliveryEvent.new(event.raw)
+            receipt = SharedEventReceipt.create_or_find_by!(account_id: event.account_id, event_id: event.event_id) do |row|
+              row.message_id = MessageId.normalize(event.message_id)
+              row.recipient = normalize_recipient(event.recipient)
+              row.payload_json = JSON.generate(event.raw)
+              row.state = "pending"
+            end
+            raise ValidationError, "event ID already recorded with a different payload" unless receipt.event.raw == event.raw
+            receipt
+          end
+
+          # Call after provider acceptance has committed in the tenant database.
+          # Duplicate registrations are harmless; collisions remain visible and
+          # deliberately prevent routing rather than selecting an arbitrary tenant.
+          def register(delivery, tenant_key: Tenancy.require_context!)
+            assert_context!(tenant_key)
+            outside_shared_transaction!
+            raise ArgumentError, "registration must follow the tenant commit" if delivery.class.connection.transaction_open?
+            delivery.reload
+            unless delivery.persisted? && %w[accepted partial].include?(delivery.state) && !delivery.provider_message_id.to_s.empty?
+              raise ArgumentError, "expected a committed accepted delivery with a provider message ID"
+            end
+            unless OutboundMessage.where(tenant_key: tenant_key, outbound_delivery_id: delivery.id).exists?
+              raise ArgumentError, "delivery does not belong to a mailbox in the current tenant"
+            end
+            delivery.outbound_recipients.map do |recipient|
+              ProviderCorrelation.create_or_find_by!(account_id: delivery.account_id,
+                message_id: MessageId.normalize(delivery.provider_message_id), recipient: normalize_recipient(recipient.recipient),
+                tenant_key: tenant_key.to_s, outbound_delivery_id: delivery.id)
+            end
+          end
+
+          def apply(receipt, &on_change)
+            outside_shared_transaction!
+            raise ArgumentError, "expected a persisted shared receipt" unless receipt.is_a?(SharedEventReceipt) && receipt.persisted?
+            receipt.reload
+            return receipt if receipt.state == "applied"
+
+            candidates = ProviderCorrelation.where(account_id: receipt.account_id,
+              message_id: receipt.message_id, recipient: receipt.recipient).limit(2).to_a
+            outcome = :unmatched
+            if candidates.length == 1
+              correlation = candidates.first
+              outcome = Tenancy.with(correlation.tenant_key) do
+                project(receipt.event, correlation, &on_change)
+              end
+            end
+            # Never overwrite another worker's completed projection.
+            SharedEventReceipt.where(id: receipt.id, state: %w[pending unmatched]).update_all(
+              state: outcome.to_s, applied_at: outcome == :applied ? Time.now.utc : nil, updated_at: Time.now.utc)
+            receipt.reload
+          end
+
+          # A bounded page, not an unbounded find_each scan. Use the last scanned
+          # ID as after_id for the next page, and restart at zero on the next pass.
+          def replay(limit: 100, after_id: 0, account_id: nil, &on_change)
+            raise ArgumentError, "limit must be between 1 and 1000" unless limit.is_a?(Integer) && (1..1000).cover?(limit)
+            raise ArgumentError, "after_id must be nonnegative" unless after_id.is_a?(Integer) && after_id >= 0
+            scope = SharedEventReceipt.where(state: %w[pending unmatched]).where("id > ?", after_id)
+            scope = scope.where(account_id: account_id) if account_id
+            scope.order(:id).limit(limit).to_a.each { |receipt| apply(receipt, &on_change) }
+          end
+
+          private
+
+          def outside_shared_transaction!
+            if SharedEventReceipt.connection.transaction_open?
+              raise ArgumentError, "shared event processing must run outside an existing database transaction"
+            end
+          end
+
+          def normalize_recipient(value)
+            ActiveRecord::Outbox.normalize_recipient(value)
+          end
+
+          def assert_context!(key)
+            raise ConfigurationError, "delivery belongs to another tenant" unless Tenancy.require_context! == key
+          end
+
+          def project(event, correlation, &on_change)
+            assert_context!(correlation.tenant_key)
+            return :unmatched unless OutboundMessage.where(tenant_key: correlation.tenant_key,
+              outbound_delivery_id: correlation.outbound_delivery_id).exists?
+            delivery = ActiveRecord::OutboundDelivery.find_by(id: correlation.outbound_delivery_id,
+              account_id: event.account_id, provider_message_id: MessageId.normalize(event.message_id), state: %w[accepted partial])
+            return :unmatched unless delivery && delivery.outbound_recipients.exists?(recipient: normalize_recipient(event.recipient))
+            return :unmatched unless ReceivingDomain.active.where(tenant_key: correlation.tenant_key,
+              account_id: event.account_id, domain: delivery.from_address.rpartition("@").last.downcase).exists?
+            # DeliveryEvents also refuses collisions within the tenant. Its
+            # transactional receipt protects callback writes against redelivery.
+            receipt = ActiveRecord::DeliveryEvents.record(event, &on_change)
+            receipt.state == "applied" ? :applied : :unmatched
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/cloudflare/email/mailboxes/inbound_retention.rb
+++ b/lib/cloudflare/email/mailboxes/inbound_retention.rb
@@ -1,0 +1,14 @@
+module Cloudflare
+  module Email
+    module Mailboxes
+      # ActionMailbox normally deletes processed mail after its retention window.
+      # A mailbox membership owns the raw source until explicit application purge.
+      module InboundRetention
+        def incinerate
+          return if Mailboxes.enabled? && Message.where(inbound_email_id: id).exists?
+          super
+        end
+      end
+    end
+  end
+end

--- a/lib/cloudflare/email/mailboxes/jobs.rb
+++ b/lib/cloudflare/email/mailboxes/jobs.rb
@@ -1,0 +1,34 @@
+require "active_job"
+
+module Cloudflare
+  module Email
+    module Mailboxes
+      class SendJob < ::ActiveJob::Base
+        queue_as :mailers
+
+        def perform(tenant_key, mailbox_id, operation_key)
+          Mailboxes.for_tenant(tenant_key) { |session| session.deliver(mailbox_id, operation_key: operation_key) }
+        end
+      end
+
+      class RecoverJob < ::ActiveJob::Base
+        queue_as :mailers
+
+        def perform(tenant_key, after_id = 0)
+          cursor = Mailboxes.for_tenant(tenant_key) { |session| session.recover(after_id: after_id) }
+          self.class.perform_later(tenant_key, cursor) if cursor
+        end
+      end
+
+      class ReplayEventsJob < ::ActiveJob::Base
+        queue_as :mailers
+
+        def perform(after_id = 0)
+          handler = Mailboxes.recipient_handler
+          page = Events.replay(after_id: after_id, &(handler.method(:call) if handler.respond_to?(:call)))
+          self.class.perform_later(page.last.id) if page.length == 100
+        end
+      end
+    end
+  end
+end

--- a/lib/cloudflare/email/mailboxes/models.rb
+++ b/lib/cloudflare/email/mailboxes/models.rb
@@ -1,0 +1,148 @@
+require "active_record"
+require "cloudflare/email/active_record/base"
+
+module Cloudflare
+  module Email
+    module Mailboxes
+      # Domains are an administrator-maintained receiving directory. An active
+      # record is an assertion by the application, not DNS ownership verification.
+      class ReceivingDomain < Mailboxes.directory_base
+        self.table_name = "cloudflare_email_receiving_domains"
+        STATES = %w[pending active suspended].freeze
+        attr_readonly :domain, :tenant_key, :account_id
+        before_validation { self.domain = domain.to_s.strip.downcase }
+        validates :tenant_key, :account_id, presence: true
+        validates :domain, presence: true, uniqueness: true,
+          length: { maximum: 253 },
+          format: { with: /\A[a-z0-9](?:[a-z0-9-]*[a-z0-9])?(?:\.[a-z0-9](?:[a-z0-9-]*[a-z0-9])?)+\z/ }
+        validates :state, inclusion: { in: STATES }
+        validate do
+          errors.add(:domain, "has an oversized label") if domain.to_s.split(".").any? { |label| label.length > 63 }
+        end
+        scope :active, -> { where(state: "active") }
+      end
+
+      module TenantIdentity
+        extend ActiveSupport::Concern
+        included do
+          attr_readonly :tenant_key
+          validates :tenant_key, presence: true
+          before_validation :assign_tenant_identity
+          validate :validate_tenant_identity
+          before_destroy :assert_tenant_identity!
+        end
+
+        private
+
+        def assign_tenant_identity
+          self.tenant_key ||= Tenancy.current_key
+        end
+
+        def validate_tenant_identity
+          return unless Tenancy.enabled? || Tenancy.current_key
+          Tenancy.require_context!
+          errors.add(:tenant_key, "does not match the current tenant") unless tenant_key == Tenancy.current_key
+        end
+
+        def assert_tenant_identity!
+          return unless Tenancy.enabled? || Tenancy.current_key
+          Tenancy.require_context!
+          raise ArgumentError, "record belongs to another tenant" unless tenant_key == Tenancy.current_key
+        end
+
+        def validate_parent_tenant(parent, attribute)
+          errors.add(attribute, "belongs to another tenant") if parent && parent.tenant_key != tenant_key
+        end
+      end
+
+      class Mailbox < Cloudflare::Email::ActiveRecord::Base
+        include TenantIdentity
+        self.table_name = "cloudflare_email_mailboxes"
+        has_many :addresses, class_name: "Cloudflare::Email::Mailboxes::Address", dependent: :restrict_with_exception
+        has_many :messages, class_name: "Cloudflare::Email::Mailboxes::Message", dependent: :restrict_with_exception
+        has_many :outbound_messages, class_name: "Cloudflare::Email::Mailboxes::OutboundMessage", dependent: :restrict_with_exception
+        validates :name, presence: true, length: { maximum: 255 }
+        validates :state, inclusion: { in: %w[active suspended] }
+        scope :active, -> { where(state: "active") }
+      end
+
+      class Address < Cloudflare::Email::ActiveRecord::Base
+        include TenantIdentity
+        self.table_name = "cloudflare_email_addresses"
+        belongs_to :mailbox, class_name: "Cloudflare::Email::Mailboxes::Mailbox"
+        attr_readonly :mailbox_id, :receiving_domain_id, :local_part, :domain, :address
+        before_validation :normalize_address
+        validates :mailbox, :receiving_domain_id, presence: true
+        validates :local_part, length: { in: 1..64 },
+          format: { with: /\A[a-z0-9!\#$%&'*+\/=\?^_`{|}~-]+(?:\.[a-z0-9!\#$%&'*+\/=\?^_`{|}~-]+)*\z/ }
+        validates :address, uniqueness: true, length: { maximum: 254 }
+        validates :state, inclusion: { in: %w[pending active suspended] }
+        validate :validate_directory
+        validate { validate_parent_tenant(mailbox, :mailbox) }
+        scope :active, -> { where(state: "active") }
+
+        def receiving_domain
+          ReceivingDomain.find_by(id: receiving_domain_id)
+        end
+
+        private
+
+        def normalize_address
+          self.local_part = local_part.to_s.strip.downcase
+          self.domain = domain.to_s.strip.downcase
+          self.address = "#{local_part}@#{domain}"
+        end
+
+        def validate_directory
+          registered = receiving_domain
+          unless registered && registered.domain == domain && registered.tenant_key == tenant_key
+            errors.add(:receiving_domain_id, "must match this tenant and domain")
+            return
+          end
+          if new_record? && registered.state != "active"
+            errors.add(:receiving_domain_id, "must be active before creating addresses")
+          end
+        end
+      end
+
+      class Message < Cloudflare::Email::ActiveRecord::Base
+        include TenantIdentity
+        self.table_name = "cloudflare_email_mailbox_messages"
+        belongs_to :mailbox, class_name: "Cloudflare::Email::Mailboxes::Mailbox"
+        attr_readonly :mailbox_id, :inbound_email_id, :recipient
+        validates :mailbox, :inbound_email_id, :recipient, presence: true
+        # The unique database index also supports create_or_find_by! retries.
+        validate { validate_parent_tenant(mailbox, :mailbox) }
+        scope :unread, -> { where(read_at: nil) }
+        scope :inbox, -> { where(archived_at: nil) }
+
+        def mark_read!
+          update!(read_at: Time.current)
+        end
+
+        def mark_unread!
+          update!(read_at: nil)
+        end
+
+        def archive!
+          update!(archived_at: Time.current)
+        end
+
+        def unarchive!
+          update!(archived_at: nil)
+        end
+      end
+
+      class OutboundMessage < Cloudflare::Email::ActiveRecord::Base
+        include TenantIdentity
+        self.table_name = "cloudflare_email_mailbox_outbound_messages"
+        belongs_to :mailbox, class_name: "Cloudflare::Email::Mailboxes::Mailbox"
+        belongs_to :outbound_delivery, class_name: "Cloudflare::Email::ActiveRecord::OutboundDelivery"
+        attr_readonly :mailbox_id, :outbound_delivery_id
+        validates :mailbox, :outbound_delivery, presence: true
+        # Enforce uniqueness in the database so idempotent link creation works.
+        validate { validate_parent_tenant(mailbox, :mailbox) }
+      end
+    end
+  end
+end

--- a/lib/cloudflare/email/mailboxes/provider_correlation.rb
+++ b/lib/cloudflare/email/mailboxes/provider_correlation.rb
@@ -1,0 +1,11 @@
+module Cloudflare
+  module Email
+    module Mailboxes
+      # Shared routing evidence, never inferred from a sender or event domain.
+      class ProviderCorrelation < Mailboxes.directory_base
+        self.table_name = "cloudflare_email_provider_correlations"
+        attr_readonly :account_id, :message_id, :recipient, :tenant_key, :outbound_delivery_id
+      end
+    end
+  end
+end

--- a/lib/cloudflare/email/mailboxes/service.rb
+++ b/lib/cloudflare/email/mailboxes/service.rb
@@ -1,0 +1,288 @@
+require "digest"
+require "cloudflare/email/envelope"
+
+module Cloudflare
+  module Email
+    module Mailboxes
+      class << self
+        # Call after host authorization. The directory is a control-plane API,
+        # not a public endpoint accepting arbitrary customer domain claims.
+        def register_domain(domain:, tenant_key:, account_id:)
+          Tenancy.normalize_key(tenant_key)
+          ReceivingDomain.create!(domain: domain, tenant_key: tenant_key, account_id: account_id)
+        end
+
+        def activate_domain!(id, evidence:, sending_enabled: false)
+          raise ArgumentError, "verification evidence is required" if evidence.to_s.strip.empty?
+          domain = ReceivingDomain.find(id)
+          domain.update!(state: "active", provisioning_evidence: evidence,
+            verified_at: Time.now.utc, sending_enabled: sending_enabled)
+          domain
+        end
+
+        def for_tenant(key)
+          raise ArgumentError, "a block is required" unless block_given?
+          Tenancy.with(key) { yield Session.new(key) }
+        end
+
+        # Only call after verifying the complete ingress HMAC. Resolve before
+        # ActionMailbox or ActiveStorage accesses a tenant connection.
+        def receive(recipient:)
+          raise ArgumentError, "persistence block required" unless block_given?
+          address = canonical_address(recipient)
+          directory = ReceivingDomain.find_by(domain: address.split("@", 2).last, state: "active")
+          raise Unavailable, "receiving domain unavailable" unless directory
+          for_tenant(directory.tenant_key) do |session|
+            session.receive(address, directory) { yield }
+          end
+        rescue ::ActiveRecord::RecordNotFound
+          raise Unavailable, "mailbox address unavailable"
+        end
+
+        def canonical_address(value)
+          unless Envelope.valid_address?(value)
+            raise ValidationError, "mailbox address must be an ASCII dot-atom address"
+          end
+          value.downcase
+        end
+      end
+
+      class Session
+        attr_reader :tenant_key
+
+        def initialize(tenant_key)
+          @tenant_key = tenant_key
+        end
+
+        def mailboxes
+          context!
+          Mailbox.where(tenant_key: tenant_key)
+        end
+
+        def create(name:, address:, owner_ref: nil)
+          context!
+          Mailbox.transaction do
+            mailbox = Mailbox.create!(tenant_key: tenant_key, name: name, owner_ref: owner_ref)
+            add_address(mailbox.id, address: address)
+            mailbox
+          end
+        end
+
+        def add_address(mailbox_id, address:)
+          mailbox = active_mailbox!(mailbox_id)
+          canonical = Mailboxes.canonical_address(address)
+          local, domain = canonical.split("@", 2)
+          directory = ReceivingDomain.find_by!(domain: domain, tenant_key: tenant_key, state: "active")
+          Address.create!(tenant_key: tenant_key, mailbox_id: mailbox.id,
+            receiving_domain_id: directory.id, local_part: local, domain: domain,
+            address: canonical, state: "pending")
+        end
+
+        def activate_address!(address_id, evidence:)
+          context!
+          raise ArgumentError, "route verification evidence is required" if evidence.to_s.strip.empty?
+          address = Address.where(tenant_key: tenant_key).find(address_id)
+          active_mailbox!(address.mailbox_id)
+          active_domain!(address)
+          address.update!(state: "active", provisioning_evidence: evidence)
+          address
+        end
+
+        def provision_address!(address_id, provisioner:, worker_name:)
+          context!
+          raise ArgumentError, "provision outside a database transaction" if Address.connection.transaction_open?
+          address = Address.where(tenant_key: tenant_key).find(address_id)
+          active_mailbox!(address.mailbox_id)
+          active_domain!(address)
+          provisioner.provision(address: address.address, worker_name: worker_name)
+          # Failed requests leave the address pending; the existing provisioner
+          # upserts a rule, making a deliberate retry safe.
+          activate_address!(address.id, evidence: "Cloudflare address rule provisioned for Worker #{worker_name}")
+        end
+
+        def suspend(mailbox_id)
+          mailboxes.find(mailbox_id).tap { |mailbox| mailbox.update!(state: "suspended") }
+        end
+
+        def resume(mailbox_id)
+          mailboxes.find(mailbox_id).tap { |mailbox| mailbox.update!(state: "active") }
+        end
+
+        def messages(mailbox_id)
+          mailbox = mailboxes.find(mailbox_id)
+          Message.where(tenant_key: tenant_key, mailbox_id: mailbox.id)
+        end
+
+        def addresses(mailbox_id)
+          mailbox = mailboxes.find(mailbox_id)
+          Address.where(tenant_key: tenant_key, mailbox_id: mailbox.id)
+        end
+
+        def suspend_address(mailbox_id, address_id)
+          addresses(mailbox_id).find(address_id).tap { |address| address.update!(state: "suspended") }
+        end
+
+        def outbound_messages(mailbox_id)
+          mailbox = mailboxes.find(mailbox_id)
+          OutboundMessage.where(tenant_key: tenant_key, mailbox_id: mailbox.id)
+        end
+
+        def inbound_email(mailbox_id, message_id)
+          message = messages(mailbox_id).find(message_id)
+          ensure_storage_connection!
+          ::ActionMailbox::InboundEmail.find(message.inbound_email_id)
+        end
+
+        # Explicit permanent removal. Archive is the reversible default.
+        # Other mailbox memberships retain their shared raw source.
+        def purge_message(mailbox_id, message_id)
+          context!
+          ensure_storage_connection!
+          Message.transaction do
+            message = messages(mailbox_id).find(message_id)
+            inbound_id = message.inbound_email_id
+            message.destroy!
+            unless Message.where(inbound_email_id: inbound_id).exists?
+              ::ActionMailbox::InboundEmail.find_by(id: inbound_id)&.destroy!
+            end
+          end
+        end
+
+        def mark_read(mailbox_id, message_id, read: true)
+          messages(mailbox_id).find(message_id).update!(read_at: read ? Time.now.utc : nil)
+        end
+
+        def archive(mailbox_id, message_id, archived: true)
+          messages(mailbox_id).find(message_id).update!(archived_at: archived ? Time.now.utc : nil)
+        end
+
+        def prepare(mailbox_id, operation_key:, mail:)
+          context!
+          raise ArgumentError, "operation_key is required" unless operation_key.is_a?(String) && !operation_key.strip.empty?
+          mail = mail.message if mail.respond_to?(:message) && !mail.respond_to?(:encoded)
+          raise ValidationError, "mail must be a rendered Mail message" unless mail.respond_to?(:encoded)
+          mailbox = active_mailbox!(mailbox_id)
+          from = Array(mail.from)
+          raise ValidationError, "mail must have one mailbox From address" unless from.length == 1
+          sender = Array(mail.sender)
+          address = authorized_sender!(mailbox, from.first)
+          envelope_from = mail.respond_to?(:smtp_envelope_from) ? mail.smtp_envelope_from : from.first
+          unless Mailboxes.canonical_address(envelope_from) == address.address &&
+              sender.all? { |value| Mailboxes.canonical_address(value) == address.address }
+            raise ValidationError, "MIME and envelope sender must match the mailbox address"
+          end
+          domain = active_domain!(address)
+          raise Unavailable, "domain is not enabled for sending" unless domain.sending_enabled
+          key = "mailbox:#{Digest::SHA256.hexdigest(JSON.generate([tenant_key, mailbox.id, operation_key]))}"
+          Mailbox.transaction do
+            delivery = ActiveRecord::Outbox.prepare_mail(account_id: domain.account_id, operation_key: key, mail: mail)
+            OutboundMessage.create_or_find_by!(tenant_key: tenant_key, mailbox_id: mailbox.id,
+              outbound_delivery_id: delivery.id)
+            delivery
+          end
+        end
+
+        # Enqueue only after the outer transaction commits. No mail or model
+        # GlobalIDs are serialized into this job, just stable identities.
+        def enqueue(mailbox_id, operation_key:)
+          context!
+          raise ArgumentError, "enqueue after database commit" if Mailbox.connection.transaction_open?
+          linked_delivery!(mailbox_id, operation_key)
+          SendJob.perform_later(tenant_key, mailbox_id, operation_key)
+        end
+
+        def deliver(mailbox_id, operation_key:)
+          mailbox = active_mailbox!(mailbox_id)
+          delivery = linked_delivery!(mailbox.id, operation_key)
+          address = authorized_sender!(mailbox, delivery.from_address)
+          domain = active_domain!(address)
+          raise Unavailable, "domain is not enabled for sending" unless domain.sending_enabled && domain.account_id == delivery.account_id
+          ActiveRecord::Outbox.deliver(delivery, client: Mailboxes.client_for(tenant_key, delivery.account_id))
+          handler = Mailboxes.delivery_handler
+          delivery.with_lock { handler.call(delivery) } if handler.respond_to?(:call)
+          Events.register(delivery, tenant_key: tenant_key) if %w[accepted partial].include?(delivery.state) && delivery.provider_message_id
+          delivery
+        end
+
+        def reconcile(mailbox_id, operation_key:, **evidence, &handler)
+          delivery = linked_delivery!(mailbox_id, operation_key)
+          raise ArgumentError, "reconcile outside an outer transaction" if Mailbox.connection.transaction_open?
+          ActiveRecord::Outbox.reconcile(delivery, **evidence, &handler)
+          Events.register(delivery, tenant_key: tenant_key) if %w[accepted partial].include?(delivery.state) && delivery.provider_message_id
+          delivery
+        end
+
+        # A bounded repair pass after an enqueue gap or cross-database commit
+        # gap. Does not automatically resend sending/unknown/rejected rows.
+        def recover(limit: 100, after_id: 0)
+          context!
+          raise ArgumentError, "recover outside a database transaction" if Mailbox.connection.transaction_open?
+          raise ArgumentError, "limit must be 1..1000" unless limit.is_a?(Integer) && (1..1000).cover?(limit)
+          raise ArgumentError, "after_id must be nonnegative" unless after_id.is_a?(Integer) && after_id >= 0
+          links = OutboundMessage.where(tenant_key: tenant_key).where("id > ?", after_id).order(:id).limit(limit).to_a
+          links.each do |link|
+            delivery = ActiveRecord::OutboundDelivery.find(link.outbound_delivery_id)
+            if delivery.state == "prepared"
+              enqueue(link.mailbox_id, operation_key: delivery.operation_key) if mailboxes.find(link.mailbox_id).state == "active"
+            elsif %w[accepted partial].include?(delivery.state)
+              handler = Mailboxes.delivery_handler
+              delivery.with_lock { handler.call(delivery) } if handler.respond_to?(:call)
+              Events.register(delivery, tenant_key: tenant_key) if delivery.provider_message_id
+            end
+          end
+          links.last&.id
+        end
+
+        def receive(address, directory)
+          context!
+          ensure_storage_connection! if defined?(::ActionMailbox::InboundEmail)
+          Mailbox.transaction do
+            destination = Address.where(tenant_key: tenant_key, address: address, receiving_domain_id: directory.id, state: "active").first
+            raise Unavailable, "mailbox address unavailable" unless destination
+            mailbox = active_mailbox!(destination.mailbox_id)
+            active_domain!(destination)
+            inbound = yield
+            Message.create_or_find_by!(tenant_key: tenant_key, mailbox_id: mailbox.id,
+              inbound_email_id: inbound.id) { |row| row.recipient = address } if inbound
+            inbound
+          end
+        end
+
+        private
+
+        def context!
+          raise ConfigurationError, "mailbox session used outside its tenant context" unless Tenancy.require_context! == tenant_key
+        end
+
+        def ensure_storage_connection!
+          unless defined?(::ActionMailbox::InboundEmail) && ::ActionMailbox::InboundEmail.connection_pool == Mailbox.connection_pool &&
+              ::ActiveStorage::Blob.connection_pool == Mailbox.connection_pool
+            raise ConfigurationError, "ActionMailbox, ActiveStorage and mailbox records must share the tenant connection"
+          end
+        end
+
+        def active_mailbox!(id)
+          context!
+          mailboxes.where(state: "active").find(id)
+        end
+
+        def active_domain!(address)
+          ReceivingDomain.find_by!(id: address.receiving_domain_id, domain: address.domain,
+            tenant_key: tenant_key, state: "active")
+        end
+
+        def authorized_sender!(mailbox, address)
+          Address.where(tenant_key: tenant_key, mailbox_id: mailbox.id, state: "active")
+            .find_by!(address: Mailboxes.canonical_address(address))
+        end
+
+        def linked_delivery!(mailbox_id, operation_key)
+          mailbox = mailboxes.find(mailbox_id)
+          delivery = ActiveRecord::OutboundDelivery.find_by!(operation_key: operation_key)
+          OutboundMessage.find_by!(tenant_key: tenant_key, mailbox_id: mailbox.id, outbound_delivery_id: delivery.id)
+          delivery
+        end
+      end
+    end
+  end
+end

--- a/lib/cloudflare/email/mailboxes/shared_event_receipt.rb
+++ b/lib/cloudflare/email/mailboxes/shared_event_receipt.rb
@@ -1,0 +1,14 @@
+module Cloudflare
+  module Email
+    module Mailboxes
+      class SharedEventReceipt < Mailboxes.directory_base
+        self.table_name = "cloudflare_email_shared_event_receipts"
+        attr_readonly :account_id, :event_id, :message_id, :recipient, :payload_json
+
+        def event
+          DeliveryEvent.new(JSON.parse(payload_json))
+        end
+      end
+    end
+  end
+end

--- a/lib/cloudflare/email/tenancy.rb
+++ b/lib/cloudflare/email/tenancy.rb
@@ -1,0 +1,78 @@
+require "cloudflare/email/error"
+
+module Cloudflare
+  module Email
+    # An adapter boundary: the host owns tenant discovery and connection switching.
+    # Configure once, before requiring any optional Active Record models.
+    module Tenancy
+      CONTEXT_KEY = :cloudflare_email_tenant_key
+
+      class << self
+        def configure(base_class:, switch:, current:)
+          raise ConfigurationError, "configure tenancy before loading Cloudflare Email models" if @models_loaded
+          raise ConfigurationError, "tenancy is already configured" if enabled?
+          unless base_class.is_a?(Class) && base_class.respond_to?(:abstract_class?) && base_class.abstract_class?
+            raise ConfigurationError, "base_class must be an abstract Active Record class"
+          end
+          unless switch.respond_to?(:call) && current.respond_to?(:call)
+            raise ConfigurationError, "switch and current must be callable"
+          end
+
+          @base_class, @switch, @current = base_class, switch, current
+          self
+        end
+
+        def enabled?
+          !@switch.nil?
+        end
+
+        def model_base(default)
+          @models_loaded = true
+          @base_class || default
+        end
+
+        def current_key
+          Thread.current[CONTEXT_KEY]
+        end
+
+        # Only trusted host integration code should use this to capture new work.
+        # Model access and persisted job deserialization still require explicit
+        # gem context; the adapter must not invent a default tenant here.
+        def host_current_key
+          return unless enabled?
+          key = @current.call
+          normalize_key(key) unless key.nil?
+        end
+
+        def normalize_key(key)
+          unless key.is_a?(String) && !key.empty? && key == key.strip && !key.match?(/[[:cntrl:]]/)
+            raise ConfigurationError, "tenant key must be a nonempty string without surrounding whitespace or control characters"
+          end
+          key.dup.freeze
+        end
+
+        def require_context!
+          key = current_key
+          raise ConfigurationError, "an explicit Cloudflare Email tenant context is required" unless key
+          if enabled? && @current.call != key
+            raise ConfigurationError, "host database tenant does not match Cloudflare Email tenant context"
+          end
+          key
+        end
+
+        def with(key)
+          key = normalize_key(key)
+          previous = current_key
+          run = proc do
+            Thread.current[CONTEXT_KEY] = key
+            require_context!
+            yield
+          ensure
+            Thread.current[CONTEXT_KEY] = previous
+          end
+          enabled? ? @switch.call(key, &run) : run.call
+        end
+      end
+    end
+  end
+end

--- a/lib/cloudflare/email/tenant_job_context.rb
+++ b/lib/cloudflare/email/tenant_job_context.rb
@@ -1,0 +1,90 @@
+require "cloudflare/email/tenancy"
+
+module Cloudflare
+  module Email
+    # Opt in with `prepend Cloudflare::Email::TenantJobContext` on jobs whose
+    # arguments or work reference tenant records. Queue payloads must be trusted.
+    module TenantJobContext
+      PAYLOAD_KEY = "cloudflare_email_tenant_key".freeze
+
+      def serialize
+        key = cloudflare_email_job_tenant_key
+        return super unless key
+        Tenancy.with(key) do
+          payload = super
+          verify_cloudflare_email_host_tenant!(key, payload["tenant"])
+          payload.merge(PAYLOAD_KEY => key)
+        end
+      end
+
+      def deserialize(job_data)
+        # Bind before super: host job integrations may deserialize model arguments
+        # eagerly. Never infer a missing tenant from the worker's ambient context.
+        if !job_data.key?(PAYLOAD_KEY) && cloudflare_email_optional_job_context?
+          @cloudflare_email_job_tenant_key = nil
+          return super
+        end
+        @cloudflare_email_job_tenant_key = Tenancy.normalize_key(job_data[PAYLOAD_KEY])
+        verify_cloudflare_email_host_tenant!(@cloudflare_email_job_tenant_key, job_data["tenant"])
+        Tenancy.with(@cloudflare_email_job_tenant_key) { super }
+      end
+
+      def perform_now
+        # Active Job resolves GlobalIDs before around_perform, so that callback
+        # cannot safely implement database tenant selection.
+        key = cloudflare_email_job_tenant_key
+        return super unless key
+        if defined?(::ActiveRecord::Tenanted::Job) && respond_to?(:tenant)
+          verify_cloudflare_email_host_tenant!(key, tenant)
+        end
+        Tenancy.with(key) { super }
+      end
+
+      def self.install_framework_jobs!
+        if defined?(::ActionMailbox)
+          %i[RoutingJob IncinerationJob].each do |name|
+            next unless ::ActionMailbox.const_defined?(name)
+            klass = ::ActionMailbox.const_get(name)
+            klass.define_singleton_method(:cloudflare_email_optional_job_context?) { !Tenancy.enabled? }
+            klass.prepend(self) unless klass.ancestors.include?(self)
+          end
+        end
+        if defined?(::ActiveStorage)
+          %i[BaseJob AnalyzeJob PurgeJob MirrorJob TransformJob PreviewImageJob].each do |name|
+            next unless ::ActiveStorage.const_defined?(name)
+            klass = ::ActiveStorage.const_get(name)
+            klass.define_singleton_method(:cloudflare_email_optional_job_context?) { !Tenancy.enabled? }
+            klass.prepend(self) unless klass.ancestors.include?(self)
+          end
+        end
+      end
+
+      private
+
+      def cloudflare_email_job_tenant_key
+        # Once serialized/deserialized, retries retain their original tenant even
+        # if re-enqueued from a different tenant or outside a tenant context.
+        return @cloudflare_email_job_tenant_key if instance_variable_defined?(:@cloudflare_email_job_tenant_key)
+        return nil if cloudflare_email_optional_job_context? && !Tenancy.current_key
+        # Native uploads/mailbox work may originate in the host's own with_tenant
+        # block. Framework jobs can capture that trusted context on first use.
+        # deserialize never takes this path for missing persisted metadata.
+        if !Tenancy.current_key && self.class.respond_to?(:cloudflare_email_optional_job_context?)
+          key = Tenancy.host_current_key
+          return @cloudflare_email_job_tenant_key = key if key
+        end
+        @cloudflare_email_job_tenant_key = Tenancy.require_context!
+      end
+
+      def cloudflare_email_optional_job_context?
+        self.class.respond_to?(:cloudflare_email_optional_job_context?) && self.class.cloudflare_email_optional_job_context?
+      end
+
+      def verify_cloudflare_email_host_tenant!(key, host_key)
+        if host_key && host_key != key
+          raise ConfigurationError, "job host tenant conflicts with Cloudflare Email tenant context"
+        end
+      end
+    end
+  end
+end

--- a/lib/generators/cloudflare/email/mailboxes/mailboxes_generator.rb
+++ b/lib/generators/cloudflare/email/mailboxes/mailboxes_generator.rb
@@ -1,0 +1,55 @@
+require "rails/generators"
+require "rails/generators/active_record"
+require "generators/cloudflare/email/outbox/outbox_generator"
+require "generators/cloudflare/email/tracking/tracking_generator"
+
+module Cloudflare
+  module Email
+    module Generators
+      class MailboxesGenerator < ::Rails::Generators::Base
+        include ::ActiveRecord::Generators::Migration
+        namespace "cloudflare:email:mailboxes"
+        source_root File.expand_path("templates", __dir__)
+        class_option :tenant_migrations_path, type: :string, default: "db/migrate",
+          desc: "Migration directory applied to every tenant database"
+        class_option :directory_migrations_path, type: :string, default: "db/migrate",
+          desc: "Migration directory applied only to the shared directory database"
+
+        def copy_migrations
+          invoke "cloudflare:email:outbox", [], migrations_path: options[:tenant_migrations_path]
+          invoke "cloudflare:email:tracking", [], migrations_path: options[:tenant_migrations_path]
+          migration_template "create_cloudflare_email_receiving_domains.rb",
+            File.join(options[:directory_migrations_path], "create_cloudflare_email_receiving_domains.rb")
+          migration_template "create_cloudflare_email_shared_events.rb",
+            File.join(options[:directory_migrations_path], "create_cloudflare_email_shared_events.rb")
+          migration_template "create_cloudflare_email_mailboxes.rb",
+            File.join(options[:tenant_migrations_path], "create_cloudflare_email_mailboxes.rb")
+        end
+
+        def create_initializer
+          create_file "config/initializers/00_cloudflare_email_tenancy.rb", <<~RUBY
+            # Single database: no configuration is necessary.
+            # Separate tenant databases: configure BEFORE the optional models load.
+            # Replace these application-specific adapter names with your own:
+            # require "cloudflare/email/tenancy"
+            # Cloudflare::Email::Tenancy.configure(
+            #   base_class: TenantRecord,
+            #   switch: ->(key, &block) { TenantRecord.with_tenant(key, &block) },
+            #   current: -> { TenantRecord.current_tenant }
+            # )
+            # require "cloudflare/email/mailboxes/configuration"
+            # Cloudflare::Email::Mailboxes.configure(directory_base: SharedRecord)
+            # ActionMailbox and ActiveStorage must use this same tenant connection.
+            # See docs/mailboxes.md for the complete application setup.
+          RUBY
+          create_file "config/initializers/cloudflare_email_mailboxes.rb", <<~RUBY
+            # Optional mailbox persistence. Run the generated migrations first.
+            # For database tenancy, configure Tenancy and the shared directory
+            # base before requiring cloudflare/email/mailboxes. See docs/mailboxes.md.
+            require "cloudflare/email/mailboxes"
+          RUBY
+        end
+      end
+    end
+  end
+end

--- a/lib/generators/cloudflare/email/mailboxes/templates/create_cloudflare_email_mailboxes.rb
+++ b/lib/generators/cloudflare/email/mailboxes/templates/create_cloudflare_email_mailboxes.rb
@@ -1,0 +1,54 @@
+class CreateCloudflareEmailMailboxes < ActiveRecord::Migration[7.1]
+  def up
+    create_table :cloudflare_email_mailboxes do |t|
+      t.string :tenant_key, null: false
+      t.string :name, null: false
+      t.string :owner_ref
+      t.string :state, null: false, default: "active"
+      t.timestamps
+    end
+    add_index :cloudflare_email_mailboxes, [:tenant_key, :owner_ref], name: "idx_cf_email_mailbox_owner"
+
+    create_table :cloudflare_email_addresses do |t|
+      t.string :tenant_key, null: false
+      t.references :mailbox, null: false, index: false, foreign_key: { to_table: :cloudflare_email_mailboxes }
+      # The domain directory can live in another database: no cross-database FK.
+      t.bigint :receiving_domain_id, null: false
+      t.string :local_part, null: false
+      t.string :domain, null: false
+      t.string :address, null: false
+      t.string :state, null: false, default: "pending"
+      t.text :provisioning_evidence
+      t.timestamps
+    end
+    add_index :cloudflare_email_addresses, :address, unique: true, name: "idx_cf_email_mailbox_address"
+    add_index :cloudflare_email_addresses, :mailbox_id, name: "idx_cf_email_address_mailbox"
+
+    create_table :cloudflare_email_mailbox_messages do |t|
+      t.string :tenant_key, null: false
+      t.references :mailbox, null: false, index: false, foreign_key: { to_table: :cloudflare_email_mailboxes }
+      # No database FK to the optional Rails table; the ingress service requires
+      # the same connection and manages membership+raw source atomically.
+      t.bigint :inbound_email_id, null: false
+      t.string :recipient, null: false
+      t.datetime :read_at
+      t.datetime :archived_at
+      t.timestamps
+    end
+    add_index :cloudflare_email_mailbox_messages, [:mailbox_id, :inbound_email_id], unique: true, name: "idx_cf_email_mailbox_inbound"
+    add_index :cloudflare_email_mailbox_messages, [:tenant_key, :mailbox_id, :archived_at, :id], name: "idx_cf_email_mailbox_inbox"
+
+    create_table :cloudflare_email_mailbox_outbound_messages do |t|
+      t.string :tenant_key, null: false
+      t.references :mailbox, null: false, index: false, foreign_key: { to_table: :cloudflare_email_mailboxes }
+      t.references :outbound_delivery, null: false, index: false, foreign_key: { to_table: :cloudflare_email_outbound_deliveries }
+      t.timestamps
+    end
+    add_index :cloudflare_email_mailbox_outbound_messages, :outbound_delivery_id, unique: true, name: "idx_cf_email_mailbox_outbound"
+    add_index :cloudflare_email_mailbox_outbound_messages, :mailbox_id, name: "idx_cf_email_outbound_mailbox"
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration, "Preserve mailbox ownership and retained messages; use a forward fix"
+  end
+end

--- a/lib/generators/cloudflare/email/mailboxes/templates/create_cloudflare_email_receiving_domains.rb
+++ b/lib/generators/cloudflare/email/mailboxes/templates/create_cloudflare_email_receiving_domains.rb
@@ -1,0 +1,16 @@
+class CreateCloudflareEmailReceivingDomains < ActiveRecord::Migration[7.1]
+  def change
+    create_table :cloudflare_email_receiving_domains do |t|
+      t.string :domain, null: false
+      t.string :tenant_key, null: false
+      t.string :account_id, null: false
+      t.string :state, null: false, default: "pending"
+      t.boolean :sending_enabled, null: false, default: false
+      t.text :provisioning_evidence
+      t.datetime :verified_at
+      t.timestamps
+    end
+    add_index :cloudflare_email_receiving_domains, :domain, unique: true, name: "idx_cf_email_directory_domain"
+    add_index :cloudflare_email_receiving_domains, [:tenant_key, :state], name: "idx_cf_email_directory_tenant"
+  end
+end

--- a/lib/generators/cloudflare/email/mailboxes/templates/create_cloudflare_email_shared_events.rb
+++ b/lib/generators/cloudflare/email/mailboxes/templates/create_cloudflare_email_shared_events.rb
@@ -1,0 +1,35 @@
+class CreateCloudflareEmailSharedEvents < ActiveRecord::Migration[7.2]
+  def up
+    create_table :cloudflare_email_shared_event_receipts do |t|
+      t.string :account_id, null: false
+      t.string :event_id, null: false
+      t.string :message_id, null: false
+      t.string :recipient, null: false
+      t.text :payload_json, null: false
+      t.string :state, null: false, default: "pending"
+      t.datetime :applied_at
+      t.timestamps
+    end
+    add_index :cloudflare_email_shared_event_receipts, [:account_id, :event_id], unique: true,
+      name: "idx_cf_shared_events_identity"
+    add_index :cloudflare_email_shared_event_receipts, [:state, :id], name: "idx_cf_shared_events_replay"
+
+    create_table :cloudflare_email_provider_correlations do |t|
+      t.string :account_id, null: false
+      t.string :message_id, null: false
+      t.string :recipient, null: false
+      t.string :tenant_key, null: false
+      t.bigint :outbound_delivery_id, null: false
+      t.timestamps
+    end
+    add_index :cloudflare_email_provider_correlations,
+      [:account_id, :message_id, :recipient, :tenant_key, :outbound_delivery_id], unique: true,
+      name: "idx_cf_provider_correlations_identity"
+    add_index :cloudflare_email_provider_correlations, [:account_id, :message_id, :recipient],
+      name: "idx_cf_provider_correlations_lookup"
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration, "Preserve tenant routing and event deduplication evidence; use a forward fix"
+  end
+end

--- a/lib/generators/cloudflare/email/outbox/outbox_generator.rb
+++ b/lib/generators/cloudflare/email/outbox/outbox_generator.rb
@@ -8,9 +8,10 @@ module Cloudflare
         include ::ActiveRecord::Generators::Migration
         namespace "cloudflare:email:outbox"
         source_root File.expand_path("templates", __dir__)
+        class_option :migrations_path, type: :string, default: "db/migrate"
 
         def copy_outbox_migration
-          migration_template "create_cloudflare_email_outbox.rb", "db/migrate/create_cloudflare_email_outbox.rb"
+          migration_template "create_cloudflare_email_outbox.rb", File.join(options[:migrations_path], "create_cloudflare_email_outbox.rb")
         end
 
         def create_initializer

--- a/lib/generators/cloudflare/email/tracking/tracking_generator.rb
+++ b/lib/generators/cloudflare/email/tracking/tracking_generator.rb
@@ -8,9 +8,10 @@ module Cloudflare
         include ::ActiveRecord::Generators::Migration
         namespace "cloudflare:email:tracking"
         source_root File.expand_path("templates", __dir__)
+        class_option :migrations_path, type: :string, default: "db/migrate"
 
         def copy_tracking_migration
-          migration_template "create_cloudflare_email_event_receipts.rb", "db/migrate/create_cloudflare_email_event_receipts.rb"
+          migration_template "create_cloudflare_email_event_receipts.rb", File.join(options[:migrations_path], "create_cloudflare_email_event_receipts.rb")
         end
 
         def create_initializer

--- a/script/verify_package.rb
+++ b/script/verify_package.rb
@@ -62,4 +62,7 @@ Dir.mktmpdir("cloudflare-email-package-") do |temporary|
   run!({ "CLOUDFLARE_EMAIL_TEST_GEM_ROOT" => extracted }, RbConfig.ruby,
        File.join(root, "test/support/outbound_integration.rb"), chdir: root)
   puts "PASS: packaged outbound snapshots, jobs, and delivery-event projection"
+  run!({ "CLOUDFLARE_EMAIL_TEST_GEM_ROOT" => extracted }, RbConfig.ruby,
+       File.join(root, "test/support/mailbox_ingress.rb"), chdir: root)
+  puts "PASS: packaged tenant mailbox ingress, routing jobs, retention, and migrations"
 end

--- a/test/mailbox_events_test.rb
+++ b/test/mailbox_events_test.rb
@@ -1,0 +1,10 @@
+require "test_helper"
+require "open3"
+require "rbconfig"
+
+class MailboxEventsSubprocessTest < Minitest::Test
+  def test_shared_intake_and_two_sqlite_tenant_projection
+    output, status = Open3.capture2e(RbConfig.ruby, File.expand_path("support/mailbox_events.rb", __dir__))
+    assert status.success?, output
+  end
+end

--- a/test/mailbox_ingress_test.rb
+++ b/test/mailbox_ingress_test.rb
@@ -1,0 +1,10 @@
+require "test_helper"
+require "open3"
+require "rbconfig"
+
+class MailboxIngressTest < Minitest::Test
+  def test_real_rails_tenant_ingress_and_routing_jobs
+    output, status = Open3.capture2e(RbConfig.ruby, "-Ilib", File.expand_path("support/mailbox_ingress.rb", __dir__))
+    assert status.success?, output
+  end
+end

--- a/test/mailbox_models_test.rb
+++ b/test/mailbox_models_test.rb
@@ -1,0 +1,15 @@
+require "test_helper"
+require "open3"
+require "rbconfig"
+
+class MailboxModelsTest < Minitest::Test
+  def test_fresh_mailbox_generator_installation
+    output, status = Open3.capture2e(RbConfig.ruby, File.expand_path("support/mailbox_generator.rb", __dir__))
+    assert status.success?, output
+  end
+
+  def test_optional_mailbox_models
+    output, status = Open3.capture2e(RbConfig.ruby, File.expand_path("support/mailbox_models.rb", __dir__))
+    assert status.success?, output
+  end
+end

--- a/test/mailbox_service_test.rb
+++ b/test/mailbox_service_test.rb
@@ -1,0 +1,10 @@
+require "test_helper"
+require "open3"
+require "rbconfig"
+
+class MailboxServiceTest < Minitest::Test
+  def test_real_sqlite_tenant_mailbox_services
+    output, status = Open3.capture2e(RbConfig.ruby, File.expand_path("support/mailbox_service.rb", __dir__))
+    assert status.success?, output
+  end
+end

--- a/test/support/activerecord_tenanted.rb
+++ b/test/support/activerecord_tenanted.rb
@@ -1,0 +1,127 @@
+ENV["RAILS_ENV"] = "test"
+require "tmpdir"
+require "fileutils"
+require "yaml"
+require "minitest/autorun"
+require "rails/all"
+require "activerecord-tenanted"
+
+TENANTED_ROOT = Dir.mktmpdir("cf-actual-tenanted")
+GEM_SOURCE = File.expand_path("../..", __dir__)
+$LOAD_PATH.unshift File.join(GEM_SOURCE, "lib")
+require "cloudflare-email"
+require "cloudflare/email/tenancy"
+require "cloudflare/email/mailboxes/configuration"
+Minitest.after_run { FileUtils.remove_entry(TENANTED_ROOT) }
+FileUtils.mkdir_p(File.join(TENANTED_ROOT, "config"))
+FileUtils.mkdir_p(File.join(TENANTED_ROOT, "db/tenant_migrate"))
+File.write(File.join(TENANTED_ROOT, "config/database.yml"), {
+  "test" => {
+    "primary" => { "adapter" => "sqlite3", "database" => File.join(TENANTED_ROOT, "directory.sqlite3") },
+    "tenant" => { "adapter" => "sqlite3", "database" => File.join(TENANTED_ROOT, "tenants/%{tenant}/db.sqlite3"),
+      "tenanted" => true, "migrations_paths" => File.join(TENANTED_ROOT, "db/tenant_migrate") }
+  }
+}.to_yaml)
+%w[outbox/templates/create_cloudflare_email_outbox.rb tracking/templates/create_cloudflare_email_event_receipts.rb mailboxes/templates/create_cloudflare_email_mailboxes.rb].each_with_index do |source, index|
+  FileUtils.cp(File.join(GEM_SOURCE, "lib/generators/cloudflare/email", source),
+    File.join(TENANTED_ROOT, "db/tenant_migrate", "2026091200000#{index}_#{File.basename(source)}"))
+end
+
+class ActualTenantedApp < Rails::Application
+  config.root = TENANTED_ROOT
+  config.eager_load = false
+  config.secret_key_base = "x" * 64
+  config.logger = Logger.new(File::NULL)
+  config.active_record_tenanted.connection_class = "TenantRecord"
+  config.active_record_tenanted.tenanted_rails_records = false
+  config.active_record_tenanted.log_tenant_tag = false
+  config.active_job.queue_adapter = :test
+  config.active_storage.service = :test
+  config.active_storage.service_configurations = { "test" => { "service" => "Disk", "root" => File.join(TENANTED_ROOT, "storage") } }
+  initializer "cloudflare_test.configure_tenant_models",
+      after: "active_record_tenanted.active_record_base", before: :load_config_initializers do
+    # Non-autoloaded bases: the optional gem retains these class identities.
+    Object.const_set(:TenantRecord, Class.new(ActiveRecord::Base) do
+      self.abstract_class = true
+    end)
+    TenantRecord.tenanted "tenant"
+    Object.const_set(:DirectoryRecord, Class.new(ActiveRecord::Base) do
+      self.abstract_class = true
+    end)
+    DirectoryRecord.connects_to database: { writing: :primary }
+    Cloudflare::Email::Tenancy.configure(base_class: TenantRecord,
+      current: -> { TenantRecord.current_tenant },
+      switch: ->(key, &block) {
+        raise Cloudflare::Email::Mailboxes::Unavailable, "tenant is not provisioned" unless TenantRecord.tenant_exist?(key)
+        TenantRecord.with_tenant(key, &block)
+      })
+    Cloudflare::Email::Mailboxes.configure(directory_base: DirectoryRecord)
+    require "cloudflare/email/mailboxes"
+  end
+end
+ActualTenantedApp.initialize!
+ActiveRecord::Migration.verbose = false
+require "generators/cloudflare/email/mailboxes/templates/create_cloudflare_email_receiving_domains"
+require "generators/cloudflare/email/mailboxes/templates/create_cloudflare_email_shared_events"
+CreateCloudflareEmailReceivingDomains.new.migrate(:up)
+CreateCloudflareEmailSharedEvents.new.migrate(:up)
+%w[alpha beta].each { |key| TenantRecord.create_tenant(key) }
+
+class ActualTenantedMailboxTest < Minitest::Test
+  Mailboxes = Cloudflare::Email::Mailboxes
+  Tenancy = Cloudflare::Email::Tenancy
+
+  def setup
+    Mailboxes::ReceivingDomain.delete_all
+    %w[alpha beta].each do |key|
+      Mailboxes::ReceivingDomain.create!(domain: "#{key}.example.com", tenant_key: key, account_id: "account", state: "active")
+      Tenancy.with(key) { Mailboxes::Mailbox.delete_all }
+    end
+  end
+
+  def test_actual_library_isolates_same_numeric_ids_and_restores_context
+    records = %w[alpha beta].map do |key|
+      Tenancy.with(key) do
+        mailbox = Mailboxes::Mailbox.create!(name: key, tenant_key: key, state: "active")
+        assert_equal key, mailbox.tenant
+        assert_equal key, TenantRecord.current_tenant
+        assert_equal [key], Mailboxes::Mailbox.pluck(:name)
+        mailbox
+      end
+    end
+    assert_equal records[0].id, records[1].id
+    assert_nil TenantRecord.current_tenant
+    assert_nil Tenancy.current_key
+    Tenancy.with("beta") do
+      assert_raises(Cloudflare::Email::ConfigurationError) { records[0].reload }
+    end
+    assert_raises(Cloudflare::Email::ConfigurationError) { Mailboxes::Mailbox.count }
+    assert_raises(RuntimeError) { Tenancy.with("alpha") { raise "callback failed" } }
+    assert_nil TenantRecord.current_tenant
+    assert_nil Tenancy.current_key
+  end
+
+  def test_unknown_tenant_does_not_create_database
+    refute TenantRecord.tenant_exist?("unknown")
+    assert_raises(Mailboxes::Unavailable) { Tenancy.with("unknown") { Mailboxes::Mailbox.count } }
+    refute File.exist?(File.join(TENANTED_ROOT, "tenants/unknown/db.sqlite3"))
+    assert_nil TenantRecord.current_tenant
+  end
+
+  def test_global_id_requires_matching_explicit_tenant_context
+    gid = Tenancy.with("alpha") do
+      record = Mailboxes::Mailbox.create!(name: "GlobalID", tenant_key: "alpha", state: "active")
+      record.to_global_id
+    end
+    assert_equal "alpha", gid.tenant
+    assert_raises(ActiveRecord::Tenanted::NoTenantError) { GlobalID::Locator.locate(gid) }
+    Tenancy.with("beta") do
+      assert_raises(ActiveRecord::Tenanted::WrongTenantError) { GlobalID::Locator.locate(gid) }
+    end
+    Tenancy.with("alpha") do
+      assert_equal "GlobalID", GlobalID::Locator.locate(gid).name
+      without_tenant = gid.to_s.split("?", 2).first
+      assert_raises(ActiveRecord::Tenanted::MissingTenantError) { GlobalID::Locator.locate(without_tenant) }
+    end
+  end
+end

--- a/test/support/default_tenant_jobs.rb
+++ b/test/support/default_tenant_jobs.rb
@@ -1,0 +1,43 @@
+require_relative "../test_helper"
+require "active_job"
+require "cloudflare/email/tenant_job_context"
+
+ActiveJob::Base.logger = Logger.new(File::NULL)
+
+module ActionMailbox
+  class RoutingJob < ActiveJob::Base
+    def perform
+      Cloudflare::Email::Tenancy.current_key
+    end
+  end
+end
+Cloudflare::Email::TenantJobContext.install_framework_jobs!
+
+class DefaultTenantJobsTest < Minitest::Test
+  Tenancy = Cloudflare::Email::Tenancy
+  PayloadKey = Cloudflare::Email::TenantJobContext::PAYLOAD_KEY
+
+  def test_preserves_unconfigured_framework_job_behavior
+    payload = ActionMailbox::RoutingJob.new.serialize
+    refute payload.key?(PayloadKey)
+    assert_nil ActiveJob::Base.execute(payload)
+  end
+
+  def test_single_database_mailbox_context_is_preserved
+    payload = Tenancy.with("alpha") { ActionMailbox::RoutingJob.new.serialize }
+    assert_equal "alpha", payload.fetch(PayloadKey)
+    Tenancy.with("beta") do
+      assert_equal "alpha", ActiveJob::Base.execute(payload)
+      assert_equal "beta", Tenancy.current_key
+    end
+    assert_nil Tenancy.current_key
+  end
+
+  def test_legacy_payload_is_not_rewritten_with_ambient_tenant_on_retry
+    payload = ActionMailbox::RoutingJob.new.serialize
+    Tenancy.with("beta") do
+      job = ActiveJob::Base.deserialize(payload)
+      refute job.serialize.key?(PayloadKey)
+    end
+  end
+end

--- a/test/support/mailbox_events.rb
+++ b/test/support/mailbox_events.rb
@@ -1,0 +1,197 @@
+require_relative "../test_helper"
+require "active_record"
+require "tmpdir"
+require "fileutils"
+require "cloudflare/email/tenancy"
+require "cloudflare/email/mailboxes/configuration"
+
+EVENT_TENANT_ROOT = Dir.mktmpdir("cf-mailbox-events")
+Minitest.after_run { FileUtils.remove_entry(EVENT_TENANT_ROOT) }
+class EventsDirectoryRecord < ActiveRecord::Base
+  self.abstract_class = true
+end
+class EventsTenantRecord < ActiveRecord::Base
+  self.abstract_class = true
+end
+EventsDirectoryRecord.establish_connection(adapter: "sqlite3", database: File.join(EVENT_TENANT_ROOT, "directory.sqlite3"))
+Cloudflare::Email::Tenancy.configure(base_class: EventsTenantRecord,
+  current: -> { Thread.current[:events_test_tenant] },
+  switch: ->(key, &block) {
+    previous = Thread.current[:events_test_tenant]
+    EventsTenantRecord.establish_connection(adapter: "sqlite3", database: File.join(EVENT_TENANT_ROOT, "#{key}.sqlite3"))
+    Thread.current[:events_test_tenant] = key
+    begin
+      block.call
+    ensure
+      Thread.current[:events_test_tenant] = previous
+      EventsTenantRecord.establish_connection(adapter: "sqlite3", database: File.join(EVENT_TENANT_ROOT, "#{previous}.sqlite3")) if previous
+    end
+  })
+Cloudflare::Email::Mailboxes.configure(directory_base: EventsDirectoryRecord)
+require "cloudflare/email/mailboxes/models"
+require "cloudflare/email/mailboxes/events"
+require "generators/cloudflare/email/mailboxes/templates/create_cloudflare_email_shared_events"
+require "generators/cloudflare/email/outbox/templates/create_cloudflare_email_outbox"
+require "generators/cloudflare/email/tracking/templates/create_cloudflare_email_event_receipts"
+
+ActiveRecord::Migration.verbose = false
+# Migrations use ActiveRecord::Base; point it at each physical database while
+# model connections continue to use their explicitly configured base classes.
+ActiveRecord::Base.establish_connection(EventsDirectoryRecord.connection_db_config.configuration_hash)
+CreateCloudflareEmailSharedEvents.new.migrate(:up)
+ActiveRecord::Schema.define do
+  create_table :cloudflare_email_receiving_domains do |t|
+    t.string :domain
+    t.string :tenant_key
+    t.string :account_id
+    t.string :state
+  end
+end
+%w[alpha beta].each do |key|
+  Cloudflare::Email::Tenancy.with(key) do
+    ActiveRecord::Base.establish_connection(EventsTenantRecord.connection_db_config.configuration_hash)
+    CreateCloudflareEmailOutbox.new.migrate(:up)
+    CreateCloudflareEmailEventReceipts.new.migrate(:up)
+    ActiveRecord::Schema.define do
+      create_table :cloudflare_email_mailbox_outbound_messages do |t|
+        t.string :tenant_key
+        t.bigint :outbound_delivery_id
+        t.bigint :mailbox_id
+      end
+    end
+  end
+end
+
+class TenantMailboxEventsTest < Minitest::Test
+  Email = Cloudflare::Email
+  Events = Email::Mailboxes::Events
+  Receipt = Email::Mailboxes::SharedEventReceipt
+  Correlation = Email::Mailboxes::ProviderCorrelation
+  Tenancy = Email::Tenancy
+  Outbox = Email::ActiveRecord::Outbox
+  Delivery = Email::ActiveRecord::OutboundDelivery
+
+  def setup
+    Receipt.delete_all
+    Correlation.delete_all
+    Email::Mailboxes::ReceivingDomain.delete_all
+    %w[alpha beta].each do |key|
+      Email::Mailboxes::ReceivingDomain.create!(domain: "#{key}.example.com", account_id: "account", tenant_key: key, state: "active")
+      Tenancy.with(key) do
+        Email::Mailboxes::OutboundMessage.delete_all
+        Email::ActiveRecord::EventReceipt.delete_all
+        Email::ActiveRecord::OutboundRecipient.delete_all
+        Delivery.delete_all
+      end
+    end
+  end
+
+  def event(id: "event", message_id: "provider")
+    Email::DeliveryEvent.new("type" => "cf.email.sending.message.delivered",
+      "source" => { "type" => "email.sending", "domain" => "alpha.example.com" },
+      "metadata" => { "accountId" => "account", "eventSchemaVersion" => 1, "eventTimestamp" => "2026-09-11T10:00:00Z" },
+      "payload" => { "eventId" => id, "messageId" => message_id, "recipient" => "reader@example.net", "terminal" => true })
+  end
+
+  def accepted(key, register: true)
+    Tenancy.with(key) do
+      delivery = Outbox.prepare(account_id: "account", operation_key: key,
+        from: "sender@#{key}.example.com", recipients: ["reader@example.net"], mime_message: "Subject: test\r\n\r\nhello")
+      delivery.update!(state: "accepted", provider_message_id: "provider")
+      delivery.outbound_recipients.update_all(state: "accepted", acceptance_state: "accepted")
+      Email::Mailboxes::OutboundMessage.insert_all!([{ tenant_key: key, outbound_delivery_id: delivery.id, mailbox_id: 1 }])
+      Events.register(delivery) if register
+      delivery.id
+    end
+  end
+
+  def test_event_before_registration_is_durable_then_routes_only_to_owner
+    alpha_id = accepted("alpha", register: false)
+    accepted("beta", register: false)
+    receipt = Events.record(event)
+    assert_equal "unmatched", Events.apply(receipt).state
+    assert_equal receipt.id, Events.record(event).id
+    Tenancy.with("alpha") { Events.register(Delivery.find(alpha_id)) }
+    calls = 0
+    Events.replay { calls += 1 }
+    assert_equal "applied", receipt.reload.state
+    Events.apply(receipt) { calls += 1 }
+    assert_equal 1, calls
+    Tenancy.with("alpha") { assert_equal "delivered", Delivery.find(alpha_id).outbound_recipients.first.state }
+    Tenancy.with("beta") { assert_equal "accepted", Delivery.first.outbound_recipients.first.state }
+  end
+
+  def test_cross_tenant_provider_collision_is_retained_without_projection
+    accepted("alpha")
+    accepted("beta")
+    receipt = Events.record(event)
+    assert_equal "unmatched", Events.apply(receipt).state
+    %w[alpha beta].each do |key|
+      Tenancy.with(key) { assert_equal 0, Email::ActiveRecord::EventReceipt.count }
+    end
+  end
+
+  def test_shared_failure_after_tenant_commit_replays_without_duplicate_callback
+    accepted("alpha")
+    receipt = Events.record(event)
+    calls = 0
+    Events.apply(receipt) { calls += 1 }
+    # Model the shared completion write having failed after the tenant commit.
+    receipt.update!(state: "pending", applied_at: nil)
+    Events.apply(receipt) { calls += 1 }
+    assert_equal "applied", receipt.reload.state
+    assert_equal 1, calls
+  end
+
+  def test_failed_tenant_callback_rolls_back_projection_and_can_replay
+    accepted("alpha")
+    receipt = Events.record(event)
+    assert_raises(RuntimeError) { Events.apply(receipt) { raise "application callback failed" } }
+    assert_equal "pending", receipt.reload.state
+    Tenancy.with("alpha") { assert_equal "accepted", Delivery.first.outbound_recipients.first.state }
+    assert_equal "applied", Events.apply(receipt).state
+  end
+
+  def test_payload_conflicts_and_outer_transactions_are_rejected
+    receipt = Events.record(event)
+    assert_raises(Email::ValidationError) { Events.record(event(message_id: "other")) }
+    Receipt.transaction do
+      assert_raises(ArgumentError) { Events.record(event(id: "other")) }
+      assert_raises(ArgumentError) { Events.apply(receipt) }
+    end
+    assert_equal 1, Receipt.count
+    begin
+      receipt.update!(payload_json: JSON.generate(event(message_id: "tampered").raw))
+    rescue ActiveRecord::ReadonlyAttributeError
+      # Supported Rails releases differ in whether readonly assignment raises.
+    end
+    assert_equal "provider", receipt.reload.event.message_id
+  end
+
+  def test_replay_is_bounded_and_cursor_can_advance_past_unmatched
+    3.times { |i| Events.record(event(id: "event#{i}")) }
+    page = Events.replay(limit: 2)
+    assert_equal 2, page.length
+    assert_equal 1, Events.replay(limit: 2, after_id: page.last.id).length
+    assert_raises(ArgumentError) { Events.replay(limit: 1001) }
+  end
+
+  def test_suspended_directory_prevents_projection
+    accepted("alpha")
+    Email::Mailboxes::ReceivingDomain.find_by!(tenant_key: "alpha").update!(state: "suspended")
+    assert_equal "unmatched", Events.apply(Events.record(event)).state
+  end
+
+  def test_registration_requires_current_owner_and_rejects_cross_tenant_instances
+    id = accepted("alpha", register: false)
+    leaked = Tenancy.with("alpha") { Delivery.find(id) }
+    assert_raises(Email::ConfigurationError) { Events.register(leaked) }
+    Tenancy.with("alpha") do
+      assert_raises(Email::ConfigurationError) { Events.register(leaked, tenant_key: "beta") }
+    end
+    Tenancy.with("beta") do
+      assert_raises(Email::ConfigurationError) { Events.register(leaked) }
+    end
+    assert_equal 0, Correlation.count
+  end
+end

--- a/test/support/mailbox_generator.rb
+++ b/test/support/mailbox_generator.rb
@@ -1,0 +1,52 @@
+require "bundler/setup"
+require "minitest/autorun"
+require "active_record"
+require "tmpdir"
+require "generators/cloudflare/email/mailboxes/mailboxes_generator"
+
+class MailboxGeneratorInstallationTest < Minitest::Test
+  Generator = Cloudflare::Email::Generators::MailboxesGenerator
+
+  def test_fresh_single_database_install
+    Dir.mktmpdir do |dir|
+      Generator.start(["--quiet"], destination_root: dir)
+      files = Dir.glob(File.join(dir, "db/migrate/*.rb"))
+      assert_equal 5, files.length
+      assert_equal 5, files.map { |path| File.basename(path).split("_").first }.uniq.length
+      migrate(File.join(dir, "db/migrate"), File.join(dir, "single.sqlite3"))
+      assert ActiveRecord::Base.connection.table_exists?(:cloudflare_email_mailbox_messages)
+      assert ActiveRecord::Base.connection.table_exists?(:cloudflare_email_provider_correlations)
+      assert ActiveRecord::Base.connection.table_exists?(:cloudflare_email_event_receipts)
+      names = Dir.glob(File.join(dir, "config/initializers/*.rb")).sort.map { |path| File.basename(path) }
+      assert_equal "00_cloudflare_email_tenancy.rb", names.first
+      # Ruby source in every generated initializer parses successfully.
+      names.each do |name|
+        RubyVM::InstructionSequence.compile_file(File.join(dir, "config/initializers", name))
+      end
+    end
+  end
+
+  def test_separate_directory_and_tenant_database_install
+    Dir.mktmpdir do |dir|
+      Generator.start(["--quiet", "--tenant-migrations-path=db/tenant_migrate",
+        "--directory-migrations-path=db/directory_migrate"], destination_root: dir)
+      assert_equal 3, Dir.glob(File.join(dir, "db/tenant_migrate/*.rb")).length
+      assert_equal 2, Dir.glob(File.join(dir, "db/directory_migrate/*.rb")).length
+      migrate(File.join(dir, "db/directory_migrate"), File.join(dir, "directory.sqlite3"))
+      assert ActiveRecord::Base.connection.table_exists?(:cloudflare_email_receiving_domains)
+      refute ActiveRecord::Base.connection.table_exists?(:cloudflare_email_mailboxes)
+      migrate(File.join(dir, "db/tenant_migrate"), File.join(dir, "tenant.sqlite3"))
+      assert ActiveRecord::Base.connection.table_exists?(:cloudflare_email_mailboxes)
+      assert ActiveRecord::Base.connection.table_exists?(:cloudflare_email_outbound_deliveries)
+      refute ActiveRecord::Base.connection.table_exists?(:cloudflare_email_receiving_domains)
+    end
+  end
+
+  private
+
+  def migrate(path, database)
+    ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: database)
+    ActiveRecord::Migration.verbose = false
+    ActiveRecord::MigrationContext.new(path).migrate
+  end
+end

--- a/test/support/mailbox_ingress.rb
+++ b/test/support/mailbox_ingress.rb
@@ -1,0 +1,198 @@
+require_relative "../test_helper"
+require "tmpdir"
+require "fileutils"
+require "rails"
+require "active_record/railtie"
+require "action_controller/railtie"
+require "action_mailer/railtie"
+require "active_job/railtie"
+require "active_storage/engine"
+require "action_mailbox/engine"
+require "cloudflare/email/engine"
+require "cloudflare/email/tenancy"
+require "cloudflare/email/mailboxes/configuration"
+require "rack/test"
+
+MAILBOX_INGRESS_ROOT = Dir.mktmpdir("cf-tenant-ingress")
+ENV["RAILS_ENV"] = "test"
+ENV["DATABASE_URL"] = "sqlite3:#{MAILBOX_INGRESS_ROOT}/directory.sqlite3"
+ENV["CLOUDFLARE_INGRESS_SECRET"] = "test-ingress-secret"
+Minitest.after_run do
+  ActiveRecord::Base.connection_handler.clear_all_connections!
+  FileUtils.remove_entry(MAILBOX_INGRESS_ROOT)
+end
+
+class MailboxDirectoryRecord < ActiveRecord::Base
+  self.abstract_class = true
+  establish_connection(adapter: "sqlite3", database: "#{MAILBOX_INGRESS_ROOT}/directory.sqlite3")
+end
+class MailboxTenantRecord < ActiveRecord::Base
+  self.abstract_class = true
+  connects_to shards: %i[alpha beta].to_h { |key|
+    [key, { writing: { adapter: "sqlite3", database: "#{MAILBOX_INGRESS_ROOT}/#{key}.sqlite3" } }]
+  }
+end
+Cloudflare::Email::Tenancy.configure(base_class: MailboxTenantRecord,
+  switch: ->(key, &block) { MailboxTenantRecord.connected_to(role: :writing, shard: key.to_sym, &block) },
+  current: -> { MailboxTenantRecord.current_shard.to_s })
+Cloudflare::Email::Mailboxes.configure(directory_base: MailboxDirectoryRecord)
+require "cloudflare/email/mailboxes"
+require "cloudflare/email/verification"
+
+# This fixture host uses Rails shards for framework records as well as gem
+# records. Production hosts must configure their tenancy adapter equivalently.
+module MailboxFrameworkConnection
+  def connection_pool
+    Cloudflare::Email::Tenancy.require_context!
+    MailboxTenantRecord.connection_pool
+  end
+end
+
+class MailboxIngressApp < Rails::Application
+  config.root = MAILBOX_INGRESS_ROOT
+  config.eager_load = false
+  config.enable_reloading = false
+  config.secret_key_base = "t" * 64
+  config.hosts.clear
+  config.logger = Logger.new(File::NULL)
+  config.action_dispatch.show_exceptions = :none
+  config.active_job.queue_adapter = :test
+  config.action_mailbox.ingress = :cloudflare
+  config.active_storage.service = :local
+  config.active_storage.service_configurations = {
+    local: {service: "Disk", root: "#{MAILBOX_INGRESS_ROOT}/blobs"}
+  }
+  config.to_prepare do
+    ActionMailbox::Record.singleton_class.prepend(MailboxFrameworkConnection)
+    ActiveStorage::Record.singleton_class.prepend(MailboxFrameworkConnection)
+  end
+end
+MailboxIngressApp.initialize!
+
+class ApplicationMailbox < ActionMailbox::Base
+  routing all: :capture
+end
+class CaptureMailbox < ApplicationMailbox
+  class_attribute :captures, default: []
+  def process
+    self.class.captures += [[Cloudflare::Email::Tenancy.require_context!, inbound_email.id,
+      mail.subject, inbound_email.raw_email.download]]
+  end
+end
+
+ActiveRecord::Migration.verbose = false
+%w[activestorage actionmailbox].each do |name|
+  Dir["#{Gem.loaded_specs.fetch(name).full_gem_path}/db/migrate/*.rb"].each { |path| require path }
+end
+%w[outbox/templates/create_cloudflare_email_outbox tracking/templates/create_cloudflare_email_event_receipts
+   mailboxes/templates/create_cloudflare_email_receiving_domains mailboxes/templates/create_cloudflare_email_mailboxes
+   mailboxes/templates/create_cloudflare_email_shared_events].each { |path| require "generators/cloudflare/email/#{path}" }
+CreateCloudflareEmailReceivingDomains.new.migrate(:up)
+CreateCloudflareEmailSharedEvents.new.migrate(:up)
+%w[alpha beta].each do |key|
+  ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: "#{MAILBOX_INGRESS_ROOT}/#{key}.sqlite3")
+  [CreateActiveStorageTables, CreateActionMailboxTables, CreateCloudflareEmailOutbox,
+   CreateCloudflareEmailEventReceipts, CreateCloudflareEmailMailboxes].each { |migration| migration.new.migrate(:up) }
+  directory = Cloudflare::Email::Mailboxes.register_domain(domain: "#{key}.example.com", tenant_key: key, account_id: "account")
+  Cloudflare::Email::Mailboxes.activate_domain!(directory.id, evidence: "isolated test setup")
+  Cloudflare::Email::Mailboxes.for_tenant(key) do |session|
+    box = session.create(name: "Support", address: "support@#{key}.example.com")
+    session.activate_address!(box.addresses.first.id, evidence: "isolated test route")
+    address = session.add_address(box.id, address: "alias@#{key}.example.com")
+    session.activate_address!(address.id, evidence: "isolated test alias")
+  end
+end
+
+class MailboxIngressIntegrationTest < Minitest::Test
+  include Rack::Test::Methods
+  Email = Cloudflare::Email
+  def app = Rails.application
+
+  def setup
+    CaptureMailbox.captures = []
+    ActiveJob::Base.queue_adapter.enqueued_jobs.clear
+    %w[alpha beta].each do |key|
+      Email::Mailboxes.for_tenant(key) do |session|
+        Email::Mailboxes::Message.delete_all
+        ActionMailbox::InboundEmail.destroy_all
+        session.mailboxes.update_all(state: "active")
+      end
+    end
+  end
+
+  def raw
+    "From: sender@example.net\r\nTo: misleading@example.net\r\nSubject: Tenant mail\r\nMessage-ID: <tenant-mail@example.net>\r\n\r\nhello\r\n"
+  end
+
+  def post_mail(recipient, valid: true)
+    envelope = Email::Envelope.encode(from: "sender@example.net", to: recipient)
+    timestamp = Time.now.to_i.to_s
+    signature = Email::Verification.sign(secret: valid ? "test-ingress-secret" : "other",
+      body: raw, timestamp: timestamp, envelope: envelope)
+    post "/rails/action_mailbox/cloudflare/inbound_emails", raw,
+      "CONTENT_TYPE" => "message/rfc822", "HTTP_X_CF_EMAIL_TIMESTAMP" => timestamp,
+      "HTTP_X_CF_EMAIL_SIGNATURE" => signature, "HTTP_X_CF_EMAIL_SIGNATURE_VERSION" => "2",
+      "HTTP_X_CF_EMAIL_ENVELOPE" => envelope
+  end
+
+  def test_signed_envelope_selects_storage_before_jobs_and_preserves_bytes
+    %w[alpha beta].each do |key|
+      post_mail("support@#{key}.example.com")
+      assert_equal 200, last_response.status
+      Email::Mailboxes.for_tenant(key) do
+        assert_equal 1, Email::Mailboxes::Message.count
+        inbound = ActionMailbox::InboundEmail.last
+        assert_equal raw, inbound.raw_email.download
+        assert_equal "support@#{key}.example.com", Email::Envelope.for(inbound).fetch("to")
+      end
+    end
+    assert_nil Email::Tenancy.current_key
+    jobs = ActiveJob::Base.queue_adapter.enqueued_jobs.select { |job| job[:job] == ActionMailbox::RoutingJob }
+    assert_equal 2, jobs.size
+    jobs.reverse_each { |job| ActiveJob::Base.execute(job) }
+    assert_equal %w[beta alpha], CaptureMailbox.captures.map(&:first)
+    assert CaptureMailbox.captures.all? { |capture| capture.last == raw }
+    assert_nil Email::Tenancy.current_key
+  end
+
+  def test_duplicate_and_alias_membership_are_recipient_scoped
+    2.times { post_mail("support@alpha.example.com"); assert_equal 200, last_response.status }
+    post_mail("alias@alpha.example.com")
+    assert_equal 200, last_response.status
+    Email::Mailboxes.for_tenant("alpha") do
+      assert_equal 2, ActionMailbox::InboundEmail.count
+      assert_equal 2, Email::Mailboxes::Message.count
+    end
+    Email::Mailboxes.for_tenant("beta") { assert_equal 0, Email::Mailboxes::Message.count }
+  end
+
+  def test_unknown_suspended_and_unsigned_destinations_store_nothing
+    post_mail("support@unknown.example.com")
+    assert_equal 422, last_response.status
+    post_mail("missing@alpha.example.com")
+    assert_equal 422, last_response.status
+    post_mail("support@alpha.example.com", valid: false)
+    assert_equal 401, last_response.status
+    Email::Mailboxes.for_tenant("alpha") { |session| session.suspend(session.mailboxes.first.id) }
+    post_mail("support@alpha.example.com")
+    assert_equal 422, last_response.status
+    Email::Mailboxes.for_tenant("alpha") { assert_equal 0, ActionMailbox::InboundEmail.count }
+    assert_nil Email::Tenancy.current_key
+  end
+
+  def test_membership_retains_raw_mail_until_explicit_purge
+    post_mail("support@alpha.example.com")
+    assert_equal 200, last_response.status
+    Email::Mailboxes.for_tenant("alpha") do |session|
+      membership = session.messages(session.mailboxes.first.id).first
+      inbound = session.inbound_email(membership.mailbox_id, membership.id)
+      inbound.update!(status: :delivered)
+      inbound.update_columns(updated_at: 1.year.ago)
+      inbound.incinerate
+      assert_equal raw, inbound.reload.raw_email.download
+      session.purge_message(membership.mailbox_id, membership.id)
+      assert_equal 0, ActionMailbox::InboundEmail.count
+      assert_equal 0, Email::Mailboxes::Message.count
+    end
+  end
+end

--- a/test/support/mailbox_models.rb
+++ b/test/support/mailbox_models.rb
@@ -1,0 +1,93 @@
+require "bundler/setup"
+require "minitest/autorun"
+require "active_record"
+require "tmpdir"
+require "cloudflare-email"
+
+module Cloudflare::Email::Mailboxes
+  def self.directory_base
+    ::ActiveRecord::Base
+  end
+end
+require "cloudflare/email/mailboxes/models"
+
+ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
+ActiveRecord::Migration.verbose = false
+templates = File.expand_path("../../lib/generators/cloudflare/email", __dir__)
+require File.join(templates, "outbox/templates/create_cloudflare_email_outbox")
+require File.join(templates, "mailboxes/templates/create_cloudflare_email_receiving_domains")
+require File.join(templates, "mailboxes/templates/create_cloudflare_email_mailboxes")
+CreateCloudflareEmailOutbox.new.migrate(:up)
+CreateCloudflareEmailReceivingDomains.new.migrate(:up)
+CreateCloudflareEmailMailboxes.new.migrate(:up)
+
+class MailboxModelPersistenceTest < Minitest::Test
+  Models = Cloudflare::Email::Mailboxes
+  Tenancy = Cloudflare::Email::Tenancy
+
+  def setup
+    [Models::OutboundMessage, Models::Message, Models::Address, Models::Mailbox, Models::ReceivingDomain].each(&:delete_all)
+    @domain = Models::ReceivingDomain.create!(domain: "CUSTOMER.Example.COM", tenant_key: "one", account_id: "cf", state: "active")
+    @mailbox = Models::Mailbox.create!(tenant_key: "one", name: "Support", owner_ref: "customer:123")
+  end
+
+  def test_directory_normalizes_domain_and_rejects_invalid_or_duplicate_domains
+    assert_equal "customer.example.com", @domain.domain
+    assert_raises(ActiveRecord::RecordInvalid) do
+      Models::ReceivingDomain.create!(domain: "Customer.example.com", tenant_key: "two", account_id: "cf")
+    end
+    %w[localhost bad..example.com -bad.example.com bad_.example.com].each do |domain|
+      record = Models::ReceivingDomain.new(domain: domain, tenant_key: "one", account_id: "cf")
+      refute record.valid?, domain
+    end
+  end
+
+  def test_addresses_normalize_and_require_matching_active_directory
+    record = create_address(local_part: "SUPPORT")
+    assert_equal "support@customer.example.com", record.address
+    assert_equal "pending", record.state
+    assert_raises(ActiveRecord::RecordInvalid) { create_address(local_part: "support") }
+    assert_raises(ActiveRecord::RecordInvalid) { create_address(local_part: "other", tenant_key: "two") }
+    assert_raises(ActiveRecord::RecordInvalid) { create_address(local_part: "bad..part") }
+    @domain.update!(state: "suspended")
+    assert_raises(ActiveRecord::RecordInvalid) { create_address(local_part: "other") }
+  end
+
+  def test_record_identity_and_current_tenant_are_guarded
+    record = create_address
+    record.update!(local_part: "renamed")
+    assert_equal "support", record.reload.local_part
+    assert_equal "support@customer.example.com", record.address
+    Tenancy.with("two") do
+      refute @mailbox.valid?
+      assert_raises(ArgumentError) { @mailbox.destroy! }
+    end
+    Tenancy.with("one") do
+      child = Models::Mailbox.create!(name: "Sales")
+      assert_equal "one", child.tenant_key
+    end
+  end
+
+  def test_message_memberships_are_idempotent_and_have_inbox_state
+    message = Models::Message.create!(tenant_key: "one", mailbox: @mailbox, inbound_email_id: 123, recipient: "support@customer.example.com")
+    assert_equal 1, @mailbox.messages.inbox.unread.count
+    message.mark_read!
+    assert_equal 0, @mailbox.messages.unread.count
+    message.archive!
+    assert_equal 0, @mailbox.messages.inbox.count
+    message.unarchive!
+    message.mark_unread!
+    assert_equal 1, @mailbox.messages.inbox.unread.count
+    assert_raises(ActiveRecord::RecordNotUnique) do
+      Models::Message.create!(tenant_key: "one", mailbox: @mailbox, inbound_email_id: 123, recipient: "alias@customer.example.com")
+    end
+    assert_raises(ActiveRecord::DeleteRestrictionError) { @mailbox.destroy! }
+  end
+
+  private
+
+  def create_address(**overrides)
+    Models::Address.create!({ tenant_key: "one", mailbox: @mailbox, receiving_domain_id: @domain.id,
+      domain: @domain.domain, local_part: "support" }.merge(overrides))
+  end
+end

--- a/test/support/mailbox_service.rb
+++ b/test/support/mailbox_service.rb
@@ -1,0 +1,375 @@
+require_relative "../test_helper"
+require "tmpdir"
+require "fileutils"
+require "active_record"
+require "mail"
+require "minitest/mock"
+require "cloudflare/email/tenancy"
+require "cloudflare/email/mailboxes/configuration"
+
+SERVICE_ROOT = Dir.mktmpdir("cf-mailbox-service")
+Minitest.after_run do
+  ActiveRecord::Base.connection_handler.clear_all_connections!
+  FileUtils.remove_entry(SERVICE_ROOT)
+end
+class ServiceDirectoryRecord < ActiveRecord::Base
+  self.abstract_class = true
+  establish_connection adapter: "sqlite3", database: File.join(SERVICE_ROOT, "directory.sqlite3")
+end
+class ServiceTenantRecord < ActiveRecord::Base
+  self.abstract_class = true
+  connects_to shards: %i[alpha beta].to_h { |key|
+    [key, { writing: { adapter: "sqlite3", database: File.join(SERVICE_ROOT, "#{key}.sqlite3") } }]
+  }
+end
+Cloudflare::Email::Tenancy.configure(base_class: ServiceTenantRecord,
+  switch: ->(key, &block) { ServiceTenantRecord.connected_to(role: :writing, shard: key.to_sym, &block) },
+  current: -> { ServiceTenantRecord.current_shard.to_s })
+SERVICE_CLIENTS = {}
+Cloudflare::Email::Mailboxes.configure(directory_base: ServiceDirectoryRecord,
+  client_resolver: ->(tenant, account) { SERVICE_CLIENTS.fetch(tenant) })
+require "cloudflare/email/mailboxes"
+require "generators/cloudflare/email/mailboxes/templates/create_cloudflare_email_receiving_domains"
+require "generators/cloudflare/email/mailboxes/templates/create_cloudflare_email_shared_events"
+require "generators/cloudflare/email/mailboxes/templates/create_cloudflare_email_mailboxes"
+require "generators/cloudflare/email/outbox/templates/create_cloudflare_email_outbox"
+require "generators/cloudflare/email/tracking/templates/create_cloudflare_email_event_receipts"
+ActiveRecord::Migration.verbose = false
+# Establish Base only during fixture installation; requests use fixed shard pools.
+ActiveRecord::Base.establish_connection(ServiceDirectoryRecord.connection_db_config.configuration_hash)
+CreateCloudflareEmailReceivingDomains.new.migrate(:up)
+CreateCloudflareEmailSharedEvents.new.migrate(:up)
+%w[alpha beta].each do |key|
+  Cloudflare::Email::Tenancy.with(key) do
+    ActiveRecord::Base.establish_connection(ServiceTenantRecord.connection_db_config.configuration_hash)
+    CreateCloudflareEmailOutbox.new.migrate(:up)
+    CreateCloudflareEmailEventReceipts.new.migrate(:up)
+    CreateCloudflareEmailMailboxes.new.migrate(:up)
+  end
+end
+ActiveJob::Base.queue_adapter = :test
+ActiveJob::Base.logger = Logger.new(File::NULL)
+
+class MailboxServiceIntegrationTest < Minitest::Test
+  Email = Cloudflare::Email
+  Box = Email::Mailboxes
+  Delivery = Email::ActiveRecord::OutboundDelivery
+  ENDPOINT = "https://api.cloudflare.com/client/v4/accounts/shared/email/sending/send_raw"
+
+  def setup
+    Box::ProviderCorrelation.delete_all
+    Box::SharedEventReceipt.delete_all
+    Box::ReceivingDomain.delete_all
+    ActiveJob::Base.queue_adapter.enqueued_jobs.clear
+    @ids = {}
+    %w[alpha beta].each do |key|
+      SERVICE_CLIENTS[key] = Email::Client.new(account_id: "shared", api_token: "test-token", retries: 0, retry_ambiguous: false)
+      Box.for_tenant(key) do |session|
+        [Box::OutboundMessage, Box::Message, Box::Address, Box::Mailbox,
+          Email::ActiveRecord::EventReceipt, Email::ActiveRecord::OutboundReconciliation,
+          Email::ActiveRecord::OutboundRecipient, Delivery].each(&:delete_all)
+        ServiceTenantRecord.connection.execute("DELETE FROM sqlite_sequence WHERE name = 'cloudflare_email_mailboxes'")
+        ServiceTenantRecord.connection.execute("INSERT INTO sqlite_sequence(name, seq) VALUES ('cloudflare_email_mailboxes', 41)")
+        domain = Box.register_domain(domain: "#{key}.example.com", tenant_key: key, account_id: "shared")
+        Box.activate_domain!(domain.id, evidence: "operator verified DNS and sending", sending_enabled: true)
+        mailbox = session.create(name: "Support", address: "Support@#{key}.example.com", owner_ref: "customer:42")
+        @ids[key] = mailbox.id
+        session.activate_address!(mailbox.addresses.first.id, evidence: "route verified")
+      end
+    end
+  end
+
+  def mail(key = "alpha", from: nil)
+    Mail.new do
+      from(from || "support@#{key}.example.com")
+      to "reader@example.net"
+      subject "Hello"
+      body "Saved mailbox message"
+      date Time.utc(2026, 9, 11)
+      message_id "fixed-#{key}@example.com"
+    end
+  end
+
+  def provider_success
+    stub_request(:post, ENDPOINT).to_return(status: 200, headers: { "Content-Type" => "application/json" },
+      body: JSON.generate(success: true, result: { message_id: "provider-123" }))
+  end
+
+  def test_directory_and_address_lifecycle_and_owner_reference
+    pending = Box.register_domain(domain: "NEW.Example.com", tenant_key: "alpha", account_id: "shared")
+    assert_equal "pending", pending.state
+    assert_equal "new.example.com", pending.domain
+    assert_raises(ArgumentError) { Box.activate_domain!(pending.id, evidence: " ") }
+    Box.for_tenant("alpha") do |session|
+      assert_equal "customer:42", session.mailboxes.find(42).owner_ref
+      assert_raises(ActiveRecord::RecordNotFound) { session.add_address(42, address: "new@new.example.com") }
+      address = session.add_address(42, address: "ALIAS@alpha.example.com")
+      assert_equal "pending", address.state
+      session.activate_address!(address.id, evidence: "individual route activated")
+      assert_equal "active", address.reload.state
+      session.suspend(42)
+      assert_raises(ActiveRecord::RecordNotFound) { session.add_address(42, address: "other@alpha.example.com") }
+      session.resume(42)
+      assert_equal "active", session.mailboxes.find(42).state
+    end
+  end
+
+  def test_receive_alias_deduplication_and_read_archive
+    Box.for_tenant("alpha") do |session|
+      address = session.add_address(42, address: "alias@alpha.example.com")
+      session.activate_address!(address.id, evidence: "route verified")
+    end
+    inbound = Struct.new(:id).new(100)
+    assert_equal inbound, Box.receive(recipient: "support@alpha.example.com") { inbound }
+    Box.receive(recipient: "alias@alpha.example.com") { inbound }
+    Box.for_tenant("alpha") do |session|
+      assert_equal 1, session.messages(42).count
+      id = session.messages(42).first.id
+      session.mark_read(42, id)
+      session.archive(42, id)
+      assert_equal 0, session.messages(42).inbox.unread.count
+      session.mark_read(42, id, read: false)
+      session.archive(42, id, archived: false)
+      assert_equal 1, session.messages(42).inbox.unread.count
+    end
+    Box.for_tenant("beta") { |session| assert_equal 0, session.messages(42).count }
+    assert_raises(Box::Unavailable) { Box.receive(recipient: "unknown@alpha.example.com") { flunk "stored unknown mail" } }
+  end
+
+  def test_overlapping_ids_and_operation_names_remain_isolated
+    keys = %w[alpha beta].map do |key|
+      Box.for_tenant(key) do |session|
+        delivery = session.prepare(42, operation_key: "same-operation", mail: mail(key))
+        repeated = session.prepare(42, operation_key: "same-operation", mail: mail(key))
+        assert_equal delivery.id, repeated.id
+        assert_equal 1, Box::OutboundMessage.count
+        assert_equal "support@#{key}.example.com", delivery.from_address
+        delivery.operation_key
+      end
+    end
+    refute_equal keys.first, keys.last
+    Box.for_tenant("beta") do |session|
+      assert_raises(ActiveRecord::RecordNotFound) { session.enqueue(42, operation_key: keys.first) }
+    end
+    escaped = Box.for_tenant("alpha") { |session| session }
+    assert_raises(Email::ConfigurationError) { escaped.mailboxes }
+  end
+
+  def test_prepare_requires_owned_active_sender_and_send_enabled_domain
+    Box.for_tenant("alpha") do |session|
+      assert_raises(ActiveRecord::RecordNotFound) { session.prepare(42, operation_key: "foreign", mail: mail("beta")) }
+      spoofed = mail
+      spoofed.sender = "elsewhere@example.net"
+      assert_raises(Email::ValidationError) { session.prepare(42, operation_key: "spoofed", mail: spoofed) }
+      Box::ReceivingDomain.find_by!(tenant_key: "alpha").update!(sending_enabled: false)
+      assert_raises(Box::Unavailable) { session.prepare(42, operation_key: "disabled", mail: mail) }
+      assert_equal 0, Delivery.count
+    end
+  end
+
+  def test_identity_only_job_and_duplicate_execution_send_once
+    request = provider_success
+    job = Box.for_tenant("alpha") do |session|
+      delivery = session.prepare(42, operation_key: "send", mail: mail)
+      session.enqueue(42, operation_key: delivery.operation_key)
+    end
+    serialized = job.serialize
+    assert_equal ["alpha", 42], serialized.fetch("arguments").first(2)
+    assert_equal 3, serialized.fetch("arguments").length
+    2.times { ActiveJob::Base.execute(serialized) }
+    assert_requested request, times: 1
+    assert_equal 1, Box::ProviderCorrelation.count
+    Box.for_tenant("alpha") { assert_equal "accepted", Delivery.first.state }
+    assert_nil Email::Tenancy.current_key
+  end
+
+  def test_suspended_queued_mailbox_and_mismatched_client_do_not_send
+    job = Box.for_tenant("alpha") do |session|
+      delivery = session.prepare(42, operation_key: "send", mail: mail)
+      queued = session.enqueue(42, operation_key: delivery.operation_key)
+      session.suspend(42)
+      queued
+    end
+    assert_raises(ActiveRecord::RecordNotFound) { ActiveJob::Base.execute(job.serialize) }
+    Box.for_tenant("alpha") do |session|
+      session.resume(42)
+      SERVICE_CLIENTS["alpha"] = Email::Client.new(account_id: "wrong", api_token: "token", retries: 0, retry_ambiguous: false)
+      assert_raises(Email::ConfigurationError) { session.deliver(42, operation_key: Delivery.first.operation_key) }
+      assert_equal "prepared", Delivery.first.state
+    end
+    assert_not_requested :post, ENDPOINT
+  end
+
+  def test_ambiguous_network_error_stays_unknown_without_resend
+    request = stub_request(:post, ENDPOINT).to_timeout
+    Box.for_tenant("alpha") do |session|
+      delivery = session.prepare(42, operation_key: "uncertain", mail: mail)
+      assert_raises(Email::NetworkError) { session.deliver(42, operation_key: delivery.operation_key) }
+      assert_equal "unknown", delivery.reload.state
+      assert_raises(Email::ActiveRecord::Outbox::InvalidTransition) { session.deliver(42, operation_key: delivery.operation_key) }
+      session.recover
+      assert_empty ActiveJob::Base.queue_adapter.enqueued_jobs
+    end
+    assert_requested request, times: 1
+  end
+
+  def test_recover_repairs_correlations_and_enqueue_gaps
+    request = provider_success
+    Box.for_tenant("alpha") do |session|
+      first = session.prepare(42, operation_key: "first", mail: mail)
+      session.deliver(42, operation_key: first.operation_key)
+      Box::ProviderCorrelation.delete_all
+      session.prepare(42, operation_key: "second", mail: mail)
+      session.recover
+      assert_equal 1, Box::ProviderCorrelation.count
+      assert_equal 1, ActiveJob::Base.queue_adapter.enqueued_jobs.length
+    end
+    assert_requested request, times: 1
+  end
+
+  def test_failed_provisioning_keeps_alias_pending_and_retry_activates
+    calls = []
+    provisioner = Object.new
+    provisioner.define_singleton_method(:provision) do |**options|
+      calls << options
+      raise "provider unavailable" if calls.length == 1
+    end
+    Box.for_tenant("alpha") do |session|
+      address = session.add_address(42, address: "new@alpha.example.com")
+      assert_raises(RuntimeError) { session.provision_address!(address.id, provisioner: provisioner, worker_name: "mail-worker") }
+      assert_equal "pending", address.reload.state
+      session.provision_address!(address.id, provisioner: provisioner, worker_name: "mail-worker")
+      assert_equal "active", address.reload.state
+      assert_equal({ address: "new@alpha.example.com", worker_name: "mail-worker" }, calls.first)
+    end
+  end
+
+  def test_prepare_is_transactional_and_enqueue_must_follow_commit
+    Box.for_tenant("alpha") do |session|
+      Box::Mailbox.transaction do
+        delivery = session.prepare(42, operation_key: "rolled-back", mail: mail)
+        assert_raises(ArgumentError) { session.enqueue(42, operation_key: delivery.operation_key) }
+        raise ActiveRecord::Rollback
+      end
+      assert_equal 0, Delivery.count
+      assert_equal 0, Box::OutboundMessage.count
+      assert_empty ActiveJob::Base.queue_adapter.enqueued_jobs
+    end
+  end
+
+  def test_explicit_ambiguous_reconciliation_registers_provider_evidence
+    stub_request(:post, ENDPOINT).to_timeout
+    Box.for_tenant("alpha") do |session|
+      delivery = session.prepare(42, operation_key: "reconciled", mail: mail)
+      assert_raises(Email::NetworkError) { session.deliver(42, operation_key: delivery.operation_key) }
+      session.reconcile(42, operation_key: delivery.operation_key, outcome: "accepted",
+        actor: "operator:1", reason: "provider confirmed acceptance", evidence: "support ticket 123",
+        provider_message_id: "confirmed-123", recipients: ["reader@example.net"])
+      assert_equal "accepted", delivery.reload.state
+      assert_equal "confirmed-123", Box::ProviderCorrelation.first.message_id
+    end
+  end
+
+  def test_projection_failure_retries_without_resending_and_rolls_back_projection
+    request = provider_success
+    attempts = 0
+    handler = lambda do |delivery|
+      assert_equal "alpha", Email::Tenancy.require_context!
+      assert delivery.class.connection.transaction_open?
+      Box::Mailbox.find(42).update!(name: "Projected")
+      attempts += 1
+      raise "projection unavailable" if attempts == 1
+    end
+    Box.stub(:delivery_handler, -> { handler }) do
+      Box.for_tenant("alpha") do |session|
+        delivery = session.prepare(42, operation_key: "projection-retry", mail: mail)
+        assert_raises(RuntimeError) { session.deliver(42, operation_key: delivery.operation_key) }
+        assert_equal "accepted", delivery.reload.state
+        assert_equal "Support", session.mailboxes.find(42).name
+        assert_equal 0, Box::ProviderCorrelation.count
+        session.deliver(42, operation_key: delivery.operation_key)
+        assert_equal "Projected", session.mailboxes.find(42).name
+        assert_equal 1, Box::ProviderCorrelation.count
+      end
+    end
+    assert_equal 2, attempts
+    assert_requested request, times: 1
+  end
+
+  def test_competing_send_claims_do_not_duplicate_network_delivery
+    entered, release = Queue.new, Queue.new
+    request = stub_request(:post, ENDPOINT).to_return do
+      entered << true
+      release.pop
+      { status: 200, headers: { "Content-Type" => "application/json" },
+        body: JSON.generate(success: true, result: { message_id: "concurrent-provider" }) }
+    end
+    operation = Box.for_tenant("alpha") { |session| session.prepare(42, operation_key: "concurrent", mail: mail).operation_key }
+    sender = Thread.new do
+      Box.for_tenant("alpha") { |session| session.deliver(42, operation_key: operation) }
+    end
+    entered.pop
+    Box.for_tenant("alpha") do |session|
+      assert_raises(Email::ActiveRecord::Outbox::InvalidTransition) { session.deliver(42, operation_key: operation) }
+    end
+    release << true
+    sender.value
+    assert_requested request, times: 1
+    Box.for_tenant("alpha") { assert_equal "accepted", Delivery.first.state }
+  ensure
+    release << true if release && sender&.alive?
+    sender&.join
+  end
+
+  def test_reconciliation_block_failure_rolls_back_evidence_and_projection
+    stub_request(:post, ENDPOINT).to_timeout
+    Box.for_tenant("alpha") do |session|
+      delivery = session.prepare(42, operation_key: "reconcile-projection", mail: mail)
+      assert_raises(Email::NetworkError) { session.deliver(42, operation_key: delivery.operation_key) }
+      assert_raises(RuntimeError) do
+        session.reconcile(42, operation_key: delivery.operation_key, outcome: "accepted",
+          actor: "operator:1", reason: "provider confirmed", evidence: "ticket",
+          provider_message_id: "confirmed-456", recipients: ["reader@example.net"]) do |row|
+          assert_equal delivery.id, row.id
+          Box::Mailbox.find(42).update!(name: "Projected")
+          raise "projection failed"
+        end
+      end
+      assert_equal "unknown", delivery.reload.state
+      assert_equal "Support", session.mailboxes.find(42).name
+      assert_equal 0, Email::ActiveRecord::OutboundReconciliation.count
+      assert_equal 0, Box::ProviderCorrelation.count
+    end
+  end
+
+  def test_recovery_job_schedules_next_page_and_stops_at_empty_page
+    Box.for_tenant("alpha") { |session| session.prepare(42, operation_key: "recover-page", mail: mail) }
+    Box::RecoverJob.perform_now("alpha")
+    queue = ActiveJob::Base.queue_adapter.enqueued_jobs
+    assert_equal 1, queue.count { |job| job[:job] == Box::SendJob }
+    continuation = queue.find { |job| job[:job] == Box::RecoverJob }
+    refute_nil continuation
+    assert_equal "alpha", continuation[:args].first
+    assert_operator continuation[:args].last, :>, 0
+    count = queue.length
+    Box::RecoverJob.perform_now(*continuation[:args])
+    assert_equal count, queue.length
+  end
+
+  def test_recovery_repairs_a_failed_delivery_projection_without_network_retry
+    request = provider_success
+    failed = ->(_delivery) { raise "projection failed" }
+    Box.for_tenant("alpha") do |session|
+      delivery = session.prepare(42, operation_key: "recover-projection", mail: mail)
+      Box.stub(:delivery_handler, -> { failed }) do
+        assert_raises(RuntimeError) { session.deliver(42, operation_key: delivery.operation_key) }
+      end
+      repaired = ->(_delivery) { Box::Mailbox.find(42).update!(name: "Recovered") }
+      Box.stub(:delivery_handler, -> { repaired }) { session.recover }
+      assert_equal "Recovered", session.mailboxes.find(42).name
+      assert_equal 1, Box::ProviderCorrelation.count
+      assert_empty ActiveJob::Base.queue_adapter.enqueued_jobs
+    end
+    assert_requested request, times: 1
+  end
+end

--- a/test/support/tenancy.rb
+++ b/test/support/tenancy.rb
@@ -1,0 +1,211 @@
+require_relative "../test_helper"
+require "tmpdir"
+require "fileutils"
+require "active_record"
+require "cloudflare/email/tenancy"
+
+TENANT_TEST_ROOT = Dir.mktmpdir("cloudflare-email-tenancy")
+Minitest.after_run do
+  ActiveRecord::Base.connection_handler.clear_all_connections!
+  FileUtils.remove_entry(TENANT_TEST_ROOT)
+end
+
+class TenantRecord < ActiveRecord::Base
+  self.abstract_class = true
+  connects_to shards: %i[alpha beta].to_h { |key|
+    [key, {writing: {adapter: "sqlite3", database: File.join(TENANT_TEST_ROOT, "#{key}.sqlite3")}}]
+  }
+end
+
+Cloudflare::Email::Tenancy.configure(
+  base_class: TenantRecord,
+  switch: ->(key, &block) { TenantRecord.connected_to(role: :writing, shard: key.to_sym, &block) },
+  current: -> { TenantRecord.current_shard.to_s },
+)
+require "cloudflare/email/active_record/event_receipt"
+require "cloudflare/email/active_record/outbound_delivery"
+require "cloudflare/email/active_record/outbound_recipient"
+require "cloudflare/email/active_record/outbound_reconciliation"
+require "active_job"
+require "global_id"
+require "cloudflare/email/tenant_job_context"
+
+GlobalID.app = "cloudflare-email-tenancy-test"
+Cloudflare::Email::ActiveRecord::EventReceipt.include(GlobalID::Identification)
+ActiveJob::Base.logger = Logger.new(File::NULL)
+
+class TenantReceiptJob < ActiveJob::Base
+  prepend Cloudflare::Email::TenantJobContext
+  class_attribute :observed, default: []
+
+  def deserialize(data)
+    super
+    # Emulates a host integration that eagerly resolves records during deserialize.
+    self.class.observed += [GlobalID::Locator.locate(data.fetch("arguments").first.fetch("_aj_globalid")).state]
+  end
+
+  def perform(receipt, fail_job = false)
+    self.class.observed += [[Cloudflare::Email::Tenancy.require_context!, receipt.state]]
+    raise "job failure" if fail_job
+  end
+end
+
+module ActiveStorage
+  class AnalyzeJob < TenantReceiptJob
+  end
+end
+Cloudflare::Email::TenantJobContext.install_framework_jobs!
+
+%w[alpha beta].each do |key|
+  Cloudflare::Email::Tenancy.with(key) do
+    TenantRecord.connection.create_table(:cloudflare_email_event_receipts) do |t|
+      t.string :account_id
+      t.string :event_id
+      t.string :message_id
+      t.text :payload_json
+      t.string :state
+    end
+  end
+end
+
+class TenantFoundationTest < Minitest::Test
+  Tenancy = Cloudflare::Email::Tenancy
+  Receipt = Cloudflare::Email::ActiveRecord::EventReceipt
+
+  def setup
+    %w[alpha beta].each { |key| Tenancy.with(key) { Receipt.delete_all } }
+  end
+
+  def test_isolates_overlapping_ids_and_records
+    alpha = Tenancy.with("alpha") { Receipt.create!(id: 42, account_id: "shared", event_id: "same", state: "alpha") }
+    Tenancy.with("beta") do
+      Receipt.create!(id: 42, account_id: "shared", event_id: "same", state: "beta")
+      assert_equal "beta", Receipt.find(42).state
+      assert_raises(Cloudflare::Email::ConfigurationError) { alpha.reload }
+      assert_raises(Cloudflare::Email::ConfigurationError) { alpha.update!(state: "wrong") }
+      assert_raises(Cloudflare::Email::ConfigurationError) { alpha.update_columns(state: "wrong") }
+      assert_raises(Cloudflare::Email::ConfigurationError) { alpha.delete }
+      assert_equal "beta", Receipt.find(42).state
+    end
+    Tenancy.with("alpha") { assert_equal "alpha", alpha.reload.state }
+  end
+
+  def test_requires_explicit_context_even_if_host_defaults_to_a_tenant
+    assert_raises(Cloudflare::Email::ConfigurationError) { Receipt.count }
+    assert_raises(Cloudflare::Email::ConfigurationError) { Receipt.new }
+    assert_raises(Cloudflare::Email::ConfigurationError) { Tenancy.require_context! }
+  end
+
+  def test_nested_exception_restores_host_and_gem_context
+    original_shard = TenantRecord.current_shard
+    Tenancy.with("alpha") do
+      assert_raises(RuntimeError) do
+        Tenancy.with("beta") do
+          assert_equal "beta", Tenancy.require_context!
+          assert_equal :beta, TenantRecord.current_shard
+          raise "intentional rollback"
+        end
+      end
+      assert_equal "alpha", Tenancy.require_context!
+      assert_equal :alpha, TenantRecord.current_shard
+    end
+    assert_nil Tenancy.current_key
+    assert_equal original_shard, TenantRecord.current_shard
+  end
+
+  def test_host_switch_cannot_silently_override_selected_tenant
+    Tenancy.with("alpha") do
+      TenantRecord.connected_to(role: :writing, shard: :beta) do
+        assert_raises(Cloudflare::Email::ConfigurationError) { Receipt.count }
+      end
+    end
+  end
+
+  def test_all_durable_models_use_host_connection_owner
+    %i[EventReceipt OutboundDelivery OutboundRecipient OutboundReconciliation].each do |name|
+      klass = Cloudflare::Email::ActiveRecord.const_get(name)
+      assert klass < TenantRecord
+      assert_raises(Cloudflare::Email::ConfigurationError) { klass.connection_pool }
+    end
+  end
+
+  def test_rejects_ambiguous_keys_and_late_configuration
+    [nil, "", " ", "alpha ", "alpha\n", :alpha, 123].each do |key|
+      assert_raises(Cloudflare::Email::ConfigurationError) { Tenancy.with(key) {} }
+    end
+    assert_raises(Cloudflare::Email::ConfigurationError) do
+      Tenancy.configure(base_class: TenantRecord, switch: -> {}, current: -> {})
+    end
+  end
+
+  def job_payload(fail_job: false)
+    Tenancy.with("beta") { Receipt.create!(id: 42, state: "beta") }
+    Tenancy.with("alpha") do
+      receipt = Receipt.create!(id: 42, state: "alpha")
+      TenantReceiptJob.new(receipt, fail_job).serialize
+    end
+  end
+
+  def test_job_selects_tenant_before_deserialize_and_global_id_lookup
+    payload = job_payload
+    TenantReceiptJob.observed = []
+    Tenancy.with("beta") do
+      ActiveJob::Base.execute(payload)
+      assert_equal "beta", Tenancy.require_context!
+    end
+    assert_equal ["alpha", ["alpha", "alpha"]], TenantReceiptJob.observed
+    assert_nil Tenancy.current_key
+  end
+
+  def test_job_failure_restores_context_and_reserialization_retains_tenant
+    payload = job_payload(fail_job: true)
+    job = ActiveJob::Base.deserialize(payload)
+    Tenancy.with("beta") do
+      assert_equal "alpha", job.serialize.fetch(Cloudflare::Email::TenantJobContext::PAYLOAD_KEY)
+      assert_raises(RuntimeError) { job.perform_now }
+      assert_equal "beta", Tenancy.require_context!
+    end
+    assert_nil Tenancy.current_key
+  end
+
+  def test_job_missing_tenant_does_not_fall_back_to_ambient_context
+    payload = job_payload
+    payload.delete(Cloudflare::Email::TenantJobContext::PAYLOAD_KEY)
+    Tenancy.with("beta") do
+      assert_raises(Cloudflare::Email::ConfigurationError) { ActiveJob::Base.execute(payload) }
+    end
+    assert_raises(Cloudflare::Email::ConfigurationError) { TenantReceiptJob.new.serialize }
+    assert_raises(Cloudflare::Email::ConfigurationError) { TenantReceiptJob.new.perform_now }
+  end
+
+  def test_job_rejects_conflicting_native_tenant_metadata
+    payload = job_payload
+    payload["tenant"] = "beta"
+    assert_raises(Cloudflare::Email::ConfigurationError) { ActiveJob::Base.execute(payload) }
+    assert_nil Tenancy.current_key
+  end
+
+  def test_framework_job_captures_trusted_host_only_context
+    receipt = Tenancy.with("alpha") { Receipt.create!(id: 42, state: "alpha") }
+    Tenancy.with("beta") { Receipt.create!(id: 42, state: "beta") }
+    payload = TenantRecord.connected_to(role: :writing, shard: :alpha) do
+      assert_nil Tenancy.current_key
+      assert_equal "alpha", Tenancy.host_current_key
+      ActiveStorage::AnalyzeJob.new(receipt).serialize
+    end
+    assert_equal "alpha", payload.fetch(Cloudflare::Email::TenantJobContext::PAYLOAD_KEY)
+    assert_nil Tenancy.current_key
+    ActiveStorage::AnalyzeJob.observed = []
+    TenantRecord.connected_to(role: :writing, shard: :beta) do
+      ActiveJob::Base.execute(payload)
+      assert_equal :beta, TenantRecord.current_shard
+      assert_nil Tenancy.current_key
+    end
+    assert_equal ["alpha", ["alpha", "alpha"]], ActiveStorage::AnalyzeJob.observed
+
+    payload.delete(Cloudflare::Email::TenantJobContext::PAYLOAD_KEY)
+    TenantRecord.connected_to(role: :writing, shard: :alpha) do
+      assert_raises(Cloudflare::Email::ConfigurationError) { ActiveJob::Base.execute(payload) }
+    end
+  end
+end

--- a/test/tenancy_test.rb
+++ b/test/tenancy_test.rb
@@ -1,0 +1,15 @@
+require "test_helper"
+require "open3"
+require "rbconfig"
+
+class TenancyTest < Minitest::Test
+  def test_optional_single_database_job_context
+    output, status = Open3.capture2e(RbConfig.ruby, File.expand_path("support/default_tenant_jobs.rb", __dir__))
+    assert status.success?, output
+  end
+
+  def test_real_sqlite_tenant_connections
+    output, status = Open3.capture2e(RbConfig.ruby, File.expand_path("support/tenancy.rb", __dir__))
+    assert status.success?, output
+  end
+end


### PR DESCRIPTION
Rails applications can now manage named mailboxes and aliases through an optional gem module, backed by one database or an explicit tenant connection adapter. Ingress verifies the signed recipient before choosing a tenant, stores mailbox membership with raw mail, and keeps managed messages from normal ActionMailbox incineration. The scoped API supports read/archive/purge, suspension, sender-authorized outbox preparation and tenant-aware jobs.

Reuse the existing outbox and receipt ledger for sends and lifecycle events. Shared event intake commits before ACK; provider correlation selects the tenant and tenant projection commits before shared completion. Recovery pages repair enqueue/correlation/callback gaps without resending uncertain operations. Framework jobs restore tenant context before GlobalID lookup. The composed generator supports separate shared and tenant migration paths; activerecord-tenanted remains an optional application dependency.

Validation:
- Full suite: 212 tests / 758 assertions, with separate subprocess tests for real SQLite tenants, jobs, models, generators, service concurrency/recovery, event dispatch and Rails ingress.
- Actual activerecord-tenanted 0.8 / Rails 8.1 integration: 3 tests / 23 assertions, plus dependency audit.
- Packaged Ruby/Rails installation and new packaged mailbox ingress/retention checks passed.
- Existing actual local workerd-to-Rails flow passed. Documentation: 59 local links and 31 Ruby snippets checked.
- CI runs the supported Ruby/Rails matrix, PostgreSQL, Worker, local ingress and the new tenant integration job.

See `docs/mailboxes.md`, `docs/activerecord-tenanted.md`, and `docs/verification/2026-09-11-tenant-mailboxes.md`. Host authorization, verified domain provisioning, tenant-specific framework storage, job scheduling and retention remain application responsibilities. Drain old framework job payloads before enabling database tenancy. Rebulk migration, live customer-domain verification, deployment and RubyGems publication are separate; none was performed here.
