### PR TITLE
Support existing email pipelines with custom ingress and routing diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## Unreleased
 
+- Add a bounded, Rails-independent `Ingress.verify` API for existing ingestion
+  pipelines, with optional ActionMailbox persistence and tenant registry routing.
+- Add opt-in v3 signatures for provider metadata supplied by custom Workers.
+  Metadata is authenticated transport evidence, not proof of sender authenticity.
+  Default Worker forwarding remains v2; upgrade Rails before enabling v3.
+- Verify signatures against exact timestamp header bytes; decimal parsing is
+  used only for freshness. The bundled Worker's timestamp format is unchanged.
+- Add GET-only `cloudflare:email:check_route` diagnostics for exact receiving-domain
+  DNS and Worker routing. Reports uncertainty without changing configuration or
+  claiming live delivery is verified.
+
 - Add an opt-in server-rendered mailbox management engine with host authentication,
   mailbox/domain scoping and per-action permissions. Manage mailboxes and aliases,
   suspend/resume, preview plain-text messages and mark read/archive without

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Version **0.2.0**. Ruby 3.2+, Rails 7.2–8.1; Ruby 4.0 is tested with Rails 8.1
 | [Troubleshooting](docs/troubleshooting.md) | What to check when mail or delivery updates do not arrive |
 | [Managed mailboxes](docs/mailboxes.md) | Create inboxes and aliases, read/archive mail, and send from a mailbox |
 | [Management engine (unreleased)](docs/management-engine.md) | Mount an optional server-rendered mailbox UI using your app's authentication |
+| [Custom ingress (unreleased)](docs/custom-ingress.md) | Reuse authentication, signed metadata, and tenant routing in your existing ingestion pipeline |
+| [Routing diagnostics (unreleased)](docs/routing-diagnostics.md) | Inspect exact-domain DNS and Worker routes without changing infrastructure |
 | [SQLite tenant databases](docs/activerecord-tenanted.md) | Give each organization its own SQLite database with `activerecord-tenanted` |
 | [Durable outbox](docs/outbox.md) | Detailed setup, callbacks, retries, and recovery |
 | [Delivery events](docs/delivery-events.md) | Cloudflare Queue setup and recipient status tracking |
@@ -229,7 +231,7 @@ end
 
 `Cloudflare::Email::Envelope.for(inbound_email)` returns a string-keyed `{"from" => "sender@example.com", "to" => "support@example.com"}` hash, or `nil` when the record has no authenticated envelope (for example, another ingress). The metadata is stored on the raw-email blob before routing jobs enqueue. It does not modify the MIME source. Envelope sender information records the SMTP reverse path; it does not authenticate the human sender. An empty `from` is valid for bounces.
 
-Version 0.2 requires the bundled v2 Worker; missing or v1 signatures are rejected. Coordinate Rails and Worker deployment while ingress is paused. The Worker requires ASCII dot-atom addresses, at most 254 bytes with a 64-byte local part. Quoted local parts, address literals, and internationalized addresses are not supported by this envelope format.
+The bundled Worker uses v2 signatures by default; missing or v1 signatures are rejected. The unreleased custom-ingress API also supports opt-in v3 signatures carrying authenticated Worker metadata. See [custom ingestion](docs/custom-ingress.md) and upgrade the Rails receiver before enabling v3 in a custom Worker. When upgrading from v1, coordinate Rails and Worker deployment while ingress is paused. Both envelope versions require ASCII dot-atom addresses, at most 254 bytes with a 64-byte local part. Quoted local parts, address literals, and internationalized addresses are not supported by this envelope format.
 
 Successful ingress storage returns HTTP 200; duplicate storage returns 200 too. The timestamp window limits request age, but is not a one-time replay ledger. Version 2 deduplication includes the exact SMTP recipient, so identical MIME delivered to separate To/Cc/Bcc recipients creates separate inbound records while a retry for the same recipient creates none.
 

--- a/app/controllers/cloudflare/email/ingress_controller.rb
+++ b/app/controllers/cloudflare/email/ingress_controller.rb
@@ -1,16 +1,12 @@
-require "cloudflare/email/verification"
+require "cloudflare/email/ingress"
 
 module Cloudflare
   module Email
     # ActionMailbox ingress for Cloudflare Email Worker forwards.
     #
-    # The shipped Worker template signs each forwarded message with HMAC-SHA256
-    # over "v2.{timestamp}.{encoded_envelope}.{raw_body}" and sends:
-    #   X-CF-Email-Timestamp: <unix seconds>
-    #   X-CF-Email-Signature: <hex digest>
-    #   X-CF-Email-Signature-Version: 2
-    #   X-CF-Email-Envelope: <unpadded base64url JSON from/to>
-    # Requests must include the v2 signature and authenticated SMTP envelope.
+    # The default Worker uses v2 authenticated SMTP envelopes; custom Workers
+    # can opt into v3 to authenticate additional provider metadata. Both use
+    # the shared, bounded Ingress verifier before any tenant lookup or storage.
     #
     # Set the shared secret in Rails credentials under cloudflare.ingress_secret
     # (or in the CLOUDFLARE_INGRESS_SECRET env var) and as the Worker secret
@@ -24,45 +20,30 @@ module Cloudflare
           "cloudflare_email.ingress",
           bytes: 0,
         ) do |payload|
-          preflight = Cloudflare::Email::Verification.verify_headers(secret: secret,
-            timestamp: request.headers["X-CF-Email-Timestamp"],
-            signature: request.headers["X-CF-Email-Signature"],
-            version: request.headers["X-CF-Email-Signature-Version"],
-            envelope: request.headers["X-CF-Email-Envelope"])
-          unless preflight == :ok
-            payload[:result] = preflight
-            next head(preflight == :stale ? :request_timeout : :unauthorized)
-          end
-          if request.content_length.to_i > max_email_bytes || raw_body.bytesize > max_email_bytes
-            payload[:result] = :too_large
-            next head(:payload_too_large)
-          end
-          payload[:bytes] = raw_body.bytesize
-          case Cloudflare::Email::Verification.verify(
-                secret:    secret,
-                body:      raw_body,
-                timestamp: request.headers["X-CF-Email-Timestamp"],
-                signature: request.headers["X-CF-Email-Signature"],
-                version: request.headers["X-CF-Email-Signature-Version"],
-                envelope: request.headers["X-CF-Email-Envelope"],
-              )
+          request.body.rewind if request.body.respond_to?(:rewind)
+          result = Cloudflare::Email::Ingress.verify(secret: secret,
+            headers: request.headers, body: request.body,
+            content_length: request.content_length, max_email_bytes: max_email_bytes)
+          payload[:bytes] = result.bytes.to_i
+          payload[:result] = result.status
+          case result.status
           when :stale
-            payload[:result] = :stale
             head :request_timeout
           when :bad_signature
-            payload[:result] = :bad_signature
             head :unauthorized
+          when :too_large
+            head :payload_too_large
           when :ok
             inbound = if defined?(Cloudflare::Email::Mailboxes) && Cloudflare::Email::Mailboxes.enabled?
-              recipient = Cloudflare::Email::Envelope.decode(request.headers["X-CF-Email-Envelope"]).fetch("to")
+              recipient = result.message.envelope.fetch("to")
               begin
-                Cloudflare::Email::Mailboxes.receive(recipient: recipient) { persist_inbound }
+                Cloudflare::Email::Mailboxes.receive(recipient: recipient) { result.message.persist_action_mailbox! }
               rescue Cloudflare::Email::Mailboxes::Unavailable
                 payload[:result] = :unavailable_mailbox
                 next head(:unprocessable_entity)
               end
             else
-              persist_inbound
+              result.message.persist_action_mailbox!
             end
             payload[:result]     = inbound ? :ok : :duplicate
             payload[:message_id] = inbound&.message_id
@@ -73,35 +54,10 @@ module Cloudflare
 
       private
 
-      def persist_inbound
-        envelope = Cloudflare::Email::Envelope.decode(request.headers["X-CF-Email-Envelope"])
-
-        # Commit trusted routing metadata before ActionMailbox's after_create_commit
-        # enqueues routing. Identical MIME for To/Cc/Bcc recipients is independent.
-        checksum = OpenSSL::Digest::SHA256.hexdigest("v2\0#{envelope.fetch('to')}\0".b + raw_body.b)
-        ActionMailbox::InboundEmail.transaction do
-          inbound = ActionMailbox::InboundEmail.create_and_extract_message_id!(raw_body, message_checksum: checksum)
-          if inbound
-            blob = inbound.raw_email.blob
-            blob.update!(metadata: blob.metadata.merge(
-              Cloudflare::Email::Envelope::METADATA_KEY => envelope.merge("version" => 2),
-            ))
-          end
-          inbound
-        end
-      end
-
       # Override ActionMailbox::BaseController's default name inference so
       # `config.action_mailbox.ingress = :cloudflare` gates this controller.
       def ingress_name
         :cloudflare
-      end
-
-      def raw_body
-        @raw_body ||= begin
-          request.body.rewind if request.body.respond_to?(:rewind)
-          request.body.read(max_email_bytes + 1).to_s
-        end
       end
 
       def max_email_bytes

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -14,7 +14,7 @@ durable infrastructure without copying the reference inbox's models and services
 | Shared event intake, tenant correlation and tenant-aware jobs | Durable queue workers, scheduled recovery and schema rollout to every tenant |
 | Structured/raw sending and ActionMailer transport | Compose UI, recipients and send authorization |
 | `Response#accepted?`, plus individual recipient outcomes | Handle partial acceptance without resending accepted recipients |
-| Authenticated v2 ingress and recipient-scoped deduplication | Map trusted recipient to an authorized mailbox |
+| Authenticated ingress (default v2; unreleased opt-in v3 [metadata](custom-ingress.md)) and context-scoped deduplication | Map trusted recipient to an authorized mailbox; apply sender and document policy |
 | `MessageId.normalize` and returned provider IDs | Store conversation membership and scope reply lookups |
 | Queue decoding, validation and ACK | Queue/subscription setup and recurring execution |
 | Optional ActiveRecord event receipts, deduplication and indexed replay | Configure queue polling and receipt retention |

