### PR TITLE
Add an optional server-rendered mailbox management engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- Add an opt-in server-rendered mailbox management engine with host authentication,
+  mailbox/domain scoping and per-action permissions. Manage mailboxes and aliases,
+  suspend/resume, preview plain-text messages and mark read/archive without
+  JavaScript or asset pipeline dependencies. The engine is never mounted by default.
+
 - Fix managed domain and address activation in Rails apps with strict readonly
   attributes enabled. Normalize immutable identities only when creating records;
   later lifecycle updates retain the original domain and address.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Version **0.2.0**. Ruby 3.2+, Rails 7.2–8.1; Ruby 4.0 is tested with Rails 8.1
 | [Getting started](docs/getting-started.md) | Install, send your first email, receive replies, and save reliable send operations |
 | [Troubleshooting](docs/troubleshooting.md) | What to check when mail or delivery updates do not arrive |
 | [Managed mailboxes](docs/mailboxes.md) | Create inboxes and aliases, read/archive mail, and send from a mailbox |
+| [Management engine (unreleased)](docs/management-engine.md) | Mount an optional server-rendered mailbox UI using your app's authentication |
 | [SQLite tenant databases](docs/activerecord-tenanted.md) | Give each organization its own SQLite database with `activerecord-tenanted` |
 | [Durable outbox](docs/outbox.md) | Detailed setup, callbacks, retries, and recovery |
 | [Delivery events](docs/delivery-events.md) | Cloudflare Queue setup and recipient status tracking |

--- a/app/controllers/cloudflare/email/management/mailboxes_controller.rb
+++ b/app/controllers/cloudflare/email/management/mailboxes_controller.rb
@@ -1,0 +1,171 @@
+module Cloudflare
+  module Email
+    module Management
+      class MailboxesController < ActionController::Base
+        layout "layouts/cloudflare/email/management"
+        protect_from_forgery with: :exception
+        self.forgery_protection_origin_check = true
+        around_action :with_host_context
+        helper_method :allowed?, :host_back_path
+
+        class Denied < StandardError; end
+        class InvalidInput < StandardError; end
+
+        rescue_from Denied do
+          head :forbidden
+        end
+        rescue_from ::ActiveRecord::RecordNotFound do
+          head :not_found
+        end
+        rescue_from InvalidInput, ::ActiveRecord::RecordInvalid, Cloudflare::Email::Error do
+          redirect_to(@mailbox ? mailbox_path(@mailbox) : root_path,
+            alert: "The changes could not be saved. Check the address, registered domain and required fields.",
+            status: :see_other)
+        end
+        rescue_from Cloudflare::Email::ConfigurationError do
+          head :service_unavailable
+        end
+
+        def index
+          authorize!(:index)
+          @mailboxes = page(scoped_mailboxes)
+          @domains = permitted_domains if allowed?(:create)
+        end
+
+        def show
+          load_mailbox!(:show)
+          @addresses = @session.addresses(@mailbox.id).order(:id).to_a
+          @domains = allowed?(:add_address, @mailbox) ? permitted_domains : []
+          @messages = allowed?(:show_message, @mailbox) ? page(@session.messages(@mailbox.id)) : []
+        end
+
+        def create
+          authorize!(:create)
+          values = params.require(:mailbox).permit(:name, :address)
+          name = values[:name].to_s.strip
+          raise InvalidInput unless (1..255).cover?(name.length)
+          address = permitted_address!(values[:address])
+          Mailboxes::Mailbox.transaction do
+            @mailbox = @adapter.create_mailbox(@session, name: name, address: address)
+            # A hook cannot turn an arbitrary return value into a readable mailbox.
+            @mailbox = scoped_mailboxes.find(@mailbox.id)
+          end
+          redirect_to mailbox_path(@mailbox), notice: "Mailbox created. Review address setup below.", status: :see_other
+        end
+
+        def add_address
+          load_mailbox!(:add_address)
+          @adapter.add_address(@session, @mailbox, address: permitted_address!(params[:address]))
+          redirect_to mailbox_path(@mailbox), notice: "Address added. Review its setup status.", status: :see_other
+        end
+
+        def suspend
+          load_mailbox!(:suspend)
+          @session.suspend(@mailbox.id)
+          redirect_to mailbox_path(@mailbox), notice: "Mailbox suspended. Messages are retained.", status: :see_other
+        end
+
+        def resume
+          load_mailbox!(:resume)
+          @session.resume(@mailbox.id)
+          redirect_to mailbox_path(@mailbox), notice: "Mailbox resumed. Pending addresses still need setup.", status: :see_other
+        end
+
+        def message
+          load_mailbox!(:show_message)
+          @entry = @session.messages(@mailbox.id).find(params[:message_id])
+          raw = @session.inbound_email(@mailbox.id, @entry.id).mail
+          @subject = raw.subject.to_s
+          @from = Array(raw.from).join(", ")
+          part = raw.text_part || (raw.mime_type == "text/plain" ? raw : nil)
+          @body = part ? part.decoded.to_s.encode("UTF-8", invalid: :replace, undef: :replace).first(100_000) :
+            "This message has no plain-text body. HTML rendering is disabled in this management interface."
+          @attachments = raw.attachments.map { |attachment| attachment.filename.to_s }
+          render :message
+        end
+
+        def mark_read
+          load_mailbox!(:mark_read)
+          @session.mark_read(@mailbox.id, params[:message_id], read: boolean_param(:read))
+          redirect_to mailbox_path(@mailbox), status: :see_other
+        end
+
+        def archive
+          load_mailbox!(:archive)
+          @session.archive(@mailbox.id, params[:message_id], archived: boolean_param(:archived))
+          redirect_to mailbox_path(@mailbox), status: :see_other
+        end
+
+        private
+
+        def with_host_context
+          response.headers["Cache-Control"] = "no-store"
+          response.headers["Referrer-Policy"] = "same-origin"
+          response.headers["X-Content-Type-Options"] = "nosniff"
+          response.headers["Content-Security-Policy"] = "default-src 'none'; style-src 'self'; img-src 'none'; form-action 'self'; frame-ancestors 'none'; base-uri 'none'"
+          factory = Management.configuration.adapter
+          unless factory.respond_to?(:call) && defined?(Mailboxes) && Mailboxes.enabled?
+            return head :service_unavailable
+          end
+          @adapter = factory.call(self)
+          authenticated = @adapter.authenticate!
+          return if performed?
+          return head :unauthorized unless authenticated == true
+          Mailboxes.for_tenant(@adapter.tenant_key) do |session|
+            @session = session
+            yield
+          end
+        end
+
+        def allowed?(action, mailbox = nil)
+          @adapter.allowed?(action, mailbox) == true
+        end
+
+        def authorize!(action, mailbox = nil)
+          raise Denied unless allowed?(action, mailbox)
+        end
+
+        def scoped_mailboxes
+          # Always retain the gem's tenant condition even if a host scope omits it.
+          @session.mailboxes.where(id: @adapter.mailboxes(@session).reselect(:id))
+        end
+
+        def load_mailbox!(action)
+          @mailbox = scoped_mailboxes.find(params[:id])
+          authorize!(action, @mailbox)
+        end
+
+        def permitted_domains
+          granted = Array(@adapter.domains(@session)).map(&:to_s)
+          Mailboxes::ReceivingDomain.active.where(tenant_key: @session.tenant_key, domain: granted).order(:domain).pluck(:domain)
+        end
+
+        def permitted_address!(value)
+          address = Mailboxes.canonical_address(value)
+          raise InvalidInput unless permitted_domains.include?(address.split("@", 2).last)
+          address
+        end
+
+        def page(relation)
+          cursor = params[:after].to_s
+          raise InvalidInput unless cursor.empty? || cursor.match?(/\A[0-9]{1,18}\z/)
+          rows = relation.where("id > ?", cursor.to_i).order(:id).limit(51).to_a
+          @next_cursor = rows.length > 50 ? rows[49].id : nil
+          rows.first(50)
+        end
+
+        def boolean_param(key)
+          value = params[key]
+          raise InvalidInput unless %w[true false].include?(value)
+          value == "true"
+        end
+
+        def host_back_path
+          callback = Management.configuration.back_path
+          value = callback.call(self) if callback.respond_to?(:call)
+          value if value.is_a?(String) && value.start_with?("/") && !value.start_with?("//") && !value.match?(/[\\\r\n]/)
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/cloudflare/email/management/mailboxes_controller.rb
+++ b/app/controllers/cloudflare/email/management/mailboxes_controller.rb
@@ -14,10 +14,10 @@ module Cloudflare
         rescue_from Denied do
           head :forbidden
         end
