### PR TITLE
Fix mailbox activation with Rails strict readonly attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+- Fix managed domain and address activation in Rails apps with strict readonly
+  attributes enabled. Normalize immutable identities only when creating records;
+  later lifecycle updates retain the original domain and address.
+
 ## 0.2.0 — 2026-09-11
 
 - Add optional managed mailboxes: domain directory, addresses/aliases, lifecycle,

--- a/lib/cloudflare/email/mailboxes/models.rb
+++ b/lib/cloudflare/email/mailboxes/models.rb
@@ -10,7 +10,7 @@ module Cloudflare
         self.table_name = "cloudflare_email_receiving_domains"
         STATES = %w[pending active suspended].freeze
         attr_readonly :domain, :tenant_key, :account_id
-        before_validation { self.domain = domain.to_s.strip.downcase }
+        before_validation(on: :create) { self.domain = domain.to_s.strip.downcase }
         validates :tenant_key, :account_id, presence: true
         validates :domain, presence: true, uniqueness: true,
           length: { maximum: 253 },
@@ -71,7 +71,7 @@ module Cloudflare
         self.table_name = "cloudflare_email_addresses"
         belongs_to :mailbox, class_name: "Cloudflare::Email::Mailboxes::Mailbox"
         attr_readonly :mailbox_id, :receiving_domain_id, :local_part, :domain, :address
-        before_validation :normalize_address
+        before_validation :normalize_address, on: :create
         validates :mailbox, :receiving_domain_id, presence: true
         validates :local_part, length: { in: 1..64 },
           format: { with: /\A[a-z0-9!\#$%&'*+\/=\?^_`{|}~-]+(?:\.[a-z0-9!\#$%&'*+\/=\?^_`{|}~-]+)*\z/ }

--- a/test/support/mailbox_models.rb
+++ b/test/support/mailbox_models.rb
@@ -1,6 +1,7 @@
 require "bundler/setup"
 require "minitest/autorun"
 require "active_record"
+ActiveRecord.raise_on_assign_to_attr_readonly = true
 require "tmpdir"
 require "cloudflare-email"
 
@@ -55,7 +56,7 @@ class MailboxModelPersistenceTest < Minitest::Test
 
   def test_record_identity_and_current_tenant_are_guarded
     record = create_address
-    record.update!(local_part: "renamed")
+    assert_raises(ActiveRecord::ReadonlyAttributeError) { record.update!(local_part: "renamed") }
     assert_equal "support", record.reload.local_part
     assert_equal "support@customer.example.com", record.address
     Tenancy.with("two") do
@@ -82,6 +83,20 @@ class MailboxModelPersistenceTest < Minitest::Test
       Models::Message.create!(tenant_key: "one", mailbox: @mailbox, inbound_email_id: 123, recipient: "alias@customer.example.com")
     end
     assert_raises(ActiveRecord::DeleteRestrictionError) { @mailbox.destroy! }
+  end
+
+  def test_strict_readonly_allows_lifecycle_updates_without_reassigning_identity
+    address = create_address
+    @domain.update!(state: "suspended")
+    @domain.update!(state: "active", sending_enabled: true, provisioning_evidence: "Verified test domain")
+    address.update!(state: "active", provisioning_evidence: "Verified test route")
+    address.update!(state: "suspended")
+    assert_equal "customer.example.com", @domain.reload.domain
+    assert @domain.sending_enabled
+    assert_equal "support@customer.example.com", address.reload.address
+    assert_equal "suspended", address.state
+    assert_raises(ActiveRecord::ReadonlyAttributeError) { @domain.domain = "other.example.com" }
+    assert_raises(ActiveRecord::ReadonlyAttributeError) { address.address = "other@customer.example.com" }
   end
 
   private

--- a/test/support/mailbox_service.rb
+++ b/test/support/mailbox_service.rb
@@ -2,6 +2,7 @@ require_relative "../test_helper"
 require "tmpdir"
 require "fileutils"
 require "active_record"
+ActiveRecord.raise_on_assign_to_attr_readonly = true
 require "mail"
 require "minitest/mock"
 require "cloudflare/email/tenancy"


### PR DESCRIPTION
Rails applications that enable `raise_on_assign_to_attr_readonly` could create a receiving domain but failed when activating it: validation reassigned its immutable domain. Address activation had the same issue.

Normalize domains and addresses only when creating records. Lifecycle updates now preserve immutable identities while strict assignment protection remains enabled.

Validation: `bundle exec rake test` — 212 tests, 758 assertions, no failures. Model and separate SQLite tenant service tests explicitly enable strict readonly assignment, including activation, suspension, sending and immutable identity checks.