--- a/docs/custom-ingress.md
+++ b/docs/custom-ingress.md
@@ -1,0 +1,128 @@
+# Use your existing inbound email pipeline
+
+This integration API is unreleased and is not included in gem version 0.2.0.
+
+You can adopt mailbox registration without replacing your Worker, document processing, sender review, or archive. Use the gem to authenticate the request and resolve an accepted address, then keep your application's policy and processing.
+
+A useful starting point is one mailbox per site: an organization owns a receiving domain, a site owns a mailbox, and that mailbox can have several accepted addresses. This is an application convention, not a requirement of the gem. Database tenancy is optional; a single SQLite database works too.
+
+## Register addresses before accepting mail
+
+Follow [mailbox setup](mailboxes.md) to register and activate the receiving domain and accepted addresses. With existing catch-all Worker routing, address creation can be a database operation once an administrator has confirmed that routing covers the exact domain. Registering a domain does not create DNS records or extend wildcard coverage.
+
+Use the same provisioning service from organization/site onboarding and from the management UI. Keep a stable site reference in the mailbox's `owner_ref`; keep site permissions, slug changes, document workflows, and sender allowlists in your app. Treat a rename as an explicit alias/lifecycle decision so old addresses are not accidentally lost.
+
+For separate organization databases, configure [the SQLite tenant adapter](activerecord-tenanted.md) before loading mailbox models. The shared directory resolves the signed recipient to a tenant. Action Mailbox, Active Storage, and the gem's mailbox records must all use that tenant's connection.
+
+## Verify a custom endpoint before writing anything
+
+`Cloudflare::Email::Ingress.verify` is usable outside the bundled controller. It accepts a String or IO body, bounds the raw body size, and returns an immutable result. Successful verification exposes the exact binary body and authenticated envelope; rejected requests expose no verified message.
+
+The following controller is a starting point for a host with registered mailboxes:
+
+```ruby
+require "cloudflare/email/ingress"
+
+class InboundEmailsController < ActionController::API
+  def create
+    result = Cloudflare::Email::Ingress.verify(
+      secret: Rails.application.credentials.dig(:cloudflare, :ingress_secret),
+      headers: request.headers,
+      body: request.body,
+      content_length: request.content_length,
+      max_email_bytes: 25 * 1024 * 1024
+    )
+
+    case result.status
+    when :too_large
+      return head :payload_too_large
+    when :bad_signature, :stale
+      return head :unauthorized
+    end
+
+    verified = result.message
+
+    Cloudflare::Email::Mailboxes.receive(
+      recipient: verified.envelope.fetch("to")
+    ) do
+      # This block runs in the recipient's tenant. Apply your sender/review
+      # policy here, before persistence schedules Action Mailbox routing.
+      # Your policy may raise a host error or return nil instead of persisting.
+      verified.persist_action_mailbox!
+    end
+
+    head :ok
+  rescue Cloudflare::Email::Mailboxes::Unavailable
+    head :unprocessable_entity
+  end
+end
+```
+
+Mount this controller at your own route and point your existing Worker there. The host owns response codes and retry policy. If your policy returns nil and you acknowledge the request, you are accepting responsibility for that email: persist a durable review record or deliberately discard it according to your application's policy. A successful verification alone does not queue processing or create a mailbox.
+
+Do not use the MIME `To` header or an unauthenticated URL subdomain to select storage. `verified.envelope.fetch("to")` is the signed SMTP recipient. `Mailboxes.receive` checks that its domain, mailbox, and accepted address are active before entering the persistence block.
+
+`persist_action_mailbox!` stores the verified raw bytes and metadata in Action Mailbox. The receiving block adds mailbox membership in the same tenant transaction. Rails schedules normal routing after the transaction commits. Apply policies that must stop processing before calling persistence; a check performed after receiving returns can be too late.
+
+For an application that owns a different raw-email store, use `verified.body`, `verified.envelope`, `verified.provider_metadata`, `verified.message_checksum`, and `verified.storage_metadata` with your own persistence/transaction system. `Mailboxes.receive` specifically expects an Action Mailbox inbound email record (or nil) from its block; do not pass an unrelated processing record. The gem does not choose your archive retention, held-message model, or document queue.
+
+## Carry Worker metadata with authenticated provenance
+
+The default Worker protocol remains v2: it authenticates the raw message and SMTP envelope. Optional v3 also authenticates a bounded metadata object:
+
+```json
+{
+  "source": "cloudflare",
+  "data": {
+    "archive_key": "inbound/example.eml"
+  }
+}
+```
+
+The `archive_key` above is an illustrative application-defined value. The gem does not fetch that object or verify an archive exists. Your trusted Worker constructs the data from sources whose provenance you understand.
+
+V3 binds the encoded metadata to the timestamp, envelope, and exact raw bytes. The `X-CF-Email-Metadata` header is unpadded base64url UTF-8 JSON. Metadata attached to a v2 request is rejected rather than treated as authenticated. Existing v2 requests without metadata continue to work.
+
+The Worker template exports `signedEmailHeaders` for an existing transport and `forwardEmail` for the bundled forwarding behavior. Keep your current archive and retry handling, and use the header builder to authenticate the original raw bytes:
+
+```js
+import { signedEmailHeaders } from "./cloudflare-ingress.js";
+
+const headers = await signedEmailHeaders({
+  secret: env.INGRESS_SECRET,
+  raw, // Uint8Array from your bounded reader
+  from: message.from,
+  to: message.to,
+  metadata: { source: "cloudflare", data: { archive_key: archiveKey } },
+});
+// Send exactly raw with these headers using your existing transport.
+```
+
+Here `cloudflare-ingress.js` is your local copy of the template's `src/index.js`. `raw` and `archiveKey` come from your existing bounded reader and archive operation. See the [Worker integration instructions](../templates/worker/README.md) for supported metadata values and forwarding behavior. Upgrade the Rails receiver before enabling v3 in the Worker.
+
+In your Action Mailbox handler, read persisted metadata through the gem:
+
+```ruby
+require "cloudflare/email/provider_metadata"
+
+metadata = Cloudflare::Email::ProviderMetadata.for(inbound_email)
+archive_key = metadata&.dig("data", "archive_key")
+```
+
+This reads verified Active Storage metadata, not similarly named MIME headers. Authenticate your Worker first and preserve the verified object unchanged. Avoid adding secrets or unnecessary personal information to provider metadata.
+
+**A valid Worker signature proves that your trusted Worker submitted the request. It does not prove the original email sender is authentic.** Even metadata labelled `source: "cloudflare"` is an assertion made by the holder of the ingress secret. Do not copy sender-controlled MIME headers into a “trusted authentication” field. If your existing Worker has reliable authentication evidence, preserve its documented provenance and let your application decide how that evidence affects acceptance. The gem intentionally does not infer SPF/DMARC results or implement a sender allowlist.
+
+Retries with the same recipient, raw bytes, and metadata context reuse the inbound record. Aliases receive distinct membership context. Changing signed metadata produces a distinct checksum: stable values are preferable to per-attempt timestamps or random IDs. Keep downstream document extraction and external side effects idempotent too.
+
+## Adopt incrementally
+
+1. Inventory existing accepted addresses, organization/subdomain mappings, fallback destinations, and disabled sites. Backfill records explicitly; do not silently create a mailbox for every incoming address.
+2. Confirm existing Worker routing for one organization's exact domain and activate only verified addresses. Exercise an alias, unknown address, suspended mailbox, and cross-tenant destination with synthetic mail.
+3. Add request verification and preserve your current sender review, archive behavior, error responses, and size limits. Test that rejected or held mail cannot reach the processing queue.
+4. Connect site provisioning to the same mailbox API used by the [management engine](management-engine.md). Scope the engine through existing host authentication and authorization.
+5. Retire duplicate infrastructure only after comparing delivery and recovery behavior. Inbound adoption does not require switching your outbound provider.
+
+Keep the shared operational communications history separate from tenant-local raw emails and mailbox membership when those serve different purposes. Define who owns deletion, archive retention, deduplication, and processing status; two competing delivery ledgers make recovery harder.
+
+The gem's custom-ingress integration test exercises a custom controller against two real SQLite tenant databases, preserving binary MIME bytes and signed metadata before routing jobs run. It also verifies rejected metadata, host review, accepted-address enforcement, and retry behavior. It does not verify a deployed customer's Cloudflare DNS, Worker authentication evidence, R2 archive, or document-processing pipeline; those require that host's end-to-end tests.

--- a/docs/features.md
+++ b/docs/features.md
@@ -29,6 +29,18 @@ a tenant connection adapter. A mailbox tenant key alone does not switch database
 | Observe email processing | ActiveSupport notifications + `doctor` | Send/ingress/event/outbox instrumentation and configuration diagnostics |
 | Deploy receiving infrastructure | Ruby deployer and routing tasks | Environment-specific Workers, ingress secrets, address routes and DNS preflight checks |
 
+## Upcoming integration tools (unreleased)
+
+Existing ingestion pipelines can use [custom ingress](custom-ingress.md) to
+verify bounded raw messages before tenant lookup, keep their own storage, or
+persist through ActionMailbox. Optional v3 signatures authenticate custom Worker
+metadata; your application still decides whether its provenance and sender policy
+are acceptable. The bundled Worker continues to use v2 by default.
+
+[Read-only routing diagnostics](routing-diagnostics.md) inspect exact-domain DNS
+and the selected Worker route. They distinguish missing configuration from an
+incomplete inspection; a passing snapshot does not prove live email delivery.
+
 ## SQLite works
 
 The optional receipt and outbox tables work with **SQLite**. Keep your existing
@@ -58,7 +70,7 @@ subscriptions. The [getting-started guide](getting-started.md) walks through eac
 
 ## Protections included
 
-Incoming requests use v2 HMAC signatures covering the timestamp, SMTP sender,
+By default, incoming requests use v2 HMAC signatures covering the timestamp, SMTP sender,
 SMTP recipient and raw message. Rails checks a five-minute timestamp window.
 Identical MIME retried for the same recipient is deduplicated; delivery to a
 different recipient is stored separately.

--- a/docs/routing-diagnostics.md
+++ b/docs/routing-diagnostics.md
@@ -1,0 +1,68 @@
+# Check whether an address is configured to reach your Worker
+
+This diagnostic is unreleased and is not included in gem version 0.2.0.
+
+A mailbox registered in Rails is not proof that Cloudflare can deliver to it.
+Use this read-only check when onboarding a receiving domain, investigating a
+missing message, or checking an existing catch-all before activating addresses.
+
+```sh
+bin/rails cloudflare:email:check_route \
+  ADDRESS=houston@customer.example.com \
+  WORKER_NAME=cloudflare-email-ingress-production \
+  ACCOUNT_ID=your-cloudflare-account-id
+```
+
+Configure your Cloudflare management token in the normal gem credentials. The
+inspection needs Zone Read, DNS Read, and Email Routing Read permissions. No Edit
+permissions are needed. `WORKER_NAME` defaults to the gem's environment-scoped
+Worker name; `ACCOUNT_ID` falls back to the configured account, if present.
+
+Every check reports `PASS`, `FAIL`, or `UNKNOWN`. The command exits zero only
+when all configuration checks pass. An unavailable API, insufficient permission,
+an unsupported matcher, or ambiguous rule ordering produces `UNKNOWN`, not a
+successful result. Output excludes raw provider responses and credentials.
+
+The check inspects:
+
+- The closest containing Cloudflare zone and its account when an expected account is supplied.
+- Whether Email Routing is enabled for the zone.
+- MX and SPF records for the **exact receiving domain**. Parent-domain records
+  cannot satisfy a subdomain's requirements, and a parent's unrelated MX provider
+  does not conflict with correctly configured subdomain records.
+- Active explicit address rules before falling back to the catch-all. An explicit
+  drop, forwarding action, or different Worker takes precedence over a correct
+  catch-all. Disabled explicit rules are ignored. Multiple matching rules or
+  unsupported matcher forms leave selection unverified rather than guessing
+  priority or tie behavior.
+
+List reads are paginated and bounded to 50 pages per endpoint, responses to 1 MiB,
+and each request to 20 seconds (with shorter connection/read timeouts). An
+incomplete inspection does not report success. This command only issues GET
+requests. It never enables routing, changes DNS, repairs rules, or activates
+mailbox records.
+
+## Use from Ruby
+
+```ruby
+require "cloudflare/email/routing_diagnostics"
+
+report = Cloudflare::Email::RoutingDiagnostics.new(
+  api_token: ENV.fetch("CLOUDFLARE_API_TOKEN")
+).check(
+  address: "houston@customer.example.com",
+  worker_name: "cloudflare-email-ingress-production",
+  account_id: ENV.fetch("CLOUDFLARE_ACCOUNT_ID")
+)
+
+report[:status] # "pass", "fail", or "unknown"
+report[:checks] # [{ name: "zone", status: "pass", message: "..." }, ...]
+```
+
+This API does not require Active Record or enable multi-tenancy. You can use it
+with a custom Worker and an existing application ingestion pipeline. It reports
+a provider configuration snapshot; it does **not** prove public DNS propagation,
+full SPF evaluation, successful live delivery, the Worker's application URL or
+behavior, or application acceptance. Keep those as separate checks, including a
+controlled end-to-end delivery when appropriate. A passing report does not
+automatically change mailbox readiness or constitute delivery evidence.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -30,7 +30,7 @@ FROM=hello@mail.example.com TO=you@example.net bin/rails cloudflare:email:send_t
 | --- | --- |
 | Address receives nothing | Verify receiving-subdomain onboarding and the address route's Worker. Sending-domain verification is separate. |
 | Route provisioning refuses a subdomain | Complete Email Routing subdomain setup and DNS preflight first. Do not enable or replace apex routing just to bypass the error. |
-| Worker reports 401 from Rails | Check matching ingress secrets and that Rails and Worker both use the v2 code. Upgrade both together. |
+| Worker reports 401 from Rails | Check matching ingress secrets and compatible signature versions. The Worker defaults to v2. The unreleased opt-in v3 [custom-ingress API](custom-ingress.md) requires upgrading Rails before enabling Worker metadata. |
 | Worker reports 408 | Check clock accuracy and the five-minute signing window. |
 | Worker reports 413 or rejects size | Raw MIME exceeds the configured limit. Match `MAX_EMAIL_BYTES` on Rails and Worker and check upstream request limits. |
 | Worker reports 3xx | Point it directly at the final HTTPS ingress URL; redirects are intentionally rejected. |
@@ -38,7 +38,7 @@ FROM=hello@mail.example.com TO=you@example.net bin/rails cloudflare:email:send_t
 | Rails returns 200 but your product shows no message | Check ActionMailbox records, job workers, failed routing jobs and your mailbox's `process` method. The default mailbox only logs receipt. |
 | Retrying creates no new inbound record | Identical MIME for the same SMTP recipient is intentionally deduplicated. |
 | Bcc message appears routed to the wrong mailbox | Use `Envelope.for(inbound_email)["to"]` after checking the envelope exists; MIME `To` does not identify every SMTP recipient. |
-| Quoted or internationalized addresses are rejected | The v2 envelope currently supports ASCII dot-atom addresses, not every possible email address syntax. |
+| Quoted or internationalized addresses are rejected | Both v2 and v3 envelopes support ASCII dot-atom addresses, not every possible email address syntax. |
 
 ## Local development
 

--- a/docs/upgrading-0.2.md
+++ b/docs/upgrading-0.2.md
@@ -26,6 +26,11 @@ Pause test ingress while updating Rails and the deployed Worker together; verify
 the matching ingress URL and shared secret before resuming delivery. There is no
 legacy routing mode or supported mixed-version rollout.
 
+The unreleased custom-ingress additions preserve v2 as the default and add
+opt-in v3 for authenticated Worker metadata. That additive upgrade is separate
+from the v1-to-v2 break above: upgrade the Rails receiver before enabling v3 in
+your custom Worker. See [custom ingestion](custom-ingress.md).
+
 Rails stores authenticated metadata before enqueueing routing jobs.
 `Cloudflare::Email::Envelope.for(inbound_email)` returns a string-keyed `from`/`to`
 hash for accepted ingress. It returns `nil` for records from another ingress or

--- a/docs/verification/2026-09-11-custom-ingress.md
+++ b/docs/verification/2026-09-11-custom-ingress.md
@@ -1,0 +1,49 @@
+# Custom ingress and routing diagnostics verification
+
+Scope: upstream gem integration tools informed by Rebulk's existing ingestion
+pipeline. This report covers local synthetic verification, not a Rebulk rollout.
+
+## Results
+
+| Check | Result |
+| --- | --- |
+| Full Ruby suite, Ruby 3.4.1 / Rails 7.2, 8.0, 8.1 | Each: 257 tests, 916 assertions, no failures/errors/skips |
+| Shared ingress unit tests | 12 tests, 98 assertions; independent Node/Ruby v3 binary/Unicode vector, tampering, metadata bounds, short streams, immutable results, retry identity |
+| Custom Rails endpoint | 5 integration tests, 37 assertions; separate SQLite tenant databases, policy before persistence, durable signed metadata and retries |
+| Built-in Rails endpoint | V3 persistence before routing enqueue, binary preservation, retries and unsigned v2 metadata rejection; covered in the full suite |
+| Read-only routing diagnostics | 27 tests, 50 assertions; mocked Cloudflare configuration, exact-domain DNS, rule selection, ambiguous/inaccessible responses and pagination |
+| Worker | 45 tests pass; Wrangler dry-run succeeds |
+| Packaged consumer | Isolated plain Ruby install and packaged Rails installation/ingress fixtures pass |
+| Local workerd → Rails | Real local forwarding, Bcc routing, attachment preservation, wrong/missing secrets, redirects and timeout handling pass |
+
+Independent reviews found two verifier issues: a readable stream can return
+short chunks, and HMAC must use the timestamp's exact transmitted bytes. Both
+were corrected and covered by regression tests. Freshness still parses decimal
+seconds; existing bundled Worker timestamps are unchanged.
+
+## Reproduce
+
+```sh
+BUNDLE_GEMFILE=gemfiles/rails_7_2.gemfile bundle exec rake test
+BUNDLE_GEMFILE=gemfiles/rails_8_0.gemfile bundle exec rake test
+BUNDLE_GEMFILE=gemfiles/rails_8_1.gemfile bundle exec rake test
+bundle exec ruby script/verify_package.rb
+BUNDLE_GEMFILE=gemfiles/local_ingress.gemfile bundle exec ruby script/verify_local_ingress.rb
+npm --prefix templates/worker test
+npm --prefix templates/worker run check
+```
+
+Use Node 22 for the Worker and local forwarding checks.
+
+## Limits
+
+No Rebulk application code, live DNS, Worker deployment, inbox activation, R2
+archive, or gem publication was changed. The local workerd test exercises the
+default v2 transport; opt-in v3 is covered by Worker tests, an independent shared
+signature vector, and real Rails integration tests, not deployed Cloudflare mail.
+
+Routing diagnostics inspect provider configuration through mocked API tests.
+A passing configuration snapshot does not establish public DNS propagation,
+complete SPF evaluation, Worker application behavior, or live delivery. Signed
+metadata authenticates the forwarding integration's assertions; the host still
+owns original-sender trust, held-message policy, and business processing.