-        rescue_from ::ActiveRecord::RecordNotFound do
+        rescue_from "ActiveRecord::RecordNotFound" do
           head :not_found
         end
-        rescue_from InvalidInput, ::ActiveRecord::RecordInvalid, Cloudflare::Email::Error do
+        rescue_from InvalidInput, "ActiveRecord::RecordInvalid", Cloudflare::Email::Error do
           redirect_to(@mailbox ? mailbox_path(@mailbox) : root_path,
             alert: "The changes could not be saved. Check the address, registered domain and required fields.",
             status: :see_other)
@@ -41,7 +41,9 @@ module Cloudflare
 
         def create
           authorize!(:create)
-          values = params.require(:mailbox).permit(:name, :address)
+          input = params.require(:mailbox)
+          raise InvalidInput unless input.is_a?(ActionController::Parameters)
+          values = input.permit(:name, :address)
           name = values[:name].to_s.strip
           raise InvalidInput unless (1..255).cover?(name.length)
           address = permitted_address!(values[:address])

--- a/app/controllers/cloudflare/email/management/styles_controller.rb
+++ b/app/controllers/cloudflare/email/management/styles_controller.rb
@@ -1,0 +1,13 @@
+module Cloudflare
+  module Email
+    module Management
+      class StylesController < ActionController::Base
+        def show
+          response.headers["X-Content-Type-Options"] = "nosniff"
+          send_data File.binread(File.expand_path("../../../../../lib/cloudflare/email/management/management.css", __dir__)),
+            type: "text/css; charset=utf-8", disposition: "inline"
+        end
+      end
+    end
+  end
+end

--- a/app/views/cloudflare/email/management/mailboxes/index.html.erb
+++ b/app/views/cloudflare/email/management/mailboxes/index.html.erb
@@ -1,0 +1,65 @@
+<div class="page-heading">
+  <div>
+    <p class="eyebrow">Email workspace</p>
+    <h1>Mailboxes</h1>
+    <p class="muted">Manage accepted addresses and the messages delivered to them.</p>
+  </div>
+</div>
+
+<div class="workspace-grid">
+  <section class="panel" aria-labelledby="mailboxes-heading">
+    <div class="panel-heading"><h2 id="mailboxes-heading">Your mailboxes</h2></div>
+    <% if @mailboxes.empty? %>
+      <div class="empty-state">
+        <h3>No mailboxes to show</h3>
+        <p>Create a mailbox to give incoming email a home.</p>
+      </div>
+    <% else %>
+      <ul class="record-list">
+        <% @mailboxes.each do |mailbox| %>
+          <li class="record-row">
+            <div class="record-content">
+              <% if allowed?(:show, mailbox) %>
+                <%= link_to mailbox.name, mailbox_path(mailbox.id), class: "record-title" %>
+              <% else %>
+                <span class="record-title"><%= mailbox.name %></span>
+              <% end %>
+              <p class="muted small">Mailbox #<%= mailbox.id %></p>
+            </div>
+            <span class="badge"><%= mailbox.state.capitalize %></span>
+          </li>
+        <% end %>
+      </ul>
+    <% end %>
+    <% if @next_cursor.present? %>
+      <nav class="pagination" aria-label="Mailbox pages">
+        <%= link_to "Next mailboxes →", root_path(after: @next_cursor), class: "button button-secondary" %>
+      </nav>
+    <% end %>
+  </section>
+
+  <% if allowed?(:create) %>
+    <section class="panel" aria-labelledby="create-heading">
+      <div class="panel-heading"><h2 id="create-heading">Create a mailbox</h2></div>
+      <div class="panel-body">
+        <% if @domains.empty? %>
+          <p class="muted">An administrator needs to register an active receiving domain before you can create a mailbox.</p>
+        <% else %>
+          <%= form_with url: mailboxes_path, scope: :mailbox, local: true, class: "stack" do |form| %>
+            <div class="field">
+              <%= form.label :name, "Mailbox name" %>
+              <%= form.text_field :name, required: true, maxlength: 255, placeholder: "Customer support" %>
+            </div>
+            <div class="field">
+              <%= form.label :address, "Email address" %>
+              <%= form.email_field :address, required: true, maxlength: 254, placeholder: "support@#{@domains.first}", aria: { describedby: "create-domains" } %>
+              <p id="create-domains" class="field-help">Available domains: <%= @domains.join(", ") %></p>
+            </div>
+            <p class="field-help">New addresses start pending. Your administrator must confirm their routing before they can receive mail.</p>
+            <%= form.submit "Create mailbox", class: "button" %>
+          <% end %>
+        <% end %>
+      </div>
+    </section>
+  <% end %>
+</div>

--- a/app/views/cloudflare/email/management/mailboxes/message.html.erb
+++ b/app/views/cloudflare/email/management/mailboxes/message.html.erb
@@ -1,0 +1,34 @@
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <%= link_to "Mailboxes", root_path %> <span aria-hidden="true">/</span>
+  <%= link_to @mailbox.name, mailbox_path(@mailbox.id) %> <span aria-hidden="true">/</span>
+  <span>Message</span>
+</nav>
+<div class="page-heading">
+  <div><p class="eyebrow">Received message</p><h1><%= @subject.presence || "(No subject)" %></h1></div>
+  <div class="actions">
+    <% if allowed?(:mark_read, @mailbox) %>
+      <%= button_to(@entry.read_at ? "Mark unread" : "Mark read", mark_read_mailbox_path(@mailbox.id), method: :post, params: { message_id: @entry.id, read: @entry.read_at ? "false" : "true" }, class: "button button-secondary") %>
+    <% end %>
+    <% if allowed?(:archive, @mailbox) %>
+      <%= button_to(@entry.archived_at ? "Unarchive" : "Archive", archive_mailbox_path(@mailbox.id), method: :post, params: { message_id: @entry.id, archived: @entry.archived_at ? "false" : "true" }, class: "button button-secondary") %>
+    <% end %>
+  </div>
+</div>
+<article class="panel" aria-label="Email message">
+  <div class="panel-body">
+    <dl class="message-metadata">
+      <dt>From</dt><dd><%= @from.presence || "(Unknown sender)" %></dd>
+      <dt>To</dt><dd><%= @entry.recipient %></dd>
+      <dt>Received</dt><dd><time datetime="<%= @entry.created_at.iso8601 %>"><%= @entry.created_at.utc.strftime("%b %-d, %Y · %H:%M UTC") %></time></dd>
+      <dt>Status</dt><dd><%= @entry.read_at ? "Read" : "Unread" %><%= " · Archived" if @entry.archived_at %></dd>
+    </dl>
+  </div>
+  <div class="message-body"><pre><%= @body.presence || "No text content is available for this message." %></pre></div>
+  <% if @attachments.any? %>
+    <section class="panel-body attachments" aria-labelledby="attachments-heading">
+      <h2 id="attachments-heading">Attachments</h2>
+      <p class="field-help">File names are shown for reference. Downloads are not available in this dashboard.</p>
+      <ul><% @attachments.each do |filename| %><li><%= filename.presence || "Unnamed attachment" %></li><% end %></ul>
+    </section>
+  <% end %>
+</article>