--- a/lib/cloudflare/email/check_route_task.rb
+++ b/lib/cloudflare/email/check_route_task.rb
@@ -1,0 +1,21 @@
+require "cloudflare/email/credentials"
+require "cloudflare/email/routing_diagnostics"
+require "cloudflare/email/worker_deployer"
+
+module Cloudflare
+  module Email
+    class CheckRouteTask
+      def self.call(address:, worker_name: nil, account_id: nil, io: $stdout)
+        report = RoutingDiagnostics.new(api_token: Credentials.management_token).check(
+          address: address, worker_name: worker_name || WorkerDeployer.default_script_name,
+          account_id: account_id || Credentials.account_id)
+        report[:checks].each { |check| io.puts "#{check[:status].upcase} #{check[:name]}: #{check[:message]}" }
+        io.puts report[:limitations]
+        report[:status] == "pass" ? 0 : 1
+      rescue StandardError
+        io.puts "UNKNOWN: Unable to inspect routing. Check ADDRESS, WORKER_NAME, and Cloudflare management credentials."
+        1
+      end
+    end
+  end
+end

--- a/lib/cloudflare/email/envelope.rb
+++ b/lib/cloudflare/email/envelope.rb
@@ -45,11 +45,11 @@ module Cloudflare
         nil
       end
 
-      # Only metadata written after v2 verification is trusted. MIME headers
+      # Only metadata written after v2/v3 verification is trusted. MIME headers
       # (including X-CF-* headers) never participate in this lookup.
       def self.for(inbound_email)
         metadata = inbound_email.raw_email.blob&.metadata&.fetch(METADATA_KEY, nil)
-        return nil unless metadata.is_a?(Hash) && metadata["version"] == 2
+        return nil unless metadata.is_a?(Hash) && [2, 3].include?(metadata["version"])
         value = metadata.reject { |key, _| key == "version" }
         valid?(value) ? value : nil
       end

--- a/lib/cloudflare/email/ingress.rb
+++ b/lib/cloudflare/email/ingress.rb
@@ -1,0 +1,101 @@
+require "digest"
+require "cloudflare/email/verification"
+
+module Cloudflare
+  module Email
+    # Shared bounded verification for custom Rack/Rails ingestion endpoints.
+    # This API deliberately performs no domain lookup or business processing.
+    module Ingress
+      DEFAULT_MAX_EMAIL_BYTES = 25 * 1024 * 1024
+      Result = Struct.new(:status, :message, :bytes, keyword_init: true)
+
+      class VerifiedMessage
+        attr_reader :body, :envelope, :provider_metadata, :storage_metadata, :message_checksum
+
+        def initialize(body:, envelope:, provider_metadata:, version:)
+          @body = body.b.freeze
+          @envelope = Ingress.deep_freeze(envelope)
+          @provider_metadata = Ingress.deep_freeze(provider_metadata)
+          @storage_metadata = {Envelope::METADATA_KEY => envelope.merge("version" => version.to_i)}
+          if provider_metadata
+            @storage_metadata[ProviderMetadata::METADATA_KEY] = provider_metadata.merge("signature_version" => 3)
+          end
+          Ingress.deep_freeze(@storage_metadata)
+          identity = if version == "3"
+            "v3\0#{JSON.generate([envelope.fetch('from'), envelope.fetch('to'), ProviderMetadata.canonical(provider_metadata)])}\0".b
+          else
+            "v2\0#{envelope.fetch('to')}\0".b
+          end
+          @message_checksum = Digest::SHA256.hexdigest(identity + @body).freeze
+          freeze
+        end
+        private_class_method :new
+
+        # Call within Mailboxes.receive when using the optional registry so the
+        # framework records and memberships share the resolved tenant context.
+        # Custom endpoints may instead persist body/metadata in their own store.
+        def persist_action_mailbox!
+          ::ActionMailbox::InboundEmail.transaction do
+            inbound = ::ActionMailbox::InboundEmail.create_and_extract_message_id!(body,
+              message_checksum: message_checksum)
+            if inbound
+              blob = inbound.raw_email.blob
+              blob.update!(metadata: blob.metadata.merge(storage_metadata))
+            end
+            inbound
+          end
+        end
+      end
+
+      def self.verify(secret:, headers:, body:, content_length: nil,
+        max_email_bytes: DEFAULT_MAX_EMAIL_BYTES, now: Time.now.to_i, window: Verification::DEFAULT_WINDOW)
+        unless max_email_bytes.is_a?(Integer) && max_email_bytes.positive?
+          raise ArgumentError, "max_email_bytes must be a positive integer"
+        end
+        values = %w[Timestamp Signature Signature-Version Envelope Metadata].to_h do |name|
+          key = "X-CF-Email-#{name}"
+          value = headers[key] || headers["HTTP_#{key.upcase.tr('-', '_')}"]
+          [name, value.is_a?(String) ? value.dup.freeze : value]
+        end
+        options = {secret: secret, timestamp: values["Timestamp"], signature: values["Signature"],
+          version: values["Signature-Version"], envelope: values["Envelope"], metadata: values["Metadata"],
+          now: now, window: window}
+        status = Verification.verify_headers(**options)
+        return Result.new(status: status).freeze unless status == :ok
+        if content_length
+          length = Integer(content_length.to_s, exception: false)
+          return Result.new(status: :bad_signature).freeze unless length && length >= 0
+          return Result.new(status: :too_large).freeze if length > max_email_bytes
+        end
+        raw = if body.is_a?(String)
+          return Result.new(status: :too_large).freeze if body.bytesize > max_email_bytes
+          body.dup.b
+        elsif body.respond_to?(:read)
+          buffer = +"".b
+          while buffer.bytesize <= max_email_bytes
+            chunk = body.read(max_email_bytes + 1 - buffer.bytesize)
+            break if chunk.nil? || chunk.empty?
+            buffer << chunk.b
+          end
+          buffer
+        else
+          raise ArgumentError, "body must be a String or readable IO"
+        end
+        return Result.new(status: :too_large).freeze if raw.bytesize > max_email_bytes
+        status = Verification.verify(body: raw, **options)
+        return Result.new(status: status, bytes: raw.bytesize).freeze unless status == :ok
+        message = VerifiedMessage.send(:new, body: raw, version: values["Signature-Version"],
+          envelope: Envelope.decode(values["Envelope"]), provider_metadata: ProviderMetadata.decode(values["Metadata"]))
+        Result.new(status: :ok, message: message, bytes: raw.bytesize).freeze
+      end
+
+      def self.deep_freeze(value)
+        case value
+        when Hash then value.each { |key, item| deep_freeze(key); deep_freeze(item) }
+        when Array then value.each { |item| deep_freeze(item) }
+        end
+        value.freeze
+      end
+    end
+  end
+end

--- a/lib/cloudflare/email/provider_metadata.rb
+++ b/lib/cloudflare/email/provider_metadata.rb
@@ -1,0 +1,77 @@
+require "json"
+require "cloudflare/email/signing"
+
+module Cloudflare
+  module Email
+    # Signed assertions supplied by the forwarding integration, not proof that
+    # the original sender passed SPF/DKIM/DMARC. Never read these from MIME.
+    module ProviderMetadata
+      METADATA_KEY = "cloudflare_email_provider_metadata".freeze
+      MAX_ENCODED_BYTES = 16 * 1024
+      MAX_DEPTH = 8
+      SOURCE = /\A[a-z][a-z0-9_.-]{0,127}\z/
+
+      def self.valid?(value)
+        value.is_a?(Hash) && value.size == 2 && value.key?("data") && value.key?("source") &&
+          value["source"].is_a?(String) && SOURCE.match?(value["source"]) &&
+          value["data"].is_a?(Hash) && json_value?(value, 0)
+      end
+
+      def self.json_value?(value, depth)
+        case value
+        when Hash
+          depth < MAX_DEPTH && value.all? { |key, item| key.is_a?(String) && utf8?(key) && json_value?(item, depth + 1) }
+        when Array
+          depth < MAX_DEPTH && value.all? { |item| json_value?(item, depth + 1) }
+        when String then utf8?(value)
+        when Integer, TrueClass, FalseClass, NilClass then true
+        when Float then value.finite?
+        else false
+        end
+      end
+
+      def self.utf8?(value)
+        value.encode(Encoding::UTF_8).valid_encoding?
+      rescue EncodingError
+        false
+      end
+
+      def self.encode(source:, data:)
+        value = {"source" => source, "data" => data}
+        raise ArgumentError, "invalid provider metadata" unless valid?(value)
+        encoded = Signing.base64url_encode(JSON.generate(value))
+        raise ArgumentError, "provider metadata exceeds size limit" if encoded.bytesize > MAX_ENCODED_BYTES
+        encoded
+      end
+
+      def self.decode(encoded)
+        return unless encoded.is_a?(String) && encoded.bytesize.between?(1, MAX_ENCODED_BYTES)
+        return unless /\A[A-Za-z0-9_-]+\z/.match?(encoded)
+        bytes = Signing.base64url_decode(encoded)
+        return unless Signing.base64url_encode(bytes) == encoded
+        text = bytes.force_encoding(Encoding::UTF_8)
+        return unless text.valid_encoding?
+        value = JSON.parse(text, max_nesting: MAX_DEPTH)
+        value if valid?(value)
+      rescue JSON::ParserError, ArgumentError
+        nil
+      end
+
+      def self.for(inbound_email)
+        metadata = inbound_email.raw_email.blob&.metadata&.fetch(METADATA_KEY, nil)
+        return unless metadata.is_a?(Hash) && metadata["signature_version"] == 3
+        value = metadata.reject { |key, _| key == "signature_version" }
+        value if valid?(value)
+      end
+
+      # Stable receipt identity if JSON object members arrive in another order.
+      def self.canonical(value)
+        case value
+        when Hash then value.keys.sort.to_h { |key| [key, canonical(value[key])] }
+        when Array then value.map { |item| canonical(item) }
+        else value
+        end
+      end
+    end
+  end
+end

--- a/lib/cloudflare/email/routing_diagnostics.rb
+++ b/lib/cloudflare/email/routing_diagnostics.rb
@@ -1,0 +1,206 @@
+require "net/http"
+require "json"
+require "uri"
+require "timeout"
+require "cloudflare/email/endpoint"
+
+module Cloudflare
+  module Email
+    # A bounded, GET-only snapshot of provider configuration. This deliberately
+    # does not inherit RoutingProvisioner: inspecting must never repair routing.
+    class RoutingDiagnostics
+      API_BASE = "https://api.cloudflare.com/client/v4".freeze
+      MAX_BYTES = 1_048_576
+      MAX_PAGES = 50
+      LIMITATIONS = "Configuration snapshot only: does not prove public DNS propagation, live delivery, Worker destination, or application acceptance.".freeze
+      class ReadError < StandardError; end
+
+      def initialize(api_token:, api_base: API_BASE)
+        raise ArgumentError, "api_token is required" if api_token.to_s.empty?
+        @api_token = api_token
+        @api_base = Endpoint.parse(api_base).to_s.delete_suffix("/")
+      end
+
+      # Status is pass only if every requested configuration check passes.
+      # Unknown means inspection could not establish readiness, not success.
+      def check(address:, worker_name:, account_id: nil)
+        unless address.is_a?(String) && address.bytesize <= 254 && address.match?(/\A[^\s@]+@(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?\.)+[a-zA-Z0-9-]+\z/)
+          raise ArgumentError, "address must be a full email address with a DNS domain"
+        end
+        raise ArgumentError, "worker_name is required" if worker_name.to_s.empty?
+        domain = address.split("@", 2).last.downcase
+        address = "#{address.split('@', 2).first}@#{domain}"
+        checks = []
+        zone = inspect_check(checks, "zone") { find_zone(domain) }
+        if zone
+          if account_id
+            actual = zone["account"].is_a?(Hash) ? zone["account"]["id"] : nil
+            add(checks, "account", actual.nil? ? "unknown" : (actual == account_id ? "pass" : "fail"),
+              actual.nil? ? "Zone account was not returned." : (actual == account_id ? "Zone belongs to the expected account." : "Zone belongs to a different account."))
+          end
+          zone_id = URI.encode_www_form_component(zone.fetch("id"))
+          inspect_check(checks, "routing") { routing_check(checks, zone_id) }
+          inspect_check(checks, "dns") { dns_check(checks, zone_id, domain) }
+          inspect_check(checks, "route") { route_check(checks, zone_id, address, worker_name) }
+        else
+          %w[routing dns route].each { |name| add(checks, name, "unknown", "Cannot inspect without a unique zone.") }
+        end
+        statuses = checks.map { |item| item[:status] }
+        { status: statuses.include?("fail") ? "fail" : (statuses.include?("unknown") ? "unknown" : "pass"),
+          checks: checks, limitations: LIMITATIONS }
+      end
+
+      private
+
+      def add(checks, name, status, message)
+        checks << { name: name, status: status, message: message }
+      end
+
+      def inspect_check(checks, name)
+        value = yield
+        add(checks, name, "pass", "Found a unique containing Cloudflare zone.") if name == "zone" && value
+        add(checks, name, "fail", "No containing Cloudflare zone was found.") if name == "zone" && !value
+        value
+      rescue ReadError => e
+        add(checks, name, "unknown", e.message)
+        nil
+      rescue StandardError
+        add(checks, name, "unknown", "Provider configuration could not be interpreted safely.")
+        nil
+      end
+
+      def find_zone(domain)
+        parts = domain.split(".")
+        (0..parts.size - 2).each do |index|
+          candidate = parts[index..].join(".")
+          zones = pages("/zones?name=#{URI.encode_www_form_component(candidate)}")
+          next if zones.empty?
+          unless zones.size == 1 && zones.first["name"].to_s.downcase == candidate && zones.first["id"].is_a?(String)
+            raise ReadError, "Zone lookup was ambiguous or incomplete."
+          end
+          return zones.first
+        end
+        nil
+      end
+
+      def routing_check(checks, zone_id)
+        result = get("/zones/#{zone_id}/email/routing")["result"]
+        enabled = result.is_a?(Hash) ? result["enabled"] : nil
+        status = enabled == true ? "pass" : (enabled == false ? "fail" : "unknown")
+        add(checks, "routing", status, enabled == true ? "Zone Email Routing is enabled." : "Zone Email Routing is disabled or its enabled flag is unavailable.")
+      end
+
+      def dns_check(checks, zone_id, domain)
+        records = pages("/zones/#{zone_id}/dns_records?name=#{URI.encode_www_form_component(domain)}")
+        # Defensively enforce exact name even when the provider returns parent
+        # records. A parent's Google MX must not invalidate a receiving subdomain.
+        records = records.select { |record| record["name"].to_s.downcase.delete_suffix(".") == domain }
+        mx = records.select { |r| r["type"] == "MX" }.map { |r| r["content"].to_s.downcase.delete_suffix(".") }.uniq.sort
+        spf = records.select { |r| r["type"] == "TXT" }.map { |r| r["content"].to_s.delete('"') }.select { |v| v.match?(/\Av=spf1(?:\s|\z)/i) }
+        mx_ok = mx == (1..3).map { |n| "route#{n}.mx.cloudflare.net" }
+        # Do not declare an include useful when an earlier `all` terminates SPF.
+        terms = spf.size == 1 ? spf.first.split.drop(1) : []
+        include_index = terms.index("include:_spf.mx.cloudflare.net")
+        all_index = terms.index { |term| term.match?(/\A[+~?-]?all\z/i) }
+        spf_ok = include_index && (!all_index || include_index < all_index)
+        add(checks, "dns", mx_ok && spf_ok ? "pass" : "fail", mx_ok && spf_ok ?
+          "Exact receiving domain has Cloudflare MX records and one SPF record including Cloudflare." :
+          "Exact receiving domain needs Cloudflare MX records and a single SPF record with an effective Cloudflare include; records may be missing or conflicting.")
+      end
+
+      def route_check(checks, zone_id, address, worker_name)
+        rules = pages("/zones/#{zone_id}/email/routing/rules")
+        matching = []
+        rules.each do |rule|
+          next if rule["enabled"] == false
+          matchers = rule["matchers"]
+          unless matchers.is_a?(Array) && matchers.size == 1 && matchers.first.is_a?(Hash)
+            raise ReadError, "Unsupported rule matchers prevent establishing which rule wins."
+          end
+          matcher = matchers.first
+          unless matcher["type"] == "literal" && matcher["field"] == "to" && matcher["value"].is_a?(String)
+            raise ReadError, "Unsupported rule matchers prevent establishing which rule wins."
+          end
+          next unless matcher["value"].casecmp?(address)
+          raise ReadError, "A matching rule has an unknown enabled state." unless rule["enabled"] == true
+          matching << rule
+        end
+        if matching.size > 1
+          raise ReadError, "Multiple explicit rules match; their priority or tie ordering has not been verified."
+        end
+        if matching.one?
+          selected = matching.first
+          source = "Explicit address rule (takes precedence over catch-all)"
+        else
+          selected = get("/zones/#{zone_id}/email/routing/rules/catch_all")["result"]
+          unless selected.is_a?(Hash) && selected["matchers"] == [{ "type" => "all" }]
+            raise ReadError, "Catch-all settings are incomplete or use unsupported matchers."
+          end
+          source = "Catch-all rule"
+        end
+        unless [true, false].include?(selected["enabled"])
+          raise ReadError, "Selected rule has an unknown enabled state."
+        end
+        unless selected["enabled"]
+          return add(checks, "route", "fail", "No enabled explicit route or catch-all accepts this address.")
+        end
+        actions = selected["actions"]
+        unless actions.is_a?(Array) && actions.all? { |action| action.is_a?(Hash) }
+          raise ReadError, "Selected rule actions were not returned."
+        end
+        correct = actions.size == 1 && actions.first["type"] == "worker" && actions.first["value"] == [worker_name]
+        add(checks, "route", correct ? "pass" : "fail", correct ?
+          "#{source} targets the expected Worker." : "#{source} does not exclusively target the expected Worker (it may drop, forward, or target another Worker).")
+      end
+
+      def pages(path)
+        records = []
+        1.upto(MAX_PAGES) do |page|
+          data = get("#{path}#{path.include?('?') ? '&' : '?'}per_page=50&page=#{page}")
+          batch = data["result"]
+          raise ReadError, "Provider returned an invalid list." unless batch.is_a?(Array) && batch.all? { |item| item.is_a?(Hash) }
+          records.concat(batch)
+          total = data.dig("result_info", "total_pages")
+          if total && (!total.is_a?(Integer) || total.negative? || (total.zero? && batch.any?))
+            raise ReadError, "Provider returned invalid pagination."
+          end
+          return records if total ? page >= total : batch.size < 50
+          raise ReadError, "Provider pagination ended before all pages were available." if batch.empty?
+        end
+        raise ReadError, "Provider pagination exceeds the inspection limit."
+      end
+
+      def get(path)
+        uri = URI.parse("#{@api_base}#{path}")
+        http = Net::HTTP.new(uri.host, uri.port)
+        http.use_ssl = uri.scheme == "https"
+        http.open_timeout = 5
+        http.read_timeout = 10
+        request = Net::HTTP::Get.new(uri.request_uri)
+        request["Authorization"] = "Bearer #{@api_token}"
+        request["Accept"] = "application/json"
+        body = +""
+        # read_timeout alone does not bound a peer streaming tiny chunks.
+        Timeout.timeout(20) do
+          http.request(request) do |response|
+            raise ReadError, "Provider request failed (HTTP #{response.code.to_i}); check token scopes and configuration." unless response.code.to_i.between?(200, 299)
+            response.read_body do |chunk|
+              raise ReadError, "Provider response exceeds the inspection size limit." if body.bytesize + chunk.bytesize > MAX_BYTES
+              body << chunk
+            end
+          end
+        end
+        data = JSON.parse(body)
+        unless data.is_a?(Hash) && data["success"] == true && data.key?("result")
+          raise ReadError, "Provider response did not contain a successful result."
+        end
+        data
+      rescue ReadError
+        raise
+      rescue StandardError
+        # Never surface raw provider bodies, URLs, credentials, or socket errors.
+        raise ReadError, "Provider request could not be read; check connectivity, token scopes, and response format."
+      end
+    end
+  end
+end

--- a/lib/cloudflare/email/verification.rb
+++ b/lib/cloudflare/email/verification.rb
@@ -1,5 +1,6 @@
 require "cloudflare/email/signing"
 require "cloudflare/email/envelope"
+require "cloudflare/email/provider_metadata"
 
 module Cloudflare
   module Email
@@ -13,20 +14,22 @@ module Cloudflare
     #   X-CF-Email-Signature: <hex digest>
     #   X-CF-Email-Signature-Version: 2
     #   X-CF-Email-Envelope: <unpadded base64url JSON from/to>
-    # The version and authenticated SMTP envelope are required.
+    # Custom integrations may use v3, adding X-CF-Email-Metadata and signing
+    # "v3.{timestamp}.{encoded_envelope}.{encoded_metadata}.{raw_body}".
+    # v2 rejects metadata headers; v3 requires them. Both require the envelope.
     module Verification
       DEFAULT_WINDOW = 5 * 60 # seconds
 
       # Returns :ok, :bad_signature, or :stale.
       # Returns :bad_signature for any malformed input.
-      def self.verify(secret:, body:, timestamp:, signature:, version: nil, envelope: nil, window: DEFAULT_WINDOW, now: Time.now.to_i)
+      def self.verify(secret:, body:, timestamp:, signature:, version: nil, envelope: nil, metadata: nil, window: DEFAULT_WINDOW, now: Time.now.to_i)
         return :bad_signature if blank?(body)
         timestamp = timestamp.to_s if timestamp.is_a?(Integer)
         preflight = verify_headers(secret: secret, timestamp: timestamp, signature: signature,
-          version: version, envelope: envelope, window: window, now: now)
+          version: version, envelope: envelope, metadata: metadata, window: window, now: now)
         return preflight unless preflight == :ok
 
-        expected = sign(secret: secret, body: body, timestamp: Integer(timestamp, 10), version: version, envelope: envelope)
+        expected = sign(secret: secret, body: body, timestamp: timestamp, version: version, envelope: envelope, metadata: metadata)
         return :bad_signature unless Signing.secure_compare(expected, signature)
 
         :ok
@@ -34,11 +37,12 @@ module Cloudflare
 
       # Reject malformed/stale requests before the controller reads MIME bytes.
       # This is only a preflight: authentication still requires verify(body: ...).
-      def self.verify_headers(secret:, timestamp:, signature:, version:, envelope:, window: DEFAULT_WINDOW, now: Time.now.to_i)
+      def self.verify_headers(secret:, timestamp:, signature:, version:, envelope:, metadata: nil, window: DEFAULT_WINDOW, now: Time.now.to_i)
         return :bad_signature if blank?(secret)
         return :bad_signature unless timestamp.is_a?(String) && /\A[0-9]{1,20}\z/.match?(timestamp)
         return :bad_signature unless signature.is_a?(String) && /\A[0-9a-f]{64}\z/.match?(signature)
-        return :bad_signature unless version == "2" && Envelope.decode(envelope)
+        return :bad_signature unless Envelope.decode(envelope)
+        return :bad_signature unless valid_metadata_version?(version, metadata)
 
         ts = begin
           Integer(timestamp.to_s, 10)
@@ -51,11 +55,15 @@ module Cloudflare
         :ok
       end
 
-      def self.sign(secret:, body:, timestamp:, envelope:, version: "2")
-        raise ArgumentError, "unsupported signature version" unless version == "2"
+      def self.sign(secret:, body:, timestamp:, envelope:, version: "2", metadata: nil)
+        raise ArgumentError, "invalid signature version or metadata" unless valid_metadata_version?(version, metadata)
         raise ArgumentError, "invalid SMTP envelope" unless Envelope.decode(envelope)
-        prefix = "v2.#{timestamp}.#{envelope}."
+        prefix = version == "3" ? "v3.#{timestamp}.#{envelope}.#{metadata}." : "v2.#{timestamp}.#{envelope}."
         Signing.hmac_hex(secret, prefix.b + body.b)
+      end
+
+      def self.valid_metadata_version?(version, metadata)
+        (version == "2" && metadata.nil?) || (version == "3" && ProviderMetadata.decode(metadata))
       end
 
       def self.blank?(v)

--- a/lib/tasks/cloudflare_email_diagnostics.rake
+++ b/lib/tasks/cloudflare_email_diagnostics.rake
@@ -1,0 +1,11 @@
+namespace :cloudflare do
+  namespace :email do
+    desc "Inspect routing without changes (ADDRESS=addr [WORKER_NAME=name] [ACCOUNT_ID=id]); nonzero if failed or unverified"
+    task check_route: :environment do
+      require "cloudflare/email/check_route_task"
+      exit Cloudflare::Email::CheckRouteTask.call(
+        address: ENV["ADDRESS"], worker_name: ENV["WORKER_NAME"] || ENV["WORKER"], account_id: ENV["ACCOUNT_ID"],
+      )
+    end
+  end
+end

--- a/templates/worker/README.md
+++ b/templates/worker/README.md
@@ -67,12 +67,77 @@ Worker request, not the original email sender. Captured requests remain valid
 inside that window; Rails deduplicates messages through Action Mailbox.
 
 Deploy the Rails gem and this Worker together with ingress paused during the
-transition. Rails requires v2 signatures and rejects v1/missing versions. It stores authenticated
+transition. Rails accepts v2 and v3 signatures and rejects v1/missing versions. It stores authenticated
 SMTP metadata separately from MIME; applications read it using
 `Cloudflare::Email::Envelope.for(inbound_email)`. Duplicate detection includes the
 exact SMTP recipient, preserving separate To/Cc/Bcc deliveries. The format accepts
 ASCII dot-atom addresses up to 254 bytes (local part up to 64 bytes), plus an empty
 sender for bounce messages. Other address forms are rejected before forwarding.