--- a/app/views/cloudflare/email/management/mailboxes/show.html.erb
+++ b/app/views/cloudflare/email/management/mailboxes/show.html.erb
@@ -1,0 +1,83 @@
+<nav class="breadcrumbs" aria-label="Breadcrumb"><%= link_to "Mailboxes", root_path %> <span aria-hidden="true">/</span> <span><%= @mailbox.name %></span></nav>
+<div class="page-heading">
+  <div>
+    <p class="eyebrow">Mailbox</p>
+    <h1><%= @mailbox.name %></h1>
+    <p class="muted"><%= @mailbox.state == "suspended" ? "Receiving is paused for every address in this mailbox." : "Addresses receive mail when both their address and domain are active." %></p>
+  </div>
+  <div class="actions">
+    <span class="badge"><%= @mailbox.state.capitalize %></span>
+    <% if @mailbox.state == "active" && allowed?(:suspend, @mailbox) %>
+      <%= button_to "Suspend mailbox", suspend_mailbox_path(@mailbox.id), method: :post, class: "button button-secondary" %>
+    <% elsif @mailbox.state == "suspended" && allowed?(:resume, @mailbox) %>
+      <%= button_to "Resume mailbox", resume_mailbox_path(@mailbox.id), method: :post, class: "button" %>
+    <% end %>
+  </div>
+</div>
+
+<div class="workspace-grid">
+  <section class="panel" aria-labelledby="messages-heading">
+    <div class="panel-heading"><h2 id="messages-heading">Received messages</h2><p class="muted small">Includes archived messages</p></div>
+    <% if @messages.empty? %>
+      <div class="empty-state"><h3>No messages to show</h3><p>Messages appear here after delivery to an active address.</p></div>
+    <% else %>
+      <ul class="record-list">
+        <% @messages.each do |entry| %>
+          <li class="record-row">
+            <div class="record-content">
+              <% if allowed?(:show_message, @mailbox) %>
+                <%= link_to "Message to #{entry.recipient}", message_mailbox_path(@mailbox.id, message_id: entry.id), class: "record-title" %>
+              <% else %>
+                <span class="record-title">Message to <%= entry.recipient %></span>
+              <% end %>
+              <p class="muted small"><time datetime="<%= entry.created_at.iso8601 %>"><%= entry.created_at.utc.strftime("%b %-d, %Y · %H:%M UTC") %></time></p>
+            </div>
+            <div class="status-list">
+              <span class="badge"><%= entry.read_at ? "Read" : "Unread" %></span>
+              <% if entry.archived_at %><span class="badge">Archived</span><% end %>
+            </div>
+          </li>
+        <% end %>
+      </ul>
+    <% end %>
+    <% if @next_cursor.present? %>
+      <nav class="pagination" aria-label="Message pages"><%= link_to "Next messages →", mailbox_path(@mailbox.id, after: @next_cursor), class: "button button-secondary" %></nav>
+    <% end %>
+  </section>
+
+  <div class="stack">
+    <section class="panel" aria-labelledby="addresses-heading">
+      <div class="panel-heading"><h2 id="addresses-heading">Addresses</h2></div>
+      <ul class="record-list">
+        <% @addresses.each do |address| %>
+          <% receiving = @mailbox.state == "active" && address.state == "active" && address.receiving_domain&.state == "active" %>
+          <li class="record-row address-row">
+            <span class="record-title"><%= address.address %></span>
+            <span class="badge"><%= receiving ? "Accepting mail" : address.state == "pending" ? "Pending setup" : "Receiving paused" %></span>
+          </li>
+        <% end %>
+      </ul>
+      <div class="panel-body"><p class="field-help">Pending addresses need routing confirmation from your administrator. Resuming a mailbox preserves each address’s existing setup state.</p></div>
+    </section>
+
+    <% if allowed?(:add_address, @mailbox) %>
+      <section class="panel" aria-labelledby="alias-heading">
+        <div class="panel-heading"><h2 id="alias-heading">Add an alias</h2></div>
+        <div class="panel-body">
+          <% if @domains.empty? %>
+            <p class="muted">No active receiving domains are available. Contact your administrator.</p>
+          <% else %>
+            <%= form_with url: aliases_mailbox_path(@mailbox.id), local: true, class: "stack" do |form| %>
+              <div class="field">
+                <%= form.label :address, "Alias email address" %>
+                <%= form.email_field :address, required: true, maxlength: 254, aria: { describedby: "alias-domains" } %>
+                <p id="alias-domains" class="field-help">Available domains: <%= @domains.join(", ") %>. Messages to this alias will appear in this mailbox.</p>
+              </div>
+              <%= form.submit "Add alias", class: "button" %>
+            <% end %>
+          <% end %>
+        </div>
+      </section>
+    <% end %>
+  </div>
+</div>

--- a/app/views/layouts/cloudflare/email/management.html.erb
+++ b/app/views/layouts/cloudflare/email/management.html.erb
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Mailbox management</title>
+    <%= csrf_meta_tags %>
+    <%= stylesheet_link_tag style_path %>
+  </head>
+  <body>
+    <a class="skip-link" href="#main">Skip to content</a>
+    <header class="site-header">
+      <div class="shell header-content">
+        <%= link_to "Mailbox management", root_path, class: "brand" %>
+        <span class="header-caption">Cloudflare Email</span>
+        <% if host_back_path %><%= link_to "Back to app", host_back_path %><% end %>
+      </div>
+    </header>
+    <main id="main" class="shell" tabindex="-1">
+      <% if flash[:notice].present? %>
+        <div class="notice" role="status"><%= flash[:notice] %></div>
+      <% end %>
+      <% if flash[:alert].present? %>
+        <div class="notice notice-error" role="alert"><%= flash[:alert] %></div>
+      <% end %>
+      <%= yield %>
+    </main>
+  </body>
+</html>

--- a/cloudflare-email.gemspec
+++ b/cloudflare-email.gemspec
@@ -24,6 +24,8 @@ Gem::Specification.new do |spec|
     "lib/**/*.rb",
     "lib/**/*.rake",
     "app/**/*.rb",
+    "app/views/**/*.erb",
+    "lib/cloudflare/email/management/*.css",
     "templates/worker/README.md",
     "templates/worker/package.json",
     "templates/worker/package-lock.json",

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -92,4 +92,6 @@ silently impose a marketing subscription model on transactional mail.
 The optional [mailbox module](mailboxes.md) now packages mailbox persistence and
 address management over the existing transport/receipt APIs. It includes a
 [tenant adapter](activerecord-tenanted.md), without adding a tenant library to
-the plain Ruby client. A future inbox UI or starter should consume these APIs.
+the plain Ruby client. The optional [management engine](management-engine.md)
+consumes these same APIs with host-supplied authentication and authorization.
+Full inbox products can continue using them through their own frontends.

--- a/docs/features.md
+++ b/docs/features.md
@@ -83,7 +83,9 @@ See [managed mailbox setup](mailboxes.md) for the application-facing API and
 The gem supplies email infrastructure and optional managed mailbox records.
 Your app supplies users, mailbox permissions, conversation records, custom folders, search, compose screens,
 drafts and any AI review or approval workflow. It also decides unsubscribe and
-recipient eligibility policy. The gem does not supply an inbox UI or AI agent.
+recipient eligibility policy. The optional [management engine](management-engine.md)
+adds server-rendered mailbox administration and plain-text message previews.
+It does not supply a compose/conversation product or AI agent.
 
 An authenticated SMTP envelope tells your app which address Cloudflare received
 the message for. It does not prove the human sender's identity. Reply correlation

--- a/docs/mailboxes.md
+++ b/docs/mailboxes.md
@@ -294,6 +294,8 @@ lookup. Drain existing ActionMailbox/ActiveStorage queues before enabling this
 mode: previously serialized jobs without the new metadata are rejected.
 
 The gem does not create organizations/users, verify customer domain ownership,
-provide IMAP/POP, or supply an inbox UI. The original Rebulk document-processing
+provide IMAP/POP, or supply a full compose/conversation inbox. The optional
+[management engine](management-engine.md) supplies mailbox administration and
+plain-text previews using your host's access policy. The original Rebulk document-processing
 Worker contract and sender-review policy still need a separate application
 migration; installing this module does not replace that live pipeline.