+
+## Reuse an existing Worker
+
+Keep your existing archiving, sender checks, and fallback policy. Copy this
+template's `src/index.js` into your Worker project and import either helper.
+`forwardEmail(message, env)` uses the same bounded reading, URL checks, timeout,
+and rejection policy as the bundled Worker. Optional metadata selects v3 signing:
+
+```js
+import { forwardEmail } from "./cloudflare-ingress.js";
+
+export default {
+  async email(message, env) {
+    // Supplied by your integration after validating its trusted provider context.
+    // This is your adapter function, not a Cloudflare EmailMessage API.
+    const providerData = await yourValidatedProviderContext(message, env);
+    return forwardEmail(message, env, {
+      metadata: { source: "your-provider", data: providerData },
+    });
+  },
+};
+```
+
+The bundled Worker does not collect provider authentication results. Never treat
+`Authentication-Results`, `Received-SPF`, or other sender-supplied MIME headers as
+trusted provider context. Signing metadata authenticates your Worker's assertion;
+it does not prove DMARC passed or authorize the original sender. Your application
+still owns sender policy, organization resolution, review, and document processing.
+
+If your Worker already owns transport and error handling, use the header builder:
+
+```js
+import { signedEmailHeaders } from "./cloudflare-ingress.js";
+
+const headers = await signedEmailHeaders({
+  secret: env.INGRESS_SECRET,
+  raw, // Original Uint8Array, obtained using your own bounded reader.
+  from: message.from,
+  to: message.to,
+  metadata: { source: "your-provider", data: providerData },
+});
+// Send these headers with exactly `raw`, using your existing transport.
+```
+
+The builder performs no network calls. You own destination validation, body size
+limits, timeouts, redirects, retries, and response handling. An optional `timestamp`
+in Unix seconds supports deterministic testing; production normally uses the
+default current time. Omitting `metadata` produces unchanged v2 headers. Invalid
+metadata throws from the builder; the forwarding helper rejects instead of
+silently falling back to v2.
+
+Metadata must contain exactly `source` and `data`. Source matches
+`[a-z][a-z0-9_.-]{0,127}`; data is a JSON object, with only JSON values and at most
+eight container levels including the outer metadata object. The UTF8 JSON is
+encoded as unpadded base64url, limited to 16,384 encoded characters, and sent as
+`X-CF-Email-Metadata`. Version 3 signs the exact bytes:
+
+```text
+HMAC-SHA256(secret, "v3.{timestamp}.{encoded_envelope}.{encoded_metadata}.{raw_body}")
+```
+
+Neither the MIME nor its headers are rewritten. Upgrade Rails to a version that
+supports v3 before enabling metadata in a custom Worker. Keep sensitive provider
+data out of metadata unless your application's retention and access policies
+permit storing it with email records.
 
 ## Validate changes
 

--- a/templates/worker/src/index.js
+++ b/templates/worker/src/index.js
@@ -4,6 +4,7 @@
  * Receives mail via Cloudflare Email Routing, signs the raw RFC822 with
  * HMAC-SHA256 over "v2.{timestamp}.{encoded_envelope}.{raw_body}", and POSTs it to the Rails
  * ingress controller shipped with the cloudflare-email gem.
+ * Custom integrations can opt into v3, binding provider metadata into the signature.
  *
  * Required environment variables (set via `wrangler secret put` OR the
  * `cloudflare:email:deploy_worker` rake task shipped with this gem):
@@ -75,8 +76,73 @@ async function readBounded(stream, limit) {
   return raw;
 }
 