--- a/docs/management-engine.md
+++ b/docs/management-engine.md
@@ -1,0 +1,187 @@
+# Optional mailbox management engine
+
+The management engine is a small, server-rendered Rails interface for the
+[managed mailbox APIs](mailboxes.md). It works with ordinary Rails apps and with
+apps using Inertia, React, Turbo or another frontend. No JavaScript, Node build,
+asset pipeline or frontend package is required for the engine.
+
+This feature is currently unreleased. It is not included in RubyGems 0.2.0.
+
+## What you get
+
+- Mailbox lists, names, creation and aliases on allowed receiving domains.
+- Address setup status and mailbox suspension/resumption.
+- A paginated list of received messages and an escaped plain-text preview.
+- Optional read/unread and archive/unarchive controls.
+- Ordinary CSRF-protected forms, mobile layouts and bundled CSS.
+
+Your app supplies login, permissions, domain entitlements and any organization
+mapping. The engine does not create users, claim domains, edit DNS, provision
+Cloudflare routes, send mail, or permanently delete records. The default creation
+hooks create pending addresses. Your administrator or existing provisioning code
+completes routing and activation through the same Ruby APIs.
+
+The viewer never renders sender HTML, loads remote images, or provides raw MIME
+or attachment downloads. It shows attachment names and up to 100,000 plain-text
+characters. Compose, conversations, AI workflows and product search belong in
+your application.
+
+## Install and mount
+
+First install the managed mailbox tables and enable the module using
+[the mailbox setup guide](mailboxes.md). SQLite works; database tenancy remains
+off unless your app configures it explicitly.
+
+Require the engine **before Rails initializes**, after Bundler loads the gem:
+
+```ruby
+# config/application.rb, after Bundler.require(*Rails.groups)
+require "cloudflare/email/management"
+```
+
+Configure a host adapter in an initializer:
+
+```ruby
+# config/initializers/cloudflare_email_management.rb
+Cloudflare::Email::Management.configure do |config|
+  # Resolve the class when handling the request, so Rails reloading works.
+  config.adapter = ->(controller) { EmailManagementAccess.new(controller) }
+  config.back_path = ->(controller) { controller.main_app.root_path }
+end
+```
+
+Mount it wherever it fits your application:
+
+```ruby
+# config/routes.rb
+mount Cloudflare::Email::Management::Engine => "/email-management",
+  as: :email_management
+```
+
+Installing the gem does not expose this interface automatically. Without a
+configured adapter and enabled mailbox module the mounted interface returns 503.
+The base adapter grants no access. Its public stylesheet endpoint serves only
+the bundled CSS.
+
+## Connect your authentication and ownership
+
+Here is a single-database example using Rails' generated authentication convention
+(`Session`, `Current.session`, and a signed `session_id` cookie). Match the cookie
+and session lookup to your app; the agentic inbox example uses `session_token`.
+Use the host authentication system's expiry, revocation and access policy.
+
+```ruby
+# app/services/email_management_access.rb
+class EmailManagementAccess < Cloudflare::Email::Management::Adapter
+  ACTIONS = %i[index show create add_address suspend resume
+    show_message mark_read archive].freeze
+
+  def authenticate!
+    Current.session = Session.find_by(
+      id: controller.request.cookie_jar.signed[:session_id]
+    )
+    @user = Current.user
+    return true if @user
+
+    controller.redirect_to controller.main_app.new_session_path
+    false
+  end
+
+  def tenant_key = "application"
+  def owner_ref = "User:#{@user.id}"
+
+  def mailboxes(session)
+    session.mailboxes.where(owner_ref: owner_ref)
+  end
+
+  def allowed?(action, mailbox = nil)
+    @user.present? && ACTIONS.include?(action) &&
+      (mailbox.nil? || mailbox.owner_ref == owner_ref)
+  end
+
+  def domains(_session)
+    ["in.example.com"] # Only domains this user is entitled to use.
+  end
+
+  def create_mailbox(session, name:, address:)
+    session.create(name: name, address: address, owner_ref: owner_ref)
+  end
+end
+```
+
+For Devise, the authentication hook can use your configured Warden scope instead
+of the cookie lookup, for example
+`@user = controller.request.env["warden"]&.authenticate(scope: :user)`.
+The engine inherits from `ActionController::Base`; host `ApplicationController`
+callbacks and methods are not inherited. Make authentication explicit in the
+adapter and return exactly `true` on success, or redirect to the host's login.
+
+The directory must already contain the active receiving domain assigned to the
+same registry key. The engine intersects `domains` with that directory and
+intersects the host mailbox relation with the current gem tenant. Parameters
+cannot select an owner or tenant.
+
+Do not return every domain merely because it exists in the database. A customer
+app should apply organization entitlement, reserved-name and signup policies.
+For separate tenant databases, return a trusted host-resolved key from
+`tenant_key` and configure the existing gem tenancy adapter and framework
+connections before mailbox models load.
+
+## Customize behavior without forking the pages
+
+The adapter has these hooks:
+
+| Hook | Contract |
+| --- | --- |
+| `authenticate!` | Authenticate the request; return exactly true or redirect/deny. |
+| `tenant_key` | Trusted registry key; never use an unchecked request parameter. |
+| `mailboxes(session)` | ActiveRecord relation containing mailboxes accessible to this principal. |
+| `allowed?(action, mailbox = nil)` | Return exactly true to permit an action. |
+| `domains(session)` | Array of domain strings permitted for this principal. |
+| `create_mailbox(session, name:, address:)` | Return the created gem mailbox, visible in the host's scope. |
+| `add_address(session, mailbox, address:)` | Add an address through your existing app provisioning service if needed. |
+
+All hooks run inside the resolved mailbox context. Creation also runs in a
+database transaction; a returned mailbox outside the host scope rolls back.
+Keep network work out of creation hooks and enqueue provisioning after commit.
+The default alias hook calls `session.add_address`.
+
+Return false for `:create` or lifecycle actions to provide a restricted dashboard.
+Use `:show_message` to control message access independently of metadata. Deny
+`:mark_read` and `:archive` when the host product already owns a different
+conversation-level read/folder model. Hidden controls also reject direct requests.
+
+An application with its own mailbox record can override creation and alias hooks
+to call that application's service and return the linked gem model. The agentic
+inbox example does this: both UIs and automatic account provisioning share one
+service, so engine-created mailboxes also appear in its full inbox.
+
+## Inertia, React and Turbo applications
+
+Use a normal HTML link or full-page navigation to the mount. For example:
+
+```jsx
+<a href="/email-management">Manage mailboxes</a>
+```
+
+The engine returns HTML, not Inertia responses. Its separate layout keeps host
+frontend dependencies out of the gem. The optional `back_path` callback returns
+a local absolute path for a Back to app link. Programmatic provisioning continues
+to work whether this engine is mounted or not.
+
+## Operational behavior
+
+Suspension preserves mailbox records and retained mail while disabling mailbox
+sending/receiving. Resuming does not activate pending addresses or repair DNS.
+Read/archive state belongs to the gem mailbox memberships and does not implicitly
+rewrite host conversation records.
+
+Private pages use no-store caching, a restrictive CSP and a same-origin referrer
+policy. Forms check both Rails CSRF tokens and origins. Serve the host over HTTPS,
+configure trusted proxy headers correctly, and keep its session cookies secure.
+Do not disable CSRF to work around a proxy configuration issue.
+
+Verification includes real Rails sessions, owner/tenant scoping, all operation
+permissions, CSRF/origin checks, rollback, escaped previews, retained raw source,
+and eager-loading a core-only app without exposing the engine. The example also
+tests desktop/mobile Chromium and JavaScript-disabled forms with synthetic mail.

--- a/docs/management-engine.md
+++ b/docs/management-engine.md
@@ -141,7 +141,10 @@ The adapter has these hooks:
 | `create_mailbox(session, name:, address:)` | Return the created gem mailbox, visible in the host's scope. |
 | `add_address(session, mailbox, address:)` | Add an address through your existing app provisioning service if needed. |
 
-All hooks run inside the resolved mailbox context. Creation also runs in a
+The adapter factory, authentication and tenant-key resolution run before the
+mailbox context is entered; the host must establish any context its authentication
+needs. Mailbox/domain scopes, permissions and mutation hooks run inside the
+resolved mailbox context. Creation also runs in a
 database transaction; a returned mailbox outside the host scope rolls back.
 Keep network work out of creation hooks and enqueue provisioning after commit.
 The default alias hook calls `session.add_address`.

--- a/lib/cloudflare/email/engine.rb
+++ b/lib/cloudflare/email/engine.rb
@@ -32,6 +32,11 @@ module Cloudflare
       end
 
       config.before_initialize do