-export default {
-  async email(message, env) {
+function plainObject(value) {
+  return value !== null && typeof value === "object" &&
+    [Object.prototype, null].includes(Object.getPrototypeOf(value));
+}
+
+function validateJson(value, depth = 1) {
+  if (typeof value === "string") {
+    if (/[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/u.test(value)) {
+      throw new TypeError("metadata strings must be valid Unicode");
+    }
+    return;
+  }
+  if (value === null || typeof value === "boolean" ||
+      (typeof value === "number" && Number.isFinite(value))) return;
+  if (depth > 8 || (!Array.isArray(value) && !plainObject(value))) {
+    throw new TypeError("metadata must contain JSON values with at most 8 container levels");
+  }
+  for (const [key, item] of Object.entries(value)) {
+    validateJson(key, depth + 1);
+    validateJson(item, depth + 1);
+  }
+}
+
+function base64url(value) {
+  const bytes = new TextEncoder().encode(value);
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+function encodeMetadata(metadata) {
+  if (!plainObject(metadata) || Object.keys(metadata).sort().join(",") !== "data,source" ||
+      typeof metadata.source !== "string" || !/^[a-z][a-z0-9_.-]{0,127}$/.test(metadata.source) ||
+      !plainObject(metadata.data)) throw new TypeError("invalid provider metadata");
+  validateJson(metadata);
+  const encoded = base64url(JSON.stringify({ source: metadata.source, data: metadata.data }));
+  if (encoded.length > 16384) throw new TypeError("encoded metadata exceeds 16384 characters");
+  return encoded;
+}
+
+// Custom transports own their body limits, destination, retries and error handling.
+// Metadata is a host assertion; never derive trusted facts from MIME headers.
+export async function signedEmailHeaders({ secret, raw, from, to, metadata, timestamp = Math.floor(Date.now() / 1000).toString() }) {
+  if (typeof secret !== "string" || secret.length === 0) throw new TypeError("missing ingress secret");
+  if (!(raw instanceof Uint8Array)) throw new TypeError("raw must be a Uint8Array");
+  if (!validAddress(from, true) || !validAddress(to)) throw new TypeError("invalid SMTP envelope");
+  const ts = String(timestamp);
+  if (!/^[0-9]{1,12}$/.test(ts)) throw new TypeError("invalid timestamp");
+  const envelope = base64url(JSON.stringify({ from, to }));
+  const encodedMetadata = metadata === undefined ? undefined : encodeMetadata(metadata);
+  const version = encodedMetadata === undefined ? "2" : "3";
+  const prefix = new TextEncoder().encode(`v${version}.${ts}.${envelope}.${encodedMetadata === undefined ? "" : `${encodedMetadata}.`}`);
+  const signedPayload = new Uint8Array(prefix.length + raw.length);
+  signedPayload.set(prefix);
+  signedPayload.set(raw, prefix.length);
+  const headers = {
+    "Content-Type": "message/rfc822",
+    "X-CF-Email-Timestamp": ts,
+    "X-CF-Email-Signature": await sign(secret, signedPayload),
+    "X-CF-Email-Signature-Version": version,
+    "X-CF-Email-Envelope": envelope,
+  };
+  if (encodedMetadata !== undefined) headers["X-CF-Email-Metadata"] = encodedMetadata;
+  return headers;
+}
+
+export async function forwardEmail(message, env, { metadata } = {}) {
     if (!env.RAILS_INGRESS_URL || !env.INGRESS_SECRET) {
       message.setReject("worker missing RAILS_INGRESS_URL or INGRESS_SECRET");
       return;
@@ -100,10 +166,6 @@ export default {
       message.setReject("worker received invalid SMTP envelope");
       return;
     }
-    // Routing metadata comes from the SMTP envelope, never from MIME headers.
-    const envelope = btoa(JSON.stringify({ from: message.from, to: message.to }))
-      .replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
-
     let raw;
     try {
       raw = await readBounded(message.raw, limit);
@@ -111,14 +173,13 @@ export default {
       message.setReject("message exceeds size limit or could not be read");
       return;
     }
-    const ts = Math.floor(Date.now() / 1000).toString();
-
-    const tsBytes = new TextEncoder().encode(`v2.${ts}.${envelope}.`);
-    const signedPayload = new Uint8Array(tsBytes.length + raw.length);
-    signedPayload.set(tsBytes, 0);
-    signedPayload.set(raw, tsBytes.length);
-
-    const signature = await sign(env.INGRESS_SECRET, signedPayload);
+    let headers;
+    try {
+      headers = await signedEmailHeaders({ secret: env.INGRESS_SECRET, raw, from: message.from, to: message.to, metadata });
+    } catch {
+      message.setReject("worker could not sign envelope or provider metadata");
+      return;
+    }
 
     let res;
     const controller = new AbortController();
@@ -126,13 +187,7 @@ export default {
     try {
       res = await fetch(env.RAILS_INGRESS_URL, {
         method: "POST",
-        headers: {
-          "Content-Type": "message/rfc822",
-          "X-CF-Email-Timestamp": ts,
-          "X-CF-Email-Signature": signature,
-          "X-CF-Email-Signature-Version": "2",
-          "X-CF-Email-Envelope": envelope,
-        },
+        headers,
         body: raw,
         signal: controller.signal,
         // Workers supports follow/manual; non-2xx handling below rejects redirects.
@@ -148,5 +203,8 @@ export default {
     if (!res.ok) {
       message.setReject(`upstream returned ${res.status}`);
     }
-  },
+}
+
+export default {
+  email(message, env) { return forwardEmail(message, env); },
 };

--- a/templates/worker/test/index.test.ts
+++ b/templates/worker/test/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import worker from "../src/index.js";
+import worker, { forwardEmail, signedEmailHeaders } from "../src/index.js";
 
 // Minimal fake EmailMessage implementing the surface the Worker uses.
 function makeMessage(raw: string) {
@@ -75,6 +75,7 @@ describe("cloudflare-email Worker", () => {
     const sig = opts.headers["X-CF-Email-Signature"];
     const envelope = opts.headers["X-CF-Email-Envelope"];
     expect(opts.headers["X-CF-Email-Signature-Version"]).toBe("2");
+    expect(opts.headers["X-CF-Email-Metadata"]).toBeUndefined();
     expect(JSON.parse(atob(envelope.replace(/-/g, "+").replace(/_/g, "/")))).toEqual({
       from: "sender@external.test", to: "inbox@trial.test",
     });
@@ -247,5 +248,62 @@ describe("cloudflare-email Worker", () => {
     const sig2 = fetchSpy.mock.calls[0][1].headers["X-CF-Email-Signature"];
 
     expect(sig1).not.toBe(sig2);
+  });
+
+  const metadata = { source: "cloudflare", data: { note: "Résumé ☁", spf: "pass", score: 0.5, flags: [true, null] } };
+  const signingInput = { secret: SECRET, raw: new Uint8Array([0, 255, 13, 10, 128]), from: "sender@external.test", to: "inbox@trial.test", timestamp: "1750000000" };
+
+  it("matches the shared v3 binary body and UTF8 metadata vector", async () => {
+    const headers = await signedEmailHeaders({ ...signingInput, metadata });
+    expect(headers["X-CF-Email-Signature-Version"]).toBe("3");
+    expect(headers["X-CF-Email-Metadata"]).toBe("eyJzb3VyY2UiOiJjbG91ZGZsYXJlIiwiZGF0YSI6eyJub3RlIjoiUsOpc3Vtw6kg4piBIiwic3BmIjoicGFzcyIsInNjb3JlIjowLjUsImZsYWdzIjpbdHJ1ZSxudWxsXX19");
+    expect(headers["X-CF-Email-Signature"]).toBe("d4e5ed55306e1619b5c40f3ec5dfea44a3131ad422a22b49ffb042069f6b720f");
+    for (const changed of [{ ...metadata, source: "other" }, { ...metadata, data: { ...metadata.data, spf: "fail" } }]) {
+      expect((await signedEmailHeaders({ ...signingInput, metadata: changed }))["X-CF-Email-Signature"]).not.toBe(headers["X-CF-Email-Signature"]);
+    }
+  });
+
+  it("forwards opt-in metadata while preserving raw MIME and normal transport policy", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(1750000000000);
+    const { message, rejects } = makeMessage(RAW);
+    await forwardEmail(message, { RAILS_INGRESS_URL: URL_, INGRESS_SECRET: SECRET }, { metadata });
+    expect(rejects).toEqual([]);
+    const options = fetchSpy.mock.calls[0][1];
+    expect(options.headers).toEqual(await signedEmailHeaders({ ...signingInput, raw: new TextEncoder().encode(RAW), metadata }));
+    expect(options.redirect).toBe("manual");
+    expect(new TextDecoder().decode(options.body)).toBe(RAW);
+  });
+
+  it.each([null, {}, { source: "Cloudflare", data: {} }, { source: "a\n", data: {} },
+    { source: "a".repeat(129), data: {} }, { source: "a", data: [] },
+    { source: "a", data: {}, extra: true }, { source: "a", data: { x: undefined } },
+    { source: "a", data: { x: NaN } }, { source: "a", data: { x: new Date() } },
+    { source: "a", data: { x: "\uD800" } }, { source: "a", data: { "\uDC00": true } },
+    { source: "a", data: { x: "x".repeat(16384) } }])("rejects malformed metadata without downgrading to v2 (%j)", async (invalid) => {
+    await expect(signedEmailHeaders({ ...signingInput, metadata: invalid })).rejects.toThrow();
+    const { message, rejects } = makeMessage(RAW);
+    await forwardEmail(message, { RAILS_INGRESS_URL: URL_, INGRESS_SECRET: SECRET }, { metadata: invalid });
+    expect(rejects).toEqual(["worker could not sign envelope or provider metadata"]);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("bounds metadata nesting including cyclic data", async () => {
+    const data: any = {};
+    let node = data;
+    for (let i = 0; i < 6; i++) { node.child = {}; node = node.child; }
+    await expect(signedEmailHeaders({ ...signingInput, metadata: { source: "a", data } })).resolves.toBeDefined();
+    node.child = {};
+    await expect(signedEmailHeaders({ ...signingInput, metadata: { source: "a", data } })).rejects.toThrow();
+    data.child = data;
+    await expect(signedEmailHeaders({ ...signingInput, metadata: { source: "a", data } })).rejects.toThrow();
+  });
+
+  it("enforces the encoded metadata size boundary", async () => {
+    // The JSON wrapper occupies 33 UTF8 bytes; 12288 bytes encode to 16384 characters.
+    const atLimit = { source: "a", data: { text: "x".repeat(12288 - 33) } };
+    const headers = await signedEmailHeaders({ ...signingInput, metadata: atLimit });
+    expect(headers["X-CF-Email-Metadata"]).toHaveLength(16384);
+    atLimit.data.text += "x";
+    await expect(signedEmailHeaders({ ...signingInput, metadata: atLimit })).rejects.toThrow(/16384/);
   });
 });

--- a/test/custom_ingress_test.rb
+++ b/test/custom_ingress_test.rb
@@ -1,0 +1,11 @@
+require "test_helper"
+require "open3"
+require "rbconfig"
+
+class CustomIngressTest < Minitest::Test
+  def test_host_owned_ingress_with_separate_sqlite_tenants
+    output, status = Open3.capture2e(RbConfig.ruby, "-Ilib", File.expand_path("support/custom_ingress.rb", __dir__))
+    assert status.success?, output
+  end
+end
+

--- a/test/ingress_test.rb
+++ b/test/ingress_test.rb
@@ -1,0 +1,183 @@
+require_relative "test_helper"
+require "cloudflare/email/ingress"
+require "stringio"
+
+class IngressTest < Minitest::Test
+  Ingress = Cloudflare::Email::Ingress
+  Metadata = Cloudflare::Email::ProviderMetadata
+  Verification = Cloudflare::Email::Verification
+  Envelope = Cloudflare::Email::Envelope
+  SECRET = "worker-test-secret-abc123"
+  NOW = 1_750_000_000
+  RAW = [0, 255, 13, 10, 128].pack("C*").freeze
+  PROVIDER = {"source" => "cloudflare", "data" => {"note" => "Résumé ☁", "spf" => "pass", "score" => 0.5, "flags" => [true, nil]}}.freeze
+  ENCODED = "eyJzb3VyY2UiOiJjbG91ZGZsYXJlIiwiZGF0YSI6eyJub3RlIjoiUsOpc3Vtw6kg4piBIiwic3BmIjoicGFzcyIsInNjb3JlIjowLjUsImZsYWdzIjpbdHJ1ZSxudWxsXX19"
+  NODE_SIGNATURE = "d4e5ed55306e1619b5c40f3ec5dfea44a3131ad422a22b49ffb042069f6b720f"
+
+  class ChunkedBody
+    attr_reader :requested
+
+    def initialize(raw, chunk_size: nil)
+      @io = StringIO.new(raw)
+      @chunk_size = chunk_size
+      @requested = []
+    end
+
+    def read(limit)
+      @requested << limit
+      @io.read(@chunk_size ? [limit, @chunk_size].min : limit)
+    end
+  end
+
+  def headers(raw: RAW, metadata: ENCODED, timestamp: NOW.to_s, from: "sender@external.test", to: "inbox@trial.test")
+    envelope = Envelope.encode(from: from, to: to)
+    version = metadata ? "3" : "2"
+    result = {
+      "X-CF-Email-Timestamp" => timestamp,
+      "X-CF-Email-Envelope" => envelope,
+      "X-CF-Email-Signature-Version" => version,
+      "X-CF-Email-Signature" => Verification.sign(secret: SECRET, body: raw,
+        timestamp: timestamp, envelope: envelope, version: version, metadata: metadata)
+    }
+    result["X-CF-Email-Metadata"] = metadata if metadata
+    result
+  end
+
+  def verify(request_headers = headers, body: RAW, **options)
+    Ingress.verify(secret: SECRET, headers: request_headers, body: body, now: NOW, **options)
+  end
+
+  def encode(value)
+    Cloudflare::Email::Signing.base64url_encode(JSON.generate(value))
+  end
+
+  def test_shared_worker_vector_preserves_binary_mime_and_unicode_metadata
+    request_headers = headers.merge("X-CF-Email-Signature" => NODE_SIGNATURE)
+    result = verify(request_headers)
+    assert_equal :ok, result.status
+    assert_equal RAW, result.message.body
+    assert_equal Encoding::BINARY, result.message.body.encoding
+    assert_equal 5, result.bytes
+    assert_equal PROVIDER, result.message.provider_metadata
+    assert_equal ENCODED, Metadata.encode(source: PROVIDER["source"], data: PROVIDER["data"])
+    assert_equal 3, result.message.storage_metadata.fetch(Envelope::METADATA_KEY).fetch("version")
+    assert_equal 3, result.message.storage_metadata.fetch(Metadata::METADATA_KEY).fetch("signature_version")
+  end
+
+  def test_v2_retains_existing_checksum_and_has_no_provider_metadata
+    result = verify(headers(metadata: nil))
+    assert_equal :ok, result.status
+    assert_nil result.message.provider_metadata
+    refute result.message.storage_metadata.key?(Metadata::METADATA_KEY)
+    assert_equal Digest::SHA256.hexdigest("v2\0inbox@trial.test\0".b + RAW), result.message.message_checksum
+  end
+
+  def test_rack_environment_header_names_are_supported
+    rack_headers = headers.transform_keys { |key| "HTTP_#{key.upcase.tr('-', '_')}" }
+    assert_equal :ok, verify(rack_headers).status
+  end
+
+  def test_preflight_rejects_invalid_stale_and_mismatched_versions_without_reading
+    alterations = [
+      ["X-CF-Email-Signature", "invalid", :bad_signature],
+      ["X-CF-Email-Timestamp", (NOW - 301).to_s, :stale],
+      ["X-CF-Email-Envelope", "invalid", :bad_signature],
+      ["X-CF-Email-Metadata", nil, :bad_signature],
+      ["X-CF-Email-Signature-Version", "2", :bad_signature],
+      ["X-CF-Email-Signature-Version", "1", :bad_signature]
+    ]
+    alterations.each do |name, value, expected|
+      body = ChunkedBody.new(RAW)
+      result = verify(headers.merge(name => value), body: body)
+      assert_equal expected, result.status
+      assert_nil result.message
+      assert_empty body.requested
+    end
+  end
+
+  def test_malformed_metadata_is_rejected_before_body_read
+    invalid = [
+      "not+base64", "#{ENCODED}=", "a" * (Metadata::MAX_ENCODED_BYTES + 1),
+      encode({"source" => "a", "data" => []}),
+      encode({"source" => "a\n", "data" => {}}),
+      encode(PROVIDER.merge("extra" => true)),
+      Cloudflare::Email::Signing.base64url_encode("\xff".b),
+      Cloudflare::Email::Signing.base64url_encode('{"source":"a","data":{"x":"\\ud800"}}')
+    ]
+    nested = {}
+    7.times { nested = {"child" => nested} }
+    invalid << encode({"source" => "a", "data" => nested})
+    invalid.each do |metadata|
+      body = ChunkedBody.new(RAW)
+      assert_equal :bad_signature, verify(headers.merge("X-CF-Email-Metadata" => metadata), body: body).status
+      assert_empty body.requested
+    end
+  end
+
+  def test_valid_but_tampered_metadata_and_body_fail_authentication
+    tampered = encode(PROVIDER.merge("data" => {"spf" => "fail"}))
+    result = verify(headers.merge("X-CF-Email-Metadata" => tampered))
+    assert_equal :bad_signature, result.status
+    assert_nil result.message
+    assert_equal :bad_signature, verify(body: RAW + "changed").status
+  end
+
+  def test_declared_oversize_is_rejected_before_read_and_understated_size_does_not_bypass_limit
+    body = ChunkedBody.new(RAW)
+    assert_equal :too_large, verify(body: body, content_length: "6", max_email_bytes: 5).status
+    assert_empty body.requested
+    oversized = RAW + "extra"
+    body = ChunkedBody.new(oversized)
+    assert_equal :too_large, verify(headers(raw: oversized), body: body, content_length: "1", max_email_bytes: 5).status
+    assert_equal [6], body.requested
+    assert_equal :too_large, verify(headers(raw: oversized), body: oversized, max_email_bytes: 5).status
+  end
+
+  def test_short_io_reads_are_accumulated_within_the_limit
+    body = ChunkedBody.new(RAW, chunk_size: 2)
+    assert_equal :ok, verify(body: body, max_email_bytes: RAW.bytesize).status
+    assert_operator body.requested.length, :>, 1
+    assert body.requested.all? { |limit| limit.between?(1, RAW.bytesize + 1) }
+    oversized = RAW + "extra"
+    assert_equal :too_large, verify(headers(raw: oversized), body: ChunkedBody.new(oversized, chunk_size: 2), max_email_bytes: 5).status
+  end
+
+  def test_invalid_size_configuration_and_length_do_not_read_body
+    body = ChunkedBody.new(RAW)
+    [0, -1, "5", nil].each do |limit|
+      assert_raises(ArgumentError) { verify(body: body, max_email_bytes: limit) }
+    end
+    ["invalid", "-1"].each do |length|
+      assert_equal :bad_signature, verify(body: body, content_length: length).status
+    end
+    assert_empty body.requested
+  end
+
+  def test_verified_result_and_nested_metadata_are_immutable_copies
+    original = RAW.dup
+    result = verify(body: original)
+    original.clear
+    assert_equal RAW, result.message.body
+    assert result.frozen?
+    assert result.message.frozen?
+    assert_raises(FrozenError) { result.message.body << "changed" }
+    assert_raises(FrozenError) { result.message.envelope["to"].replace("other@example.test") }
+    assert_raises(FrozenError) { result.message.provider_metadata["data"]["flags"] << false }
+    assert_raises(FrozenError) { result.message.storage_metadata[Metadata::METADATA_KEY]["data"]["note"].clear }
+  end
+
+  def test_retries_and_reordered_objects_deduplicate_but_new_assertions_do_not
+    original = verify.message.message_checksum
+    reordered = {"data" => PROVIDER["data"].to_a.reverse.to_h, "source" => "cloudflare"}
+    retry_headers = headers(metadata: encode(reordered), timestamp: (NOW + 1).to_s)
+    assert_equal original, verify(retry_headers).message.message_checksum
+    refute_equal original, verify(headers(metadata: encode(PROVIDER.merge("source" => "other")))).message.message_checksum
+    refute_equal original, verify(headers(from: "other@example.test")).message.message_checksum
+    refute_equal original, verify(headers(to: "other@trial.test")).message.message_checksum
+    refute_equal original, verify(headers(metadata: nil)).message.message_checksum
+  end
+
+  def test_signature_uses_exact_timestamp_header_bytes
+    assert_equal :ok, verify(headers(timestamp: "0#{NOW}")).status
+  end
+end

--- a/test/routing_diagnostics_test.rb
+++ b/test/routing_diagnostics_test.rb
@@ -1,0 +1,220 @@
+require "test_helper"
+require "cloudflare/email/routing_diagnostics"
+require "cloudflare/email/check_route_task"
+
+class RoutingDiagnosticsTest < Minitest::Test
+  BASE = "https://api.cloudflare.com/client/v4".freeze
+  ADDRESS = "bot@in.example.com".freeze
+  WORKER = "ingress".freeze
+
+  def setup
+    super
+    list("/zones?name=in.example.com", [])
+    list("/zones?name=example.com", [{ id: "zone", name: "example.com", account: { id: "account" } }])
+    response("/zones/zone/email/routing", { enabled: true })
+    list("/zones/zone/dns_records?name=in.example.com", dns_records)
+    list("/zones/zone/email/routing/rules", [])
+    response("/zones/zone/email/routing/rules/catch_all", catch_all)
+  end
+
+  def response(path, result, **extra)
+    stub_request(:get, "#{BASE}#{path}").with(headers: { "Authorization" => "Bearer secret" })
+      .to_return(status: 200, body: JSON.generate({ result: result, success: true }.merge(extra)))
+  end
+
+  def list(path, result, page: 1, **extra)
+    response("#{path}#{path.include?('?') ? '&' : '?'}per_page=50&page=#{page}", result, **extra)
+  end
+
+  def dns_records
+    (1..3).map { |n| { name: "in.example.com", type: "MX", content: "route#{n}.mx.cloudflare.net" } } +
+      [{ name: "in.example.com", type: "TXT", content: "v=spf1 include:_spf.mx.cloudflare.net ~all" }]
+  end
+
+  def catch_all
+    { enabled: true, matchers: [{ type: "all" }], actions: [{ type: "worker", value: [WORKER] }] }
+  end
+
+  def literal(address: ADDRESS, worker: WORKER, enabled: true)
+    { enabled: enabled, priority: 0, matchers: [{ field: "to", type: "literal", value: address }],
+      actions: [{ type: "worker", value: [worker] }] }
+  end
+
+  def check(account_id: "account")
+    Cloudflare::Email::RoutingDiagnostics.new(api_token: "secret").check(address: ADDRESS, worker_name: WORKER, account_id: account_id)
+  end
+
+  def status_for(name)
+    check[:checks].find { |item| item[:name] == name }[:status]
+  end
+
+  def test_read_only_configuration_snapshot_passes_with_catchall
+    report = check
+    assert_equal "pass", report[:status]
+    assert_includes report[:limitations], "does not prove"
+    [:post, :put, :delete, :patch].each { |method| assert_not_requested method, /api.cloudflare.com/ }
+  end
+
+  def test_parent_google_mx_does_not_conflict_with_receiving_subdomain
+    list("/zones/zone/dns_records?name=in.example.com", dns_records + [{ name: "example.com", type: "MX", content: "aspmx.l.google.com" }])
+    assert_equal "pass", status_for("dns")
+  end
+
+  def test_parent_records_cannot_satisfy_subdomain_dns
+    list("/zones/zone/dns_records?name=in.example.com", dns_records.map { |r| r.merge(name: "example.com") })
+    assert_equal "fail", status_for("dns")
+  end
+
+  def test_conflicting_mx_or_multiple_spf_fails
+    list("/zones/zone/dns_records?name=in.example.com", dns_records + [{ name: "in.example.com", type: "MX", content: "aspmx.l.google.com" }])
+    assert_equal "fail", status_for("dns")
+    list("/zones/zone/dns_records?name=in.example.com", dns_records + [{ name: "in.example.com", type: "TXT", content: "v=spf1 -all" }])
+    assert_equal "fail", status_for("dns")
+  end
+
+  def test_spf_include_after_all_does_not_pass
+    records = dns_records
+    records.last[:content] = "v=spf1 -all include:_spf.mx.cloudflare.net"
+    list("/zones/zone/dns_records?name=in.example.com", records)
+    assert_equal "fail", status_for("dns")
+  end
+
+  def test_wrong_account_fails_and_missing_account_is_unknown
+    assert_equal "fail", check(account_id: "other")[:status]
+    list("/zones?name=example.com", [{ id: "zone", name: "example.com" }])
+    assert_equal "unknown", status_for("account")
+    assert_equal "pass", check(account_id: nil)[:status]
+  end
+
+  def test_disabled_routing_fails
+    response("/zones/zone/email/routing", { enabled: false })
+    assert_equal "fail", status_for("routing")
+  end
+
+  def test_missing_enabled_flag_is_not_success
+    response("/zones/zone/email/routing", {})
+    assert_equal "unknown", status_for("routing")
+  end
+
+  def test_explicit_wrong_worker_shadows_good_catchall
+    list("/zones/zone/email/routing/rules", [literal(worker: "different")])
+    assert_equal "fail", status_for("route")
+    assert_not_requested :get, "#{BASE}/zones/zone/email/routing/rules/catch_all"
+  end
+
+  def test_explicit_drop_shadows_good_catchall
+    list("/zones/zone/email/routing/rules", [literal.merge(actions: [{ type: "drop" }])])
+    assert_equal "fail", status_for("route")
+  end
+
+  def test_explicit_good_worker_wins_without_reading_disabled_catchall
+    list("/zones/zone/email/routing/rules", [literal])
+    response("/zones/zone/email/routing/rules/catch_all", catch_all.merge(enabled: false))
+    assert_equal "pass", status_for("route")
+    assert_not_requested :get, "#{BASE}/zones/zone/email/routing/rules/catch_all"
+  end
+
+  def test_disabled_literal_does_not_shadow_catchall
+    list("/zones/zone/email/routing/rules", [literal(worker: "old", enabled: false)])
+    assert_equal "pass", status_for("route")
+  end
+
+  def test_disabled_catchall_without_explicit_rule_fails
+    response("/zones/zone/email/routing/rules/catch_all", catch_all.merge(enabled: false))
+    assert_equal "fail", status_for("route")
+  end
+
+  def test_multiple_matching_rules_have_unverified_ordering_even_with_priority
+    list("/zones/zone/email/routing/rules", [literal, literal(worker: "other")])
+    assert_equal "unknown", status_for("route")
+    list("/zones/zone/email/routing/rules", [literal, literal(worker: "other").merge(priority: 5)])
+    assert_equal "unknown", status_for("route")
+  end
+
+  def test_unknown_matcher_cannot_be_ignored
+    list("/zones/zone/email/routing/rules", [literal.merge(matchers: [{ field: "to", type: "regex", value: ".*" }])])
+    assert_equal "unknown", status_for("route")
+  end
+
+  def test_explicit_route_on_later_page_shadows_catchall
+    list("/zones/zone/email/routing/rules", [literal(address: "someone@in.example.com")], result_info: { total_pages: 2 })
+    list("/zones/zone/email/routing/rules", [literal(worker: "other")], page: 2, result_info: { total_pages: 2 })
+    assert_equal "fail", status_for("route")
+  end
+
+  def test_dns_pagination_collects_all_records
+    list("/zones/zone/dns_records?name=in.example.com", dns_records.take(2), result_info: { total_pages: 2 })
+    list("/zones/zone/dns_records?name=in.example.com", dns_records.drop(2), page: 2, result_info: { total_pages: 2 })
+    assert_equal "pass", status_for("dns")
+  end
+
+  def test_pagination_limit_never_passes_partial_list
+    1.upto(Cloudflare::Email::RoutingDiagnostics::MAX_PAGES) do |page|
+      list("/zones/zone/email/routing/rules", [literal(address: "other@in.example.com")], page: page, result_info: { total_pages: 100 })
+    end
+    assert_equal "unknown", status_for("route")
+    assert_not_requested :get, "#{BASE}/zones/zone/email/routing/rules?per_page=50&page=51"
+  end
+
+  def test_missing_zone_prevents_green_report
+    list("/zones?name=example.com", [])
+    assert_equal "fail", check[:status]
+  end
+
+  def test_duplicate_zones_are_unknown
+    zone = { id: "zone", name: "example.com" }
+    list("/zones?name=example.com", [zone, zone])
+    assert_equal "unknown", check[:status]
+  end
+
+  def test_provider_errors_are_sanitized_and_do_not_stop_other_checks
+    stub_request(:get, "#{BASE}/zones/zone/email/routing").to_return(status: 403, body: "secret token and upstream details")
+    report = check
+    assert_equal "unknown", report[:status]
+    refute_includes JSON.generate(report), "secret"
+    assert_equal "pass", report[:checks].find { |c| c[:name] == "route" }[:status]
+  end
+
+  def test_invalid_json_and_oversized_response_are_unknown
+    stub_request(:get, "#{BASE}/zones/zone/email/routing").to_return(status: 200, body: "secret invalid json")
+    assert_equal "unknown", status_for("routing")
+    stub_request(:get, "#{BASE}/zones/zone/email/routing").to_return(status: 200, body: "x" * (Cloudflare::Email::RoutingDiagnostics::MAX_BYTES + 1))
+    assert_equal "unknown", status_for("routing")
+  end
+
+  def test_timeout_is_unknown_and_does_not_stop_other_checks
+    stub_request(:get, "#{BASE}/zones/zone/email/routing").to_timeout
+    assert_equal "unknown", status_for("routing")
+    assert_equal "pass", status_for("route")
+  end
+
+  def test_malformed_nested_provider_data_is_unknown
+    list("/zones?name=example.com", [{ id: "zone", name: "example.com", account: "invalid" }])
+    assert_equal "unknown", status_for("account")
+    list("/zones/zone/email/routing/rules", [], result_info: "invalid")
+    assert_equal "unknown", status_for("route")
+  end
+
+  def test_invalid_success_flag_is_not_accepted
+    response("/zones/zone/email/routing", { enabled: true }, success: "yes")
+    assert_equal "unknown", status_for("routing")
+  end
+
+  def test_unknown_matching_rule_enabled_state_does_not_fall_back
+    list("/zones/zone/email/routing/rules", [literal.merge(enabled: nil)])
+    assert_equal "unknown", status_for("route")
+  end
+
+  def test_task_returns_nonzero_for_unknown_and_does_not_echo_exceptions
+    io = StringIO.new
+    Cloudflare::Email::Credentials.stub(:management_token, "secret") do
+      Cloudflare::Email::Credentials.stub(:account_id, "account") do
+        assert_equal 0, Cloudflare::Email::CheckRouteTask.call(address: ADDRESS, worker_name: WORKER, io: io)
+        response("/zones/zone/email/routing", {})
+        assert_equal 1, Cloudflare::Email::CheckRouteTask.call(address: ADDRESS, worker_name: WORKER, io: io)
+        assert_equal 1, Cloudflare::Email::CheckRouteTask.call(address: "secret-invalid-input", worker_name: WORKER, io: io)
+      end
+    end
+    refute_includes io.string, "secret"
+  end
+end

--- a/test/support/custom_ingress.rb
+++ b/test/support/custom_ingress.rb
@@ -1,0 +1,246 @@
+require_relative "../test_helper"
+require "tmpdir"
+require "fileutils"
+require "rails"
+require "active_record/railtie"
+require "action_controller/railtie"
+require "action_mailer/railtie"
+require "active_job/railtie"
+require "active_storage/engine"
+require "action_mailbox/engine"
+require "cloudflare/email/engine"
+require "cloudflare/email/tenancy"
+require "cloudflare/email/mailboxes/configuration"
+require "rack/test"
+
+CUSTOM_INGRESS_ROOT = Dir.mktmpdir("cf-tenant-ingress")
+ENV["RAILS_ENV"] = "test"
+ENV["DATABASE_URL"] = "sqlite3:#{CUSTOM_INGRESS_ROOT}/directory.sqlite3"
+ENV["CLOUDFLARE_INGRESS_SECRET"] = "test-ingress-secret"
+Minitest.after_run do
+  ActiveRecord::Base.connection_handler.clear_all_connections!
+  FileUtils.remove_entry(CUSTOM_INGRESS_ROOT)
+end
+
+class MailboxDirectoryRecord < ActiveRecord::Base
+  self.abstract_class = true
+  establish_connection(adapter: "sqlite3", database: "#{CUSTOM_INGRESS_ROOT}/directory.sqlite3")
+end
+class MailboxTenantRecord < ActiveRecord::Base
+  self.abstract_class = true
+  connects_to shards: %i[alpha beta].to_h { |key|
+    [key, { writing: { adapter: "sqlite3", database: "#{CUSTOM_INGRESS_ROOT}/#{key}.sqlite3" } }]
+  }
+end
+Cloudflare::Email::Tenancy.configure(base_class: MailboxTenantRecord,
+  switch: ->(key, &block) { MailboxTenantRecord.connected_to(role: :writing, shard: key.to_sym, &block) },
+  current: -> { MailboxTenantRecord.current_shard.to_s })
+Cloudflare::Email::Mailboxes.configure(directory_base: MailboxDirectoryRecord)
+require "cloudflare/email/mailboxes"
+require "cloudflare/email/verification"
+require "cloudflare/email/ingress"
+require "cloudflare/email/provider_metadata"
+
+# This fixture host uses Rails shards for framework records as well as gem
+# records. Production hosts must configure their tenancy adapter equivalently.
+module MailboxFrameworkConnection
+  def connection_pool
+    Cloudflare::Email::Tenancy.require_context!
+    MailboxTenantRecord.connection_pool
+  end
+end
+
+class CustomIngressApp < Rails::Application
+  config.root = CUSTOM_INGRESS_ROOT
+  config.eager_load = false
+  config.enable_reloading = false
+  config.secret_key_base = "t" * 64
+  config.hosts.clear
+  config.logger = Logger.new(File::NULL)
+  config.action_dispatch.show_exceptions = :none
+  config.active_job.queue_adapter = :test
+  config.action_mailbox.ingress = :cloudflare
+  config.active_storage.service = :local
+  config.active_storage.service_configurations = {
+    local: {service: "Disk", root: "#{CUSTOM_INGRESS_ROOT}/blobs"}
+  }
+  config.to_prepare do
+    ActionMailbox::Record.singleton_class.prepend(MailboxFrameworkConnection)
+    ActiveStorage::Record.singleton_class.prepend(MailboxFrameworkConnection)
+  end
+end
+CustomIngressApp.initialize!
+
+class ApplicationMailbox < ActionMailbox::Base
+  routing all: :capture
+end
+class CaptureMailbox < ApplicationMailbox
+  class_attribute :captures, default: []
+  def process
+    self.class.captures += [[Cloudflare::Email::Tenancy.require_context!, inbound_email.id,
+      mail.subject, inbound_email.raw_email.download, Cloudflare::Email::ProviderMetadata.for(inbound_email)]]
+  end
+end
+
+ActiveRecord::Migration.verbose = false
+%w[activestorage actionmailbox].each do |name|
+  Dir["#{Gem.loaded_specs.fetch(name).full_gem_path}/db/migrate/*.rb"].each { |path| require path }
+end
+%w[outbox/templates/create_cloudflare_email_outbox tracking/templates/create_cloudflare_email_event_receipts
+   mailboxes/templates/create_cloudflare_email_receiving_domains mailboxes/templates/create_cloudflare_email_mailboxes
+   mailboxes/templates/create_cloudflare_email_shared_events].each { |path| require "generators/cloudflare/email/#{path}" }
+CreateCloudflareEmailReceivingDomains.new.migrate(:up)
+CreateCloudflareEmailSharedEvents.new.migrate(:up)
+%w[alpha beta].each do |key|
+  ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: "#{CUSTOM_INGRESS_ROOT}/#{key}.sqlite3")
+  [CreateActiveStorageTables, CreateActionMailboxTables, CreateCloudflareEmailOutbox,
+   CreateCloudflareEmailEventReceipts, CreateCloudflareEmailMailboxes].each { |migration| migration.new.migrate(:up) }
+  directory = Cloudflare::Email::Mailboxes.register_domain(domain: "#{key}.example.com", tenant_key: key, account_id: "account")
+  Cloudflare::Email::Mailboxes.activate_domain!(directory.id, evidence: "isolated test setup")
+  Cloudflare::Email::Mailboxes.for_tenant(key) do |session|
+    box = session.create(name: "Support", address: "support@#{key}.example.com")
+    session.activate_address!(box.addresses.first.id, evidence: "isolated test route")
+    address = session.add_address(box.id, address: "alias@#{key}.example.com")
+    session.activate_address!(address.id, evidence: "isolated test alias")
+  end
+end
+
+
+# The host owns HTTP status codes and review policy. It verifies before looking
+# up a tenant, and checks policy inside that tenant before storing raw mail.
+class CustomEmailController < ActionController::API
+  def create
+    result = Cloudflare::Email::Ingress.verify(
+      secret: ENV.fetch("CLOUDFLARE_INGRESS_SECRET"),
+      headers: request.headers, body: request.body,
+      content_length: request.content_length, max_email_bytes: 1024 * 1024)
+    return head(:unauthorized) unless result.status == :ok
+
+    verified = result.message
+    held = false
+    Cloudflare::Email::Mailboxes.receive(recipient: verified.envelope.fetch("to")) do
+      # Synthetic host policy; no claim that this is a provider SPF/DMARC API.
+      if verified.provider_metadata&.dig("data", "host_review") == true
+        held = true
+        next nil
+      end
+      verified.persist_action_mailbox!
+    end
+    head(held ? :accepted : :created)
+  rescue Cloudflare::Email::Mailboxes::Unavailable
+    head :unprocessable_entity
+  end
+end
+Rails.application.routes.draw { post "/custom-email", to: "custom_email#create" }
+
+class CustomIngressIntegrationTest < Minitest::Test
+  include Rack::Test::Methods
+  Email = Cloudflare::Email
+  def app = Rails.application
+
+  def setup
+    CaptureMailbox.captures = []
+    ActiveJob::Base.queue_adapter.enqueued_jobs.clear
+    %w[alpha beta].each do |key|
+      Email::Mailboxes.for_tenant(key) do
+        Email::Mailboxes::Message.delete_all
+        ActionMailbox::InboundEmail.destroy_all
+        ActiveStorage::Blob.delete_all
+      end
+    end
+  end
+
+  def raw
+    "From: sender@example.net\r\nTo: misleading@example.net\r\nSubject: Custom pipeline\r\nMessage-ID: <custom@example.net>\r\nContent-Transfer-Encoding: binary\r\n\r\n".b + "\x00\xff\xfe".b
+  end
+
+  def post_mail(recipient, metadata: nil, version: nil, signature_valid: true)
+    version ||= metadata ? "3" : "2"
+    envelope = Email::Envelope.encode(from: "sender@example.net", to: recipient)
+    encoded = metadata && Email::Signing.base64url_encode(JSON.generate(metadata))
+    timestamp = Time.now.to_i.to_s
+    prefix = version == "3" ? "v3.#{timestamp}.#{envelope}.#{encoded}." : "v2.#{timestamp}.#{envelope}."
+    signature = Email::Signing.hmac_hex(signature_valid ? "test-ingress-secret" : "wrong", prefix.b + raw)
+    headers = {
+      "CONTENT_TYPE" => "message/rfc822",
+      "HTTP_X_CF_EMAIL_TIMESTAMP" => timestamp,
+      "HTTP_X_CF_EMAIL_SIGNATURE" => signature,
+      "HTTP_X_CF_EMAIL_SIGNATURE_VERSION" => version,
+      "HTTP_X_CF_EMAIL_ENVELOPE" => envelope
+    }
+    headers["HTTP_X_CF_EMAIL_METADATA"] = encoded if encoded
+    post "/custom-email", raw, headers
+  end
+
+  def metadata
+    { "source" => "cloudflare", "data" => { "archive_key" => "synthetic/archive.eml" } }
+  end
+
+  def test_custom_controller_stores_metadata_before_tenant_routing_jobs
+    %w[alpha beta].each do |tenant|
+      post_mail("support@#{tenant}.example.com", metadata: metadata)
+      assert_equal 201, last_response.status
+      Email::Mailboxes.for_tenant(tenant) do
+        assert_equal 1, Email::Mailboxes::Message.count
+        inbound = ActionMailbox::InboundEmail.last
+        assert_equal raw, inbound.raw_email.download
+        assert_equal metadata, Email::ProviderMetadata.for(inbound)
+        assert_equal "support@#{tenant}.example.com", Email::Envelope.for(inbound).fetch("to")
+      end
+    end
+    jobs = ActiveJob::Base.queue_adapter.enqueued_jobs.select { |job| job[:job] == ActionMailbox::RoutingJob }
+    assert_equal 2, jobs.size
+    jobs.reverse_each { |job| ActiveJob::Base.execute(job) }
+    assert_equal %w[beta alpha], CaptureMailbox.captures.map(&:first)
+    assert CaptureMailbox.captures.all? { |capture| capture[3] == raw && capture[4] == metadata }
+    assert_nil Email::Tenancy.current_key
+  end
+
+  def test_host_review_policy_can_stop_raw_storage_and_processing
+    post_mail("support@alpha.example.com", metadata: { "source" => "cloudflare", "data" => { "host_review" => true } })
+    assert_equal 202, last_response.status
+    Email::Mailboxes.for_tenant("alpha") do
+      assert_equal 0, ActionMailbox::InboundEmail.count
+      assert_equal 0, Email::Mailboxes::Message.count
+      assert_equal 0, ActiveStorage::Blob.count
+    end
+    assert_empty ActiveJob::Base.queue_adapter.enqueued_jobs.select { |job| job[:job] == ActionMailbox::RoutingJob }
+  end
+
+  def test_unsigned_metadata_and_unregistered_addresses_never_persist
+    post_mail("support@alpha.example.com", metadata: metadata, version: "2")
+    assert_equal 401, last_response.status
+    post_mail("support@alpha.example.com", metadata: metadata, signature_valid: false)
+    assert_equal 401, last_response.status
+    post_mail("unknown@alpha.example.com", metadata: metadata)
+    assert_equal 422, last_response.status
+    %w[alpha beta].each do |tenant|
+      Email::Mailboxes.for_tenant(tenant) { assert_equal 0, ActionMailbox::InboundEmail.count }
+    end
+    assert_nil Email::Tenancy.current_key
+  end
+
+  def test_binary_retries_are_idempotent_but_alias_and_metadata_context_are_distinct
+    2.times do
+      post_mail("support@alpha.example.com", metadata: metadata)
+      assert_equal 201, last_response.status
+    end
+    post_mail("alias@alpha.example.com", metadata: metadata)
+    assert_equal 201, last_response.status
+    post_mail("support@alpha.example.com", metadata: { "source" => "cloudflare", "data" => { "archive_key" => "other.eml" } })
+    assert_equal 201, last_response.status
+    Email::Mailboxes.for_tenant("alpha") do
+      assert_equal 3, ActionMailbox::InboundEmail.count
+      assert_equal 3, Email::Mailboxes::Message.count
+      assert ActionMailbox::InboundEmail.all.all? { |inbound| inbound.raw_email.download == raw }
+    end
+  end
+
+  def test_v2_custom_ingress_remains_available_without_metadata
+    2.times { post_mail("support@alpha.example.com"); assert_equal 201, last_response.status }
+    Email::Mailboxes.for_tenant("alpha") do
+      assert_equal 1, ActionMailbox::InboundEmail.count
+      assert_nil Email::ProviderMetadata.for(ActionMailbox::InboundEmail.last)
+    end
+  end
+end

--- a/test/support/rails_app.rb
+++ b/test/support/rails_app.rb
@@ -189,16 +189,54 @@ class RailsAppTest < Minitest::Test
       Rails.env = original_env
     end
 
-    def signed_post(body, timestamp: Time.now.to_i.to_s, signature: nil, version: "2",
+    def signed_post(body, timestamp: Time.now.to_i.to_s, signature: nil, version: "2", metadata: nil,
       envelope: Cloudflare::Email::Envelope.encode(from: "sender@example.com", to: "receiver@example.com"))
       signature ||= Cloudflare::Email::Verification.sign(secret: ENV.fetch("CLOUDFLARE_INGRESS_SECRET"), body: body,
-        timestamp: timestamp, version: version, envelope: envelope)
+        timestamp: timestamp, version: version, envelope: envelope, metadata: metadata)
       post "/rails/action_mailbox/cloudflare/inbound_emails", body,
         "CONTENT_TYPE" => "message/rfc822",
         "HTTP_X_CF_EMAIL_TIMESTAMP" => timestamp,
         "HTTP_X_CF_EMAIL_SIGNATURE" => signature,
         "HTTP_X_CF_EMAIL_SIGNATURE_VERSION" => version,
-        "HTTP_X_CF_EMAIL_ENVELOPE" => envelope
+        "HTTP_X_CF_EMAIL_ENVELOPE" => envelope,
+        "HTTP_X_CF_EMAIL_METADATA" => metadata
+    end
+
+    def test_v3_preserves_binary_mime_and_metadata_before_routing
+      body = "From: visible@example.com\r\nTo: unrelated@example.com\r\nMessage-ID: <v3-metadata@example.com>\r\n\r\n".b + "\x00\xff".b
+      envelope = Cloudflare::Email::Envelope.encode(from: "smtp@example.com", to: "bcc@example.com")
+      metadata = { "source" => "cloudflare", "data" => { "archive_key" => "test/archive.eml" } }
+      encoded = Cloudflare::Email::Signing.base64url_encode(JSON.generate(metadata))
+      observed = nil
+      ActionMailbox::RoutingJob.stub(:perform_later, ->(inbound) {
+        observed = [Cloudflare::Email::Envelope.for(inbound.reload), Cloudflare::Email::ProviderMetadata.for(inbound)]
+      }) do
+        signed_post(body, version: "3", envelope: envelope, metadata: encoded)
+      end
+      assert_equal 200, last_response.status, last_response.body
+      assert_equal [{ "from" => "smtp@example.com", "to" => "bcc@example.com" }, metadata], observed
+      inbound = ActionMailbox::InboundEmail.find_by!(message_id: "v3-metadata@example.com")
+      assert_equal metadata, Cloudflare::Email::ProviderMetadata.for(inbound.reload)
+      assert_equal body, inbound.raw_email.download
+      before = ActionMailbox::InboundEmail.count
+      signed_post(body, version: "3", envelope: envelope, metadata: encoded)
+      assert_equal 200, last_response.status
+      assert_equal before, ActionMailbox::InboundEmail.count
+    end
+
+    def test_v2_rejects_extra_provider_metadata_before_persistence_or_routing
+      body = "From: sender@example.com\r\nMessage-ID: <unsigned-provider-metadata@example.com>\r\n\r\nBody\r\n"
+      timestamp = Time.now.to_i.to_s
+      envelope = Cloudflare::Email::Envelope.encode(from: "sender@example.com", to: "receiver@example.com")
+      signature = Cloudflare::Email::Verification.sign(secret: ENV.fetch("CLOUDFLARE_INGRESS_SECRET"),
+        body: body, timestamp: timestamp, envelope: envelope)
+      metadata = Cloudflare::Email::Signing.base64url_encode(JSON.generate({ "source" => "cloudflare", "data" => {} }))
+      before = ActionMailbox::InboundEmail.count
+      ActionMailbox::RoutingJob.stub(:perform_later, ->(*) { flunk "unsigned provider metadata must not route" }) do
+        signed_post(body, timestamp: timestamp, signature: signature, envelope: envelope, metadata: metadata)
+      end
+      assert_equal 401, last_response.status
+      assert_equal before, ActionMailbox::InboundEmail.count
     end
 
     def test_v2_preserves_mime_and_commits_trusted_envelope_before_routing
@@ -233,15 +271,19 @@ class RailsAppTest < Minitest::Test
     end
 
     def test_ingress_bounds_body_reads_even_without_content_length
-      previous = ENV["MAX_EMAIL_BYTES"]
-      ENV["MAX_EMAIL_BYTES"] = "16"
       stream = StringIO.new("example MIME body bytes")
-      controller = Cloudflare::Email::IngressController.new
-      controller.define_singleton_method(:request) { Struct.new(:body).new(stream) }
-      assert_equal 17, controller.send(:raw_body).bytesize
+      envelope = Cloudflare::Email::Envelope.encode(from: "sender@example.com", to: "receiver@example.com")
+      timestamp = Time.now.to_i.to_s
+      signature = Cloudflare::Email::Verification.sign(secret: ENV.fetch("CLOUDFLARE_INGRESS_SECRET"),
+        timestamp: timestamp, envelope: envelope, body: stream.string)
+      result = Cloudflare::Email::Ingress.verify(secret: ENV.fetch("CLOUDFLARE_INGRESS_SECRET"),
+        body: stream, content_length: nil, max_email_bytes: 16, headers: {
+          "X-CF-Email-Timestamp" => timestamp, "X-CF-Email-Signature" => signature,
+          "X-CF-Email-Signature-Version" => "2", "X-CF-Email-Envelope" => envelope
+        })
+      assert_equal :too_large, result.status
+      assert_nil result.message
       assert_equal 17, stream.pos
-    ensure
-      ENV["MAX_EMAIL_BYTES"] = previous
     end
 
     def test_v2_deduplication_is_scoped_to_exact_smtp_recipient

--- a/test/verification_edge_cases_test.rb
+++ b/test/verification_edge_cases_test.rb
@@ -74,13 +74,17 @@ class VerificationEdgeCasesTest < Minitest::Test
     # Integer("0100", 10) is fine, but "0x1" would fail — we pass base 10 strictly.
     body = "hello"
     ts = "0100"
-    sig = sign("100", body)
-    # "0100" parses as 100 in base 10, so this is actually accepted if fresh
+    sig = sign(ts, body)
+    # Freshness uses decimal 100; authentication retains the exact header bytes.
     result = Cloudflare::Email::Verification.verify(
       version: "2", envelope: ENVELOPE,
       secret: SECRET, body: body, timestamp: ts, signature: sig, now: 100,
     )
     assert_equal :ok, result
+    assert_equal :bad_signature, Cloudflare::Email::Verification.verify(
+      version: "2", envelope: ENVELOPE,
+      secret: SECRET, body: body, timestamp: ts, signature: sign("100", body), now: 100,
+    )
   end
 
   def test_hex_timestamp_rejected


### PR DESCRIPTION
## What changes

Applications with an existing email Worker and ingestion endpoint can now reuse the gem's bounded request verification and optional mailbox/tenant persistence without replacing their archive, sender review, or document processing. The built-in ActionMailbox endpoint uses the same verifier.

Custom Workers can opt into v3 signatures that bind provider metadata to the SMTP envelope and exact raw bytes. The bundled Worker keeps v2 by default. Signed metadata is a forwarding integration's assertion, not proof of SPF/DKIM/DMARC or sender authorization. Deploy the receiver before enabling v3.

A new GET-only `cloudflare:email:check_route` task checks exact receiving-domain DNS and explicit/catch-all Worker selection. It reports missing or unknown configuration without repairing it or claiming live delivery. New guides explain incremental adoption and application responsibilities.

## Verification

- Ruby 3.4.1 with Rails 7.2, 8.0 and 8.1 full suites.
- Cross-language v3 binary/Unicode signature vector and bounded stream tests.
- Custom and built-in ingress: durable metadata before routing, duplicate handling, host policy, and separate SQLite tenant databases.
- 45 Worker tests and Wrangler dry-run.
- Packaged gem installation and local workerd-to-Rails delivery/failure checks.
- Independent implementation reviews; fixed short-read handling and exact timestamp signing.

No Rebulk changes, live routing changes, deployment, or gem publication. See the dated verification report for scope and limits.