+        unless defined?(Cloudflare::Email::Management::Engine)
+          Rails.autoloaders.main.ignore(
+            File.expand_path("../../../app/controllers/cloudflare/email/management", __dir__),
+          )
+        end
         unless defined?(::ActionMailbox::Engine)
           Rails.autoloaders.main.ignore(
             File.expand_path("../../../app/controllers/cloudflare/email/ingress_controller.rb", __dir__),

--- a/lib/cloudflare/email/management.rb
+++ b/lib/cloudflare/email/management.rb
@@ -1,0 +1,5 @@
+# Explicit opt-in: require this before Rails initializes, then configure the
+# adapter in an initializer. Loading the core gem never mounts this interface.
+require "cloudflare/email/management/adapter"
+require "cloudflare/email/management/configuration"
+require "cloudflare/email/management/engine"

--- a/lib/cloudflare/email/management.rb
+++ b/lib/cloudflare/email/management.rb
@@ -1,5 +1,7 @@
 # Explicit opt-in: require this before Rails initializes, then configure the
 # adapter in an initializer. Loading the core gem never mounts this interface.
+require "rails/engine"
+require "cloudflare-email"
 require "cloudflare/email/management/adapter"
 require "cloudflare/email/management/configuration"
 require "cloudflare/email/management/engine"

--- a/lib/cloudflare/email/management/adapter.rb
+++ b/lib/cloudflare/email/management/adapter.rb
@@ -1,0 +1,31 @@
+module Cloudflare
+  module Email
+    module Management
+      # A host supplies authentication, mailbox ownership and domain entitlement.
+      # Defaults deliberately grant no access. No principal comes from params.
+      class Adapter
+        attr_reader :controller
+
+        def initialize(controller = nil)
+          @controller = controller
+        end
+
+        def authenticate! = false
+        def tenant_key = nil
+        def mailboxes(session) = session.mailboxes.none
+        def allowed?(action, mailbox = nil) = false
+        def domains(session) = []
+
+        # Override these two hooks when the host keeps a linked product model or
+        # uses a deployment policy to activate/provision verified addresses.
+        def create_mailbox(session, name:, address:)
+          session.create(name: name, address: address)
+        end
+
+        def add_address(session, mailbox, address:)
+          session.add_address(mailbox.id, address: address)
+        end
+      end
+    end
+  end
+end

--- a/lib/cloudflare/email/management/configuration.rb
+++ b/lib/cloudflare/email/management/configuration.rb
@@ -1,0 +1,17 @@
+module Cloudflare
+  module Email
+    module Management
+      class Configuration
+        attr_accessor :adapter, :back_path
+      end
+
+      def self.configuration
+        @configuration ||= Configuration.new
+      end
+
+      def self.configure
+        yield configuration
+      end
+    end
+  end
+end

--- a/lib/cloudflare/email/management/engine.rb
+++ b/lib/cloudflare/email/management/engine.rb
@@ -1,0 +1,15 @@
+require "rails/engine"
+require "action_controller/railtie"
+
+module Cloudflare
+  module Email
+    module Management
+      class Engine < ::Rails::Engine
+        isolate_namespace Cloudflare::Email::Management
+        config.root = File.expand_path("../../../..", __dir__)
+
+        config.paths["config/routes.rb"] = "lib/cloudflare/email/management/routes.rb"
+      end
+    end
+  end
+end

--- a/lib/cloudflare/email/management/management.css
+++ b/lib/cloudflare/email/management/management.css
@@ -1,0 +1,68 @@
+:root { color-scheme: light; --ink: #172c35; --muted: #536871; --line: #dce4e6; --accent: #12655c; --surface: #fff; }
+* { box-sizing: border-box; }
+body { margin: 0; background: #f5f7f7; color: var(--ink); font: 16px/1.55 system-ui, sans-serif; }
+a { color: var(--accent); text-underline-offset: 3px; }
+a:hover { text-decoration-thickness: 2px; }
+:focus-visible { outline: 3px solid #b66a17; outline-offset: 4px; }
+.shell { width: min(1160px, 100% - 48px); margin: 0 auto; }
+.site-header { background: var(--surface); border-bottom: 1px solid var(--line); }
+.header-content { display: flex; justify-content: space-between; align-items: center; gap: 16px; min-height: 76px; }
+.brand { color: var(--ink); font-weight: 750; font-size: 18px; text-decoration: none; }
+.header-caption, .muted, .field-help { color: var(--muted); }
+main.shell { padding-top: 32px; padding-bottom: 64px; }
+h1, h2, h3, p { margin: 0; }
+h1 { font-size: clamp(26px, 4vw, 36px); line-height: 1.2; letter-spacing: -.035em; overflow-wrap: anywhere; }
+h2 { font-size: 17px; line-height: 1.4; }
+h3 { font-size: 17px; }
+.small, .field-help { font-size: 13px; }
+.eyebrow { color: var(--accent); font-size: 12px; font-weight: 750; text-transform: uppercase; letter-spacing: .1em; margin-bottom: 8px; }
+.page-heading { display: flex; justify-content: space-between; align-items: center; gap: 24px; margin-bottom: 28px; }
+.page-heading .muted { margin-top: 12px; max-width: 640px; }
+.workspace-grid { display: grid; grid-template-columns: minmax(0, 1.65fr) minmax(280px, 1fr); gap: 24px; align-items: start; }
+.panel { background: var(--surface); border: 1px solid var(--line); border-radius: 12px; overflow: hidden; min-width: 0; }
+.panel-heading { padding: 20px 24px; border-bottom: 1px solid var(--line); }
+.panel-body { padding: 24px; }
+.stack { display: flex; flex-direction: column; gap: 20px; }
+.field { display: flex; flex-direction: column; gap: 8px; }
+label { font-weight: 650; font-size: 14px; }
+input[type="text"], input[type="email"] { width: 100%; border: 1px solid #a6b7be; border-radius: 7px; padding: 11px 12px; background: #fff; color: var(--ink); font: inherit; }
+.button { display: inline-flex; align-items: center; justify-content: center; min-height: 42px; padding: 9px 15px; border: 1px solid var(--accent); border-radius: 7px; background: var(--accent); color: #fff; font: inherit; font-size: 14px; font-weight: 650; text-decoration: none; cursor: pointer; text-align: center; }
+.button:hover { filter: brightness(.93); }
+.button-secondary { background: #fff; color: var(--ink); border-color: #a6b7be; }
+.record-list { list-style: none; margin: 0; padding: 0; }
+.record-row { padding: 20px 24px; display: flex; align-items: center; justify-content: space-between; gap: 16px; }
+.record-row + .record-row { border-top: 1px solid var(--line); }
+.record-content { min-width: 0; }
+.record-title { font-weight: 650; overflow-wrap: anywhere; }
+.record-content p { margin-top: 4px; }
+.badge { display: inline-block; border: 1px solid var(--line); border-radius: 5px; background: #f3f6f6; color: #364f58; padding: 3px 8px; font-size: 12px; font-weight: 650; white-space: nowrap; }
+.status-list { display: flex; flex-direction: column; align-items: flex-end; gap: 6px; }
+.address-row { align-items: flex-start; flex-direction: column; gap: 8px; }
+.empty-state { padding: 48px 24px; text-align: center; }
+.empty-state p { color: var(--muted); max-width: 340px; margin: 8px auto 0; }
+.pagination { padding: 16px 24px; border-top: 1px solid var(--line); }
+.actions { display: flex; flex-wrap: wrap; align-items: center; gap: 10px; }
+.actions form { margin: 0; }
+.breadcrumbs { display: flex; flex-wrap: wrap; gap: 10px; color: var(--muted); font-size: 14px; margin-bottom: 28px; overflow-wrap: anywhere; }
+.notice { border: 1px solid #a7ccc0; border-radius: 8px; background: #edf8f2; color: #205340; padding: 14px 18px; margin-bottom: 24px; overflow-wrap: anywhere; }
+.notice-error { border-color: #e8b9b3; background: #fff2ef; color: #8d2a21; }
+.message-metadata { display: grid; grid-template-columns: 84px minmax(0, 1fr); gap: 10px 20px; margin: 0; font-size: 14px; }
+.message-metadata dt { color: var(--muted); }
+.message-metadata dd { margin: 0; overflow-wrap: anywhere; }
+.message-body { border-top: 1px solid var(--line); padding: 28px 24px; }
+.message-body pre { white-space: pre-wrap; overflow-wrap: anywhere; font: inherit; margin: 0; }
+.attachments { border-top: 1px solid var(--line); }
+.attachments p { margin-top: 8px; }
+.attachments li { overflow-wrap: anywhere; }
+.skip-link { position: absolute; left: 16px; top: -100px; background: #fff; padding: 12px; z-index: 1; }
+.skip-link:focus { top: 12px; }
+@media (max-width: 760px) {
+  .shell { width: calc(100% - 32px); }
+  .header-content { min-height: 64px; }
+  .header-caption { display: none; }
+  .workspace-grid { grid-template-columns: minmax(0, 1fr); }
+  .page-heading { align-items: flex-start; flex-direction: column; }
+  .panel-heading, .panel-body, .record-row, .message-body { padding: 20px; }
+  .record-row { align-items: flex-start; }
+  .message-metadata { grid-template-columns: 64px minmax(0, 1fr); gap: 10px; }
+}

--- a/lib/cloudflare/email/management/routes.rb
+++ b/lib/cloudflare/email/management/routes.rb
@@ -1,0 +1,14 @@
+Cloudflare::Email::Management::Engine.routes.draw do
+  get "style.css", to: "styles#show", as: :style
+  root to: "mailboxes#index"
+  resources :mailboxes, only: [:index, :show, :create] do
+    member do
+      post :aliases, action: :add_address
+      post :suspend
+      post :resume
+      get "messages/:message_id", action: :message, as: :message
+      post :mark_read
+      post :archive
+    end
+  end
+end

--- a/test/management_engine_test.rb
+++ b/test/management_engine_test.rb
@@ -54,4 +54,41 @@ class ManagementEngineTest < Minitest::Test
     refute_empty templates
     assert_empty templates - specification.files
   end
+
+  def test_direct_management_require_without_active_record_eager_loads_and_returns_unavailable
+    script = <<~RUBY
+      require "tmpdir"
+      require "fileutils"
+      require "rails"
+      require "action_controller/railtie"
+      require "cloudflare/email/management"
+      require "rack/mock"
+      fixture_root = Dir.mktmpdir("cf-email-no-records")
+      ENV["RAILS_ENV"] = "test"
+      ENV["CF_MANAGEMENT_FIXTURE_ROOT"] = fixture_root
+      class ManagementWithoutRecordsFixture < Rails::Application
+        config.root = ENV.fetch("CF_MANAGEMENT_FIXTURE_ROOT")
+        config.eager_load = true
+        config.enable_reloading = false
+        config.secret_key_base = "r" * 64
+        config.hosts.clear
+        config.logger = Logger.new(File::NULL)
+      end
+      begin
+        ManagementWithoutRecordsFixture.initialize!
+        abort "ActiveRecord unexpectedly loaded" if defined?(ActiveRecord)
+        abort "mailbox persistence unexpectedly enabled" if defined?(Cloudflare::Email::Mailboxes)
+        abort "core engine missing" unless defined?(Cloudflare::Email::Engine)
+        Rails.application.routes.draw do
+          mount Cloudflare::Email::Management::Engine => "/email"
+        end
+        response = Rack::MockRequest.new(Rails.application).get("/email/mailboxes")
+        abort "expected unavailable, got \#{response.status}" unless response.status == 503
+      ensure
+        FileUtils.remove_entry(fixture_root)
+      end
+    RUBY
+    output, status = Open3.capture2e(RbConfig.ruby, "-Ilib", "-e", script)
+    assert status.success?, output
+  end
 end

--- a/test/management_engine_test.rb
+++ b/test/management_engine_test.rb
@@ -1,0 +1,57 @@
+require "test_helper"
+require "open3"
+require "rbconfig"
+
+class ManagementEngineTest < Minitest::Test
+  def test_base_client_does_not_load_the_management_engine
+    script = 'require "cloudflare-email"; abort "management loaded by default" if defined?(Cloudflare::Email::Management)'
+    output, status = Open3.capture2e(RbConfig.ruby, "-Ilib", "-e", script)
+    assert status.success?, output
+  end
+
+  def test_mounted_management_with_real_rails_sessions
+    output, status = Open3.capture2e(RbConfig.ruby, "-Ilib", File.expand_path("support/management_engine.rb", __dir__))
+    assert status.success?, output
+  end
+
+  def test_core_engine_eager_load_does_not_expose_management
+    script = <<~RUBY
+      require "tmpdir"
+      require "fileutils"
+      require "rails"
+      require "action_controller/railtie"
+      require "cloudflare-email"
+      require "cloudflare/email/engine"
+      require "rack/mock"
+      fixture_root = Dir.mktmpdir("cf-email-no-management")
+      ENV["RAILS_ENV"] = "test"
+      ENV["CF_MANAGEMENT_FIXTURE_ROOT"] = fixture_root
+      class CoreOnlyFixture < Rails::Application
+        config.root = ENV.fetch("CF_MANAGEMENT_FIXTURE_ROOT")
+        config.eager_load = true
+        config.enable_reloading = false
+        config.secret_key_base = "c" * 64
+        config.hosts.clear
+        config.logger = Logger.new(File::NULL)
+      end
+      begin
+        CoreOnlyFixture.initialize!
+        abort "management loaded without opt-in" if defined?(Cloudflare::Email::Management)
+        response = Rack::MockRequest.new(Rails.application).get("/email/mailboxes")
+        abort "management path exposed" unless response.status == 404
+      ensure
+        FileUtils.remove_entry(fixture_root)
+      end
+    RUBY
+    output, status = Open3.capture2e(RbConfig.ruby, "-Ilib", "-e", script)
+    assert status.success?, output
+  end
+
+  def test_management_templates_are_packaged
+    specification = Gem::Specification.load(File.expand_path("../cloudflare-email.gemspec", __dir__))
+    templates = Dir["app/views/cloudflare/email/management/**/*.erb", "app/views/layouts/cloudflare/email/management.html.erb",
+      "lib/cloudflare/email/management/*.css"]
+    refute_empty templates
+    assert_empty templates - specification.files
+  end
+end

--- a/test/support/activerecord_tenanted.rb
+++ b/test/support/activerecord_tenanted.rb
@@ -82,7 +82,9 @@ class ActualTenantedMailboxTest < Minitest::Test
   def test_actual_library_isolates_same_numeric_ids_and_restores_context
     records = %w[alpha beta].map do |key|
       Tenancy.with(key) do
-        mailbox = Mailboxes::Mailbox.create!(name: key, tenant_key: key, state: "active")
+        # Exercise an intentional ID collision independently of test order:
+        # deleting rows does not reset each SQLite database's sequence.
+        mailbox = Mailboxes::Mailbox.create!(id: 123, name: key, tenant_key: key, state: "active")
         assert_equal key, mailbox.tenant
         assert_equal key, TenantRecord.current_tenant
         assert_equal [key], Mailboxes::Mailbox.pluck(:name)

--- a/test/support/management_engine.rb
+++ b/test/support/management_engine.rb
@@ -1,0 +1,379 @@
+require_relative "../test_helper"
+require "tmpdir"
+require "fileutils"
+require "rails"
+require "active_record/railtie"
+require "action_controller/railtie"
+require "action_mailer/railtie"
+require "active_job/railtie"
+require "active_storage/engine"
+require "action_mailbox/engine"
+require "cloudflare/email/mailboxes"
+require "cloudflare/email/management"
+require "rack/test"
+require "nokogiri"
+
+MANAGEMENT_ROOT = Dir.mktmpdir("cf-email-management")
+ENV["RAILS_ENV"] = "test"
+ENV["DATABASE_URL"] = "sqlite3:#{MANAGEMENT_ROOT}/test.sqlite3"
+Minitest.after_run do
+  ActiveRecord::Base.connection_handler.clear_all_connections!
+  FileUtils.remove_entry(MANAGEMENT_ROOT)
+end
+
+class ManagementFixtureApp < Rails::Application
+  config.root = MANAGEMENT_ROOT
+  config.eager_load = false
+  config.enable_reloading = false
+  config.secret_key_base = "m" * 64
+  config.hosts.clear
+  config.logger = Logger.new(File::NULL)
+  config.action_dispatch.show_exceptions = :rescuable
+  config.action_controller.allow_forgery_protection = true
+  config.active_job.queue_adapter = :test
+  config.active_storage.service = :local
+  config.active_storage.service_configurations = {
+    local: { service: "Disk", root: "#{MANAGEMENT_ROOT}/blobs" }
+  }
+end
+ManagementFixtureApp.initialize!
+
+class ManagementFixtureLoginController < ActionController::Base
+  # Synthetic local harness only: provides a real cookie-backed host session.
+  def create
+    session[:owner] = "owner-1"
+    head :ok
+  end
+end
+Rails.application.routes.draw do
+  post "/fixture-login", to: "management_fixture_login#create"
+  mount Cloudflare::Email::Management::Engine => "/nested/email"
+end
+
+class ManagementFixtureAdapter < Cloudflare::Email::Management::Adapter
+  class_attribute :denied_actions, default: []
+  class_attribute :permitted_domains, default: ["example.test"]
+  class_attribute :unscoped_mailboxes, default: false
+
+  def initialize(controller)
+    @controller = controller
+  end
+
+  def authenticate! = @controller.session[:owner] == "owner-1"
+  def tenant_key = "workspace"
+  def mailboxes(session)
+    scope = self.class.unscoped_mailboxes ? Cloudflare::Email::Mailboxes::Mailbox.all : session.mailboxes
+    scope.where(owner_ref: @controller.session[:owner])
+  end
+  def allowed?(action, mailbox = nil) = !self.class.denied_actions.include?(action.to_sym)
+  def domains(session) = self.class.permitted_domains
+
+  def create_mailbox(session, name:, address:)
+    session.create(name: name, address: address, owner_ref: @controller.session[:owner])
+  end
+end
+
+class ManagementWrongOwnerAdapter < ManagementFixtureAdapter
+  def create_mailbox(session, name:, address:)
+    session.create(name: name, address: address, owner_ref: "owner-2")
+  end
+end
+
+class ManagementInvalidTenantAdapter < ManagementFixtureAdapter
+  def tenant_key = nil
+end
+
+ActiveRecord::Migration.verbose = false
+%w[activestorage actionmailbox].each do |name|
+  Dir["#{Gem.loaded_specs.fetch(name).full_gem_path}/db/migrate/*.rb"].each { |path| require path }
+end
+%w[outbox/templates/create_cloudflare_email_outbox tracking/templates/create_cloudflare_email_event_receipts
+   mailboxes/templates/create_cloudflare_email_receiving_domains mailboxes/templates/create_cloudflare_email_mailboxes
+   mailboxes/templates/create_cloudflare_email_shared_events].each { |path| require "generators/cloudflare/email/#{path}" }
+[CreateActiveStorageTables, CreateActionMailboxTables, CreateCloudflareEmailOutbox,
+ CreateCloudflareEmailEventReceipts, CreateCloudflareEmailReceivingDomains,
+ CreateCloudflareEmailSharedEvents, CreateCloudflareEmailMailboxes].each { |migration| migration.new.migrate(:up) }
+
+class ManagementEngineIntegrationTest < Minitest::Test
+  include Rack::Test::Methods
+  Email = Cloudflare::Email
+  PREFIX = "/nested/email"
+  def app = Rails.application
+
+  def setup
+    clear_cookies
+    ManagementFixtureAdapter.denied_actions = []
+    ManagementFixtureAdapter.permitted_domains = ["example.test"]
+    ManagementFixtureAdapter.unscoped_mailboxes = false
+    Email::Management.configure { |config| config.adapter = ->(controller) { ManagementFixtureAdapter.new(controller) } }
+    ActiveRecord::Base.connection.disable_referential_integrity do
+      ActiveRecord::Base.connection.tables.each do |table|
+        next if %w[schema_migrations ar_internal_metadata].include?(table)
+        ActiveRecord::Base.connection.execute("DELETE FROM #{ActiveRecord::Base.connection.quote_table_name(table)}")
+      end
+    end
+    %w[example.test hidden.test].each do |name|
+      domain = Email::Mailboxes.register_domain(domain: name, tenant_key: "workspace", account_id: "synthetic-account")
+      Email::Mailboxes.activate_domain!(domain.id, evidence: "local fixture")
+    end
+    domain = Email::Mailboxes.register_domain(domain: "other.test", tenant_key: "other", account_id: "synthetic-account")
+    Email::Mailboxes.activate_domain!(domain.id, evidence: "local fixture")
+    with_session do |session|
+      @owned = session.create(name: "Owner inbox", address: "owner@example.test", owner_ref: "owner-1")
+      @private = session.create(name: "Private owner inbox", address: "private@example.test", owner_ref: "owner-2")
+    end
+    Email::Mailboxes.for_tenant("other") do |session|
+      @other = session.create(name: "Other tenant inbox", address: "box@other.test", owner_ref: "owner-1")
+    end
+    post "/fixture-login"
+    assert_equal 200, last_response.status
+  end
+
+  def with_session(&block) = Email::Mailboxes.for_tenant("workspace", &block)
+  def mailbox_path(mailbox = @owned) = "#{PREFIX}/mailboxes/#{mailbox.id}"
+  def html = Nokogiri::HTML(last_response.body)
+
+  def token(path = "#{PREFIX}/mailboxes")
+    get path
+    assert_equal 200, last_response.status, last_response.body
+    node = html.at_css('input[name="authenticity_token"]') || html.at_css('meta[name="csrf-token"]')
+    refute_nil node, "rendered management form needs a CSRF token"
+    node["value"] || node["content"]
+  end
+
+  def mutate(path, params = {}, source: mailbox_path)
+    csrf = token(source)
+    post path, params.merge(authenticity_token: csrf)
+  end
+
+  def test_opt_in_keeps_database_tenancy_disabled_and_scopes_index
+    refute Email::Tenancy.enabled?
+    get "#{PREFIX}/mailboxes"
+    assert_equal 200, last_response.status
+    assert_includes last_response.body, "Owner inbox"
+    refute_includes last_response.body, "Private owner inbox"
+    refute_includes last_response.body, "Other tenant inbox"
+    html.css("form[action]").each { |form| assert form["action"].start_with?(PREFIX), form["action"] }
+    assert_includes last_response.headers["cache-control"], "no-store"
+    assert_includes last_response.headers["content-security-policy"], "frame-ancestors 'none'"
+    assert_includes last_response.headers["content-security-policy"], "default-src 'none'"
+    # Same-origin form requests need a usable Origin for Rails CSRF validation.
+    # Cross-origin destinations still receive no mailbox URL in their Referer.
+    assert_equal "same-origin", last_response.headers["referrer-policy"]
+    assert_nil Email::Tenancy.current_key
+    stylesheet = html.at_css('link[rel="stylesheet"]')["href"]
+    assert stylesheet.start_with?(PREFIX), stylesheet
+    get stylesheet
+    assert_equal 200, last_response.status
+    assert_includes last_response.headers["content-type"], "text/css"
+    assert_includes last_response.body, ".shell"
+  end
+
+  def test_anonymous_unconfigured_and_default_adapters_fail_closed
+    clear_cookies
+    get "#{PREFIX}/mailboxes"
+    assert_equal 401, last_response.status
+    Email::Management.configure { |config| config.adapter = nil }
+    get "#{PREFIX}/mailboxes"
+    assert_equal 503, last_response.status
+    Email::Management.configure { |config| config.adapter = ->(controller) { Email::Management::Adapter.new(controller) } }
+    get "#{PREFIX}/mailboxes"
+    assert_equal 401, last_response.status
+  end
+
+  def test_owner_and_tenant_boundaries
+    [@private, @other].each do |box|
+      get mailbox_path(box)
+      assert_equal 404, last_response.status
+      mutate "#{mailbox_path(box)}/suspend"
+      assert_equal 404, last_response.status
+      assert_equal "active", box.reload.state
+    end
+  end
+
+  def test_invalid_host_tenant_configuration_returns_unavailable
+    Email::Management.configure { |config| config.adapter = ->(controller) { ManagementInvalidTenantAdapter.new(controller) } }
+    get "#{PREFIX}/mailboxes"
+    assert_equal 503, last_response.status
+    refute_includes last_response.body, "Owner inbox"
+    assert_nil last_response.headers["location"]
+    assert_nil Email::Tenancy.current_key
+  end
+
+  def test_custom_create_hook_cannot_leave_invisible_mailboxes_or_addresses
+    csrf = token
+    Email::Management.configure { |config| config.adapter = ->(controller) { ManagementWrongOwnerAdapter.new(controller) } }
+    mailbox_count = Email::Mailboxes::Mailbox.count
+    address_count = Email::Mailboxes::Address.count
+    post "#{PREFIX}/mailboxes", authenticity_token: csrf, mailbox: { name: "Wrong owner", address: "wrong-owner@example.test" }
+    assert_equal 404, last_response.status
+    assert_equal mailbox_count, Email::Mailboxes::Mailbox.count
+    assert_equal address_count, Email::Mailboxes::Address.count
+    refute Email::Mailboxes::Mailbox.exists?(name: "Wrong owner")
+    refute Email::Mailboxes::Address.exists?(address: "wrong-owner@example.test")
+    assert_nil Email::Tenancy.current_key
+  end
+
+  def test_host_scope_cannot_accidentally_remove_tenant_filter
+    ManagementFixtureAdapter.unscoped_mailboxes = true
+    get "#{PREFIX}/mailboxes"
+    assert_equal 200, last_response.status
+    refute_includes last_response.body, "Other tenant inbox"
+    get mailbox_path(@other)
+    assert_equal 404, last_response.status
+  end
+
+  def test_permissions_block_reads_and_writes
+    csrf = token
+    ManagementFixtureAdapter.denied_actions = %i[index show create suspend]
+    get "#{PREFIX}/mailboxes"
+    assert_equal 403, last_response.status
+    get mailbox_path
+    assert_equal 403, last_response.status
+    post "#{PREFIX}/mailboxes", authenticity_token: csrf, mailbox: { name: "Forbidden", address: "new@example.test" }
+    assert_equal 403, last_response.status
+    post "#{mailbox_path}/suspend", authenticity_token: csrf
+    assert_equal 403, last_response.status
+    assert_equal "active", @owned.reload.state
+    with_session { |session| refute session.mailboxes.exists?(name: "Forbidden") }
+  end
+
+  def test_create_and_alias_are_pending_and_cannot_claim_disallowed_domains
+    mutate "#{PREFIX}/mailboxes", { mailbox: { name: "New inbox", address: "new@example.test", owner_ref: "owner-2", tenant_key: "other" } }, source: "#{PREFIX}/mailboxes"
+    assert_includes [302, 303], last_response.status
+    with_session do |session|
+      box = session.mailboxes.find_by!(name: "New inbox")
+      assert_equal "owner-1", box.owner_ref
+      assert_equal "workspace", box.tenant_key
+      assert_equal "pending", session.addresses(box.id).first.state
+    end
+    mutate "#{mailbox_path}/aliases", { address: "alias@example.test" }
+    assert_includes [302, 303], last_response.status
+    with_session { |session| assert_equal "pending", session.addresses(@owned.id).find_by!(address: "alias@example.test").state }
+    %w[hidden.test other.test unregistered.test].each do |domain|
+      mutate "#{PREFIX}/mailboxes", { mailbox: { name: "Rejected", address: "new@#{domain}" } }, source: "#{PREFIX}/mailboxes"
+      assert_includes [303, 403, 422], last_response.status
+      mutate "#{mailbox_path}/aliases", { address: "alias@#{domain}" }
+      assert_includes [303, 403, 422], last_response.status
+    end
+    with_session do |session|
+      refute session.mailboxes.exists?(name: "Rejected")
+      assert_equal 2, session.addresses(@owned.id).count
+    end
+    refute Email::Mailboxes::ReceivingDomain.exists?(domain: "unregistered.test")
+  end
+
+  def test_csrf_and_http_methods_protect_mutations
+    post "#{mailbox_path}/suspend"
+    assert_equal 422, last_response.status
+    post "#{mailbox_path}/suspend", authenticity_token: "invalid"
+    assert_equal 422, last_response.status
+    get "#{mailbox_path}/suspend"
+    assert_includes [404, 405], last_response.status
+    assert_equal "active", @owned.reload.state
+    csrf = token
+    post "#{mailbox_path}/suspend", { authenticity_token: csrf }, "HTTP_ORIGIN" => "https://other.example"
+    assert_equal 422, last_response.status
+    assert_equal "active", @owned.reload.state
+    post "#{mailbox_path}/suspend", { authenticity_token: csrf }, "HTTP_ORIGIN" => "http://example.org"
+    assert_equal 303, last_response.status
+    assert_equal "suspended", @owned.reload.state
+  end
+
+  def test_suspension_is_reversible_and_retains_membership_and_raw_mail
+    member, inbound = incoming(@owned)
+    mutate "#{mailbox_path}/suspend"
+    assert_includes [302, 303], last_response.status
+    assert_equal "suspended", @owned.reload.state
+    assert Email::Mailboxes::Message.exists?(member.id)
+    assert inbound.reload.raw_email.attached?
+    mutate "#{mailbox_path}/resume"
+    assert_includes [302, 303], last_response.status
+    assert_equal "active", @owned.reload.state
+  end
+
+  def incoming(box, html_only: false)
+    raw = "From: sender@example.test\r\nTo: owner@example.test\r\nSubject: Local fixture\r\nMessage-ID: <#{SecureRandom.uuid}@example.test>\r\nContent-Type: #{html_only ? 'text/html' : 'text/plain'}; charset=UTF-8\r\n\r\n<script>alert('fixture')</script><img src=\"https://remote.example/tracker\">\r\n"
+    with_session do
+      inbound = ActionMailbox::InboundEmail.create_and_extract_message_id!(raw)
+      member = Email::Mailboxes::Message.create!(mailbox: box, tenant_key: "workspace", inbound_email_id: inbound.id, recipient: "owner@example.test")
+      [member, inbound]
+    end
+  end
+
+  def test_message_preview_escapes_content_and_scopes_membership
+    member, = incoming(@owned)
+    foreign, = incoming(@private)
+    @owned.update!(name: "<script>unsafe name</script>")
+    get mailbox_path
+    assert_equal 200, last_response.status
+    refute_includes last_response.body, "<script>unsafe name</script>"
+    get "#{mailbox_path}/messages/#{member.id}"
+    assert_equal 200, last_response.status
+    assert_includes html.text, "alert('fixture')"
+    assert_empty html.css('script, img[src^="https://remote.example"], iframe, object, embed')
+    get "#{mailbox_path}/messages/#{foreign.id}"
+    assert_equal 404, last_response.status
+    mutate "#{mailbox_path}/mark_read", { message_id: foreign.id, read: "true" }
+    assert_equal 404, last_response.status
+    assert_nil foreign.reload.read_at
+    mutate "#{mailbox_path}/archive", { message_id: foreign.id, archived: "true" }
+    assert_equal 404, last_response.status
+    assert_nil foreign.reload.archived_at
+    mutate "#{mailbox_path}/mark_read", { message_id: member.id, read: "true" }
+    assert_includes [302, 303], last_response.status
+    refute_nil member.reload.read_at
+    mutate "#{mailbox_path}/mark_read", { message_id: member.id, read: "false" }
+    assert_includes [302, 303], last_response.status
+    assert_nil member.reload.read_at
+    mutate "#{mailbox_path}/archive", { message_id: member.id, archived: "true" }
+    assert_includes [302, 303], last_response.status
+    refute_nil member.reload.archived_at
+    mutate "#{mailbox_path}/archive", { message_id: member.id, archived: "false" }
+    assert_includes [302, 303], last_response.status
+    assert_nil member.reload.archived_at
+    assert ActionMailbox::InboundEmail.exists?(member.inbound_email_id)
+  end
+
+  def test_html_only_mail_never_embeds_sender_html
+    member, = incoming(@owned, html_only: true)
+    get "#{mailbox_path}/messages/#{member.id}"
+    assert_equal 200, last_response.status
+    assert_empty html.css('script, img, iframe, object, embed')
+  end
+
+  def test_each_message_and_alias_operation_requires_permission
+    member, = incoming(@owned)
+    csrf = token
+    ManagementFixtureAdapter.denied_actions = %i[show_message mark_read archive add_address resume]
+    get "#{mailbox_path}/messages/#{member.id}"
+    assert_equal 403, last_response.status
+    %w[mark_read archive].each do |action|
+      post "#{mailbox_path}/#{action}", authenticity_token: csrf, message_id: member.id
+      assert_equal 403, last_response.status
+    end
+    post "#{mailbox_path}/aliases", authenticity_token: csrf, address: "forbidden@example.test"
+    assert_equal 403, last_response.status
+    @owned.update!(state: "suspended")
+    post "#{mailbox_path}/resume", authenticity_token: csrf
+    assert_equal 403, last_response.status
+    assert_equal "suspended", @owned.reload.state
+    assert_nil member.reload.read_at
+    assert_nil member.archived_at
+    with_session { |session| assert_equal 1, session.addresses(@owned.id).count }
+  end
+
+  def test_invalid_pagination_and_boolean_inputs_do_not_mutate_or_raise
+    ["-1", "no-number", "9" * 50].each do |cursor|
+      get "#{PREFIX}/mailboxes", after: cursor
+      assert_includes [303, 422], last_response.status
+    end
+    member, = incoming(@owned)
+    mutate "#{mailbox_path}/mark_read", { message_id: member.id, read: "unexpected" }
+    assert_includes [303, 422], last_response.status
+    assert_nil member.reload.read_at
+    mutate "#{mailbox_path}/archive", { message_id: member.id, archived: "unexpected" }
+    assert_includes [303, 422], last_response.status
+    assert_nil member.reload.archived_at
+  end
+end

--- a/test/support/management_engine.rb
+++ b/test/support/management_engine.rb
@@ -376,4 +376,15 @@ class ManagementEngineIntegrationTest < Minitest::Test
     assert_includes [303, 422], last_response.status
     assert_nil member.reload.archived_at
   end
+
+  def test_malformed_mailbox_parameter_shapes_do_not_create_records_or_raise
+    mailbox_count = Email::Mailboxes::Mailbox.count
+    address_count = Email::Mailboxes::Address.count
+    ["scalar", ["array"]].each do |value|
+      mutate "#{PREFIX}/mailboxes", { mailbox: value }, source: "#{PREFIX}/mailboxes"
+      assert_equal 303, last_response.status
+      assert_equal mailbox_count, Email::Mailboxes::Mailbox.count
+      assert_equal address_count, Email::Mailboxes::Address.count
+    end
+  end
 end


### PR DESCRIPTION
Rails hosts can now mount a mailbox management interface without adopting a frontend framework. The opt-in engine uses server-rendered HTML, ordinary Rails forms and bundled CSS, and works with JavaScript disabled.

It provides mailbox creation, aliases, receiving setup status, suspension/resumption, paginated received messages, escaped plain-text previews and optional read/archive controls. Host adapters supply authentication, tenant resolution, mailbox/domain entitlement and per-action authorization; custom creation/alias hooks reuse existing product provisioning.

The core gem never mounts the interface. Private pages use no-store caching and restrictive CSP; real forms retain CSRF and origin validation. Domain verification, DNS/routing changes, sending, permanent deletion and full compose/conversation UI remain explicit application/API responsibilities.

Validation: full gem suite 217 tests/766 assertions; management integration 15 cases/216 assertions with real Rails sessions, tenant/owner boundaries, permission enforcement, rollback and safe previews. Rails 7.2/8.0/8.1 checked. The agentic inbox example verifies desktop/mobile Chromium, actual form submission with JavaScript disabled, CSS loading and coexistence with Inertia. Browser testing caught and fixed the no-referrer/Origin:null incompatibility with Rails origin checks. CI also exposed an order-dependent SQLite test; its explicit numeric ID collision now tests the intended isolation deterministically.

Stacked on #10 (strict-readonly compatibility); not a new published release. See docs/management-engine.md for setup and the host adapter contract.
