### PR TITLE
Expose mailbox destination context with persisted email integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+- Add `Mailboxes.with_recipient` for active-address resolution and immutable
+  destination context with host-owned persistence, without ActionMailbox.
+- Yield the same destination from `Mailboxes.receive` so apps can link their
+  business records while retaining gem-managed raw email, metadata and membership
+  persistence. Host exceptions propagate instead of being reported as missing
+  mailbox records; existing no-argument receive blocks continue to work.
+
 - Add a bounded, Rails-independent `Ingress.verify` API for existing ingestion
   pipelines, with optional ActionMailbox persistence and tenant registry routing.
 - Add opt-in v3 signatures for provider metadata supplied by custom Workers.

--- a/docs/custom-ingress.md
+++ b/docs/custom-ingress.md
@@ -44,10 +44,12 @@ class InboundEmailsController < ActionController::API
 
     Cloudflare::Email::Mailboxes.receive(
       recipient: verified.envelope.fetch("to")
-    ) do
+    ) do |destination|
       # This block runs in the recipient's tenant. Apply your sender/review
       # policy here, before persistence schedules Action Mailbox routing.
       # Your policy may raise a host error or return nil instead of persisting.
+      # destination.owner_ref identifies your site/team; validate it using
+      # your application's policy in this tenant context.
       verified.persist_action_mailbox!
     end
 
@@ -65,6 +67,83 @@ Do not use the MIME `To` header or an unauthenticated URL subdomain to select st
 `persist_action_mailbox!` stores the verified raw bytes and metadata in Action Mailbox. The receiving block adds mailbox membership in the same tenant transaction. Rails schedules normal routing after the transaction commits. Apply policies that must stop processing before calling persistence; a check performed after receiving returns can be too late.
 
 For an application that owns a different raw-email store, use `verified.body`, `verified.envelope`, `verified.provider_metadata`, `verified.message_checksum`, and `verified.storage_metadata` with your own persistence/transaction system. `Mailboxes.receive` specifically expects an Action Mailbox inbound email record (or nil) from its block; do not pass an unrelated processing record. The gem does not choose your archive retention, held-message model, or document queue.
+
+## Persist the email and link your business record
+
+Email persistence remains part of the gem's supported path. Action Mailbox stores
+the raw MIME using Active Storage, the verifier saves authenticated metadata, and
+`Mailboxes.receive` adds the inbox membership. Your processing/review record can
+refer to that email rather than storing a second copy of its raw content:
+
+```ruby
+Cloudflare::Email::Mailboxes.receive(
+  recipient: verified.envelope.fetch("to")
+) do |destination|
+  # Validate owner_ref and sender policy here, before any routing is scheduled.
+  inbound = verified.persist_action_mailbox!
+  if inbound
+    # Example host model, on the SAME tenant connection as the gem records.
+    EmailIntake.create!(
+      inbound_email_id: inbound.id,
+      mailbox_id: destination.mailbox_id,
+      owner_ref: destination.owner_ref
+    )
+  end
+  inbound # Return the ActionMailbox record; duplicate deliveries return nil.
+end
+```
+
+The database writes commit together. A host failure rolls back the new email,
+membership and host link and prevents the routing job from being enqueued. This
+does not make an R2 archive, another database, or external API calls transactional.
+Host exceptions propagate; only unavailable registry destinations are translated
+to `Mailboxes::Unavailable`. Existing blocks without a destination argument still
+work.
+
+Persisting through ActionMailbox schedules its normal routing after commit. Put
+your processing in that route or a deliberately coordinated job pipeline. If an
+email must be held, implement a routing policy that cannot process it before
+approval; storing it is not itself a review gate. A routing job failure also needs
+normal job retry/recovery. Receipt deduplication does not make every downstream
+business side effect idempotent.
+
+Managed mailbox membership protects raw email from ActionMailbox's normal
+automatic incineration. Archiving a mailbox message keeps its content; deliberate
+purging can remove it once no other membership references the email. Raw email
+saved without membership follows the normal ActionMailbox lifecycle. Keep host
+references, backup and R2 retention consistent with your chosen deletion policy.
+Multi-tenancy remains opt-in.
+
+## Resolve an address with your own persistence
+
+If your application already owns its raw-email store, use the standalone API:
+
+```ruby
+Cloudflare::Email::Mailboxes.with_recipient(
+  recipient: verified.envelope.fetch("to")
+) do |destination|
+  # Example host-owned persistence service; it must commit durably before ACK.
+  ExistingEmailStore.save!(
+    tenant_key: destination.tenant_key,
+    mailbox_id: destination.mailbox_id,
+    recipient: destination.recipient,
+    raw: verified.body,
+    metadata: verified.storage_metadata
+  )
+end
+```
+
+This checks the active domain, address and mailbox, enters the configured tenant,
+and yields an immutable `Destination` with `tenant_key`, `mailbox_id`, `address_id`,
+`receiving_domain_id`, `recipient` and `owner_ref`. It returns the block's result,
+creates no email or membership, starts no storage transaction, and requires no
+ActionMailbox. Configure the optional mailbox registry and tenant adapter as usual.
+
+Both APIs must be called after complete request verification. Destination values
+are routing snapshots, not authorization tokens: an owner reference does not
+prove a site still exists or that a sender may submit to it. Use records inside
+their tenant context and recheck lifecycle/permissions when later work requires
+it. Both APIs restore the previous tenant context when the block returns or raises.
 
 ## Carry Worker metadata with authenticated provenance
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -37,6 +37,11 @@ persist through ActionMailbox. Optional v3 signatures authenticate custom Worker
 metadata; your application still decides whether its provenance and sender policy
 are acceptable. The bundled Worker continues to use v2 by default.
 
+`Mailboxes.receive` yields the resolved destination while retaining email and
+membership persistence, so your own processing record can link to the saved mail.
+`Mailboxes.with_recipient` offers the same destination context for applications
+that own their storage. Neither replaces your sender policy or business workflow.
+
 [Read-only routing diagnostics](routing-diagnostics.md) inspect exact-domain DNS
 and the selected Worker route. They distinguish missing configuration from an
 incomplete inspection; a passing snapshot does not prove live email delivery.

--- a/docs/verification/2026-09-12-destination-context.md
+++ b/docs/verification/2026-09-12-destination-context.md
@@ -1,0 +1,46 @@
+# Destination context and email persistence verification
+
+Scope: standalone accepted-address resolution and destination context yielded
+from the existing persisted receive path. No Rebulk deployment or gem release.
+
+## Results
+
+- Full suites on Ruby 3.4.1 with Rails 7.2, 8.0 and 8.1: each passed with
+  257 top-level tests and 916 assertions. These include subprocess integration
+  fixtures whose internal assertions are not included in that top-level count.
+- The standalone service fixture uses two real SQLite tenant databases with
+  colliding mailbox IDs and no ActionMailbox loaded. It verifies host-owned
+  binary-email persistence, immutable destinations, aliases, inactive records,
+  nested context restoration, host exceptions and missing-tenant refusal without
+  creating a database. Lookup itself creates no mailbox membership.
+- The custom Rails ingress fixture verifies saved raw MIME and signed metadata,
+  mailbox membership, and a host business link created from the destination.
+  Routing jobs execute in the correct tenant after commit. Retries do not
+  duplicate the linked records. A host write failure rolls back the email and
+  membership and schedules no routing job.
+- Existing callbacks remain supported, including strict zero-argument lambdas.
+- Packaged plain Ruby and Rails consumer checks pass, including mailbox ingress,
+  routing and existing retention behavior.
+- Independent review found no remaining blockers. A callback arity compatibility
+  issue was fixed and covered before completion.
+
+## Reproduce
+
+```sh
+BUNDLE_GEMFILE=gemfiles/rails_7_2.gemfile bundle exec rake test
+BUNDLE_GEMFILE=gemfiles/rails_8_0.gemfile bundle exec rake test
+BUNDLE_GEMFILE=gemfiles/rails_8_1.gemfile bundle exec rake test
+bundle exec ruby script/verify_package.rb
+```
+
+## Boundaries
+
+Destination context is a lifecycle snapshot, not host authorization or a durable
+processing claim. Applications still validate owners and sender policy and make
+downstream work idempotent. The host owns custom-store transactions; `receive`
+preserves the existing shared tenant transaction for ActionMailbox persistence.
+Neither API makes cross-database or external object-store operations atomic.
+
+Managed mailbox memberships protect raw email from automatic incineration;
+deliberate purge, backups and host-reference cleanup remain application policy.
+These local tests do not verify Rebulk's actual queues, sender policy or archive.

--- a/lib/cloudflare/email/mailboxes/service.rb
+++ b/lib/cloudflare/email/mailboxes/service.rb
@@ -4,6 +4,16 @@ require "cloudflare/email/envelope"
 module Cloudflare
   module Email
     module Mailboxes
+      # A routing snapshot, not a model or an authorization token. Use it inside
+      # the yielded tenant context; later jobs must resolve/check policy again.
+      Destination = Struct.new(:tenant_key, :mailbox_id, :address_id,
+        :receiving_domain_id, :recipient, :owner_ref, keyword_init: true) do
+        def initialize(**attributes)
+          super(**attributes.transform_values { |value| value.is_a?(String) ? value.dup.freeze : value })
+          freeze
+        end
+      end
+
       class << self
         # Call after host authorization. The directory is a control-plane API,
         # not a public endpoint accepting arbitrary customer domain claims.
@@ -27,16 +37,23 @@ module Cloudflare
 
         # Only call after verifying the complete ingress HMAC. Resolve before
         # ActionMailbox or ActiveStorage accesses a tenant connection.
-        def receive(recipient:)
-          raise ArgumentError, "persistence block required" unless block_given?
-          address = canonical_address(recipient)
-          directory = ReceivingDomain.find_by(domain: address.split("@", 2).last, state: "active")
-          raise Unavailable, "receiving domain unavailable" unless directory
-          for_tenant(directory.tenant_key) do |session|
-            session.receive(address, directory) { yield }
+        def receive(recipient:, &block)
+          raise ArgumentError, "persistence block required" unless block
+          in_recipient_tenant(recipient) do |session, address, directory|
+            session.receive(address, directory) do |destination|
+              # Preserve strict callbacks accepted before destinations were yielded.
+              block.lambda? && block.arity.zero? ? block.call : block.call(destination)
+            end
           end
-        rescue ::ActiveRecord::RecordNotFound
-          raise Unavailable, "mailbox address unavailable"
+        end
+
+        # Lookup only: the host owns persistence and the block's return value.
+        # Verify ingress before calling this API. No ActionMailbox is required.
+        def with_recipient(recipient:)
+          raise ArgumentError, "a block is required" unless block_given?
+          in_recipient_tenant(recipient) do |session, address, directory|
+            session.with_recipient(address, directory) { |destination| yield destination }
+          end
         end
 
         def canonical_address(value)
@@ -44,6 +61,17 @@ module Cloudflare
             raise ValidationError, "mailbox address must be an ASCII dot-atom address"
           end
           value.downcase
+        end
+
+        private
+
+        def in_recipient_tenant(recipient)
+          address = canonical_address(recipient)
+          directory = ReceivingDomain.find_by(domain: address.split("@", 2).last, state: "active")
+          raise Unavailable, "receiving domain unavailable" unless directory
+          for_tenant(directory.tenant_key) do |session|
+            yield session, address, directory
+          end
         end
       end
 
@@ -237,18 +265,33 @@ module Cloudflare
           context!
           ensure_storage_connection! if defined?(::ActionMailbox::InboundEmail)
           Mailbox.transaction do
-            destination = Address.where(tenant_key: tenant_key, address: address, receiving_domain_id: directory.id, state: "active").first
-            raise Unavailable, "mailbox address unavailable" unless destination
-            mailbox = active_mailbox!(destination.mailbox_id)
-            active_domain!(destination)
-            inbound = yield
-            Message.create_or_find_by!(tenant_key: tenant_key, mailbox_id: mailbox.id,
+            destination = resolve_destination(address, directory)
+            inbound = yield destination
+            Message.create_or_find_by!(tenant_key: tenant_key, mailbox_id: destination.mailbox_id,
               inbound_email_id: inbound.id) { |row| row.recipient = address } if inbound
             inbound
           end
         end
 
+        def with_recipient(address, directory)
+          context!
+          yield resolve_destination(address, directory)
+        end
+
         private
+
+        def resolve_destination(address, directory)
+          destination = Address.where(tenant_key: tenant_key, address: address,
+            receiving_domain_id: directory.id, state: "active").first
+          raise Unavailable, "mailbox address unavailable" unless destination
+          mailbox = active_mailbox!(destination.mailbox_id)
+          active_domain!(destination)
+          Destination.new(tenant_key: tenant_key, mailbox_id: mailbox.id,
+            address_id: destination.id, receiving_domain_id: directory.id,
+            recipient: address, owner_ref: mailbox.owner_ref)
+        rescue ::ActiveRecord::RecordNotFound
+          raise Unavailable, "mailbox address unavailable"
+        end
 
         def context!
           raise ConfigurationError, "mailbox session used outside its tenant context" unless Tenancy.require_context! == tenant_key

--- a/test/support/custom_ingress.rb
+++ b/test/support/custom_ingress.rb
@@ -12,6 +12,7 @@ require "cloudflare/email/engine"
 require "cloudflare/email/tenancy"
 require "cloudflare/email/mailboxes/configuration"
 require "rack/test"
+require "minitest/mock"
 
 CUSTOM_INGRESS_ROOT = Dir.mktmpdir("cf-tenant-ingress")
 ENV["RAILS_ENV"] = "test"
@@ -31,6 +32,8 @@ class MailboxTenantRecord < ActiveRecord::Base
   connects_to shards: %i[alpha beta].to_h { |key|
     [key, { writing: { adapter: "sqlite3", database: "#{CUSTOM_INGRESS_ROOT}/#{key}.sqlite3" } }]
   }
+end
+class HostEmailIntake < MailboxTenantRecord
 end
 Cloudflare::Email::Tenancy.configure(base_class: MailboxTenantRecord,
   switch: ->(key, &block) { MailboxTenantRecord.connected_to(role: :writing, shard: key.to_sym, &block) },
@@ -95,10 +98,17 @@ CreateCloudflareEmailSharedEvents.new.migrate(:up)
   ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: "#{CUSTOM_INGRESS_ROOT}/#{key}.sqlite3")
   [CreateActiveStorageTables, CreateActionMailboxTables, CreateCloudflareEmailOutbox,
    CreateCloudflareEmailEventReceipts, CreateCloudflareEmailMailboxes].each { |migration| migration.new.migrate(:up) }
+  MailboxTenantRecord.connected_to(role: :writing, shard: key.to_sym) do
+    MailboxTenantRecord.connection.create_table(:host_email_intakes) do |table|
+      table.integer :inbound_email_id
+      table.integer :mailbox_id
+      table.string :owner_ref
+    end
+  end
   directory = Cloudflare::Email::Mailboxes.register_domain(domain: "#{key}.example.com", tenant_key: key, account_id: "account")
   Cloudflare::Email::Mailboxes.activate_domain!(directory.id, evidence: "isolated test setup")
   Cloudflare::Email::Mailboxes.for_tenant(key) do |session|
-    box = session.create(name: "Support", address: "support@#{key}.example.com")
+    box = session.create(name: "Support", address: "support@#{key}.example.com", owner_ref: "site:#{key}:42")
     session.activate_address!(box.addresses.first.id, evidence: "isolated test route")
     address = session.add_address(box.id, address: "alias@#{key}.example.com")
     session.activate_address!(address.id, evidence: "isolated test alias")
@@ -118,13 +128,18 @@ class CustomEmailController < ActionController::API
 
     verified = result.message
     held = false
-    Cloudflare::Email::Mailboxes.receive(recipient: verified.envelope.fetch("to")) do
+    Cloudflare::Email::Mailboxes.receive(recipient: verified.envelope.fetch("to")) do |destination|
       # Synthetic host policy; no claim that this is a provider SPF/DMARC API.
       if verified.provider_metadata&.dig("data", "host_review") == true
         held = true
         next nil
       end
-      verified.persist_action_mailbox!
+      inbound = verified.persist_action_mailbox!
+      if inbound
+        HostEmailIntake.create!(inbound_email_id: inbound.id,
+          mailbox_id: destination.mailbox_id, owner_ref: destination.owner_ref)
+      end
+      inbound
     end
     head(held ? :accepted : :created)
   rescue Cloudflare::Email::Mailboxes::Unavailable
@@ -143,6 +158,7 @@ class CustomIngressIntegrationTest < Minitest::Test
     ActiveJob::Base.queue_adapter.enqueued_jobs.clear
     %w[alpha beta].each do |key|
       Email::Mailboxes.for_tenant(key) do
+        HostEmailIntake.delete_all
         Email::Mailboxes::Message.delete_all
         ActionMailbox::InboundEmail.destroy_all
         ActiveStorage::Blob.delete_all
@@ -183,6 +199,9 @@ class CustomIngressIntegrationTest < Minitest::Test
       Email::Mailboxes.for_tenant(tenant) do
         assert_equal 1, Email::Mailboxes::Message.count
         inbound = ActionMailbox::InboundEmail.last
+        intake = HostEmailIntake.find_by!(inbound_email_id: inbound.id)
+        assert_equal Email::Mailboxes::Message.last.mailbox_id, intake.mailbox_id
+        assert_equal "site:#{tenant}:42", intake.owner_ref
         assert_equal raw, inbound.raw_email.download
         assert_equal metadata, Email::ProviderMetadata.for(inbound)
         assert_equal "support@#{tenant}.example.com", Email::Envelope.for(inbound).fetch("to")
@@ -205,6 +224,22 @@ class CustomIngressIntegrationTest < Minitest::Test
       assert_equal 0, ActiveStorage::Blob.count
     end
     assert_empty ActiveJob::Base.queue_adapter.enqueued_jobs.select { |job| job[:job] == ActionMailbox::RoutingJob }
+  end
+
+  def test_host_link_failure_rolls_back_email_membership_and_routing
+    failure = ->(*) { raise ActiveRecord::RecordNotFound, "host site unavailable" }
+    HostEmailIntake.stub(:create!, failure) do
+      assert_raises(ActiveRecord::RecordNotFound) do
+        post_mail("support@alpha.example.com", metadata: metadata)
+      end
+    end
+    Email::Mailboxes.for_tenant("alpha") do
+      assert_equal 0, ActionMailbox::InboundEmail.count
+      assert_equal 0, Email::Mailboxes::Message.count
+      assert_equal 0, HostEmailIntake.count
+    end
+    assert_empty ActiveJob::Base.queue_adapter.enqueued_jobs.select { |job| job[:job] == ActionMailbox::RoutingJob }
+    assert_nil Email::Tenancy.current_key
   end
 
   def test_unsigned_metadata_and_unregistered_addresses_never_persist
@@ -232,6 +267,7 @@ class CustomIngressIntegrationTest < Minitest::Test
     Email::Mailboxes.for_tenant("alpha") do
       assert_equal 3, ActionMailbox::InboundEmail.count
       assert_equal 3, Email::Mailboxes::Message.count
+      assert_equal 3, HostEmailIntake.count
       assert ActionMailbox::InboundEmail.all.all? { |inbound| inbound.raw_email.download == raw }
     end
   end

--- a/test/support/mailbox_service.rb
+++ b/test/support/mailbox_service.rb
@@ -23,6 +23,9 @@ class ServiceTenantRecord < ActiveRecord::Base
     [key, { writing: { adapter: "sqlite3", database: File.join(SERVICE_ROOT, "#{key}.sqlite3") } }]
   }
 end
+class ServiceEmailReceipt < ServiceTenantRecord
+  self.table_name = "host_email_receipts"
+end
 Cloudflare::Email::Tenancy.configure(base_class: ServiceTenantRecord,
   switch: ->(key, &block) { ServiceTenantRecord.connected_to(role: :writing, shard: key.to_sym, &block) },
   current: -> { ServiceTenantRecord.current_shard.to_s })
@@ -46,6 +49,11 @@ CreateCloudflareEmailSharedEvents.new.migrate(:up)
     CreateCloudflareEmailOutbox.new.migrate(:up)
     CreateCloudflareEmailEventReceipts.new.migrate(:up)
     CreateCloudflareEmailMailboxes.new.migrate(:up)
+    ServiceTenantRecord.connection.create_table(:host_email_receipts) do |table|
+      table.integer :mailbox_id
+      table.string :recipient
+      table.binary :raw
+    end
   end
 end
 ActiveJob::Base.queue_adapter = :test
@@ -67,6 +75,7 @@ class MailboxServiceIntegrationTest < Minitest::Test
       SERVICE_CLIENTS[key] = Email::Client.new(account_id: "shared", api_token: "test-token", retries: 0, retry_ambiguous: false)
       Box.for_tenant(key) do |session|
         [Box::OutboundMessage, Box::Message, Box::Address, Box::Mailbox,
+          ServiceEmailReceipt,
           Email::ActiveRecord::EventReceipt, Email::ActiveRecord::OutboundReconciliation,
           Email::ActiveRecord::OutboundRecipient, Delivery].each(&:delete_all)
         ServiceTenantRecord.connection.execute("DELETE FROM sqlite_sequence WHERE name = 'cloudflare_email_mailboxes'")
@@ -135,6 +144,99 @@ class MailboxServiceIntegrationTest < Minitest::Test
     end
     Box.for_tenant("beta") { |session| assert_equal 0, session.messages(42).count }
     assert_raises(Box::Unavailable) { Box.receive(recipient: "unknown@alpha.example.com") { flunk "stored unknown mail" } }
+  end
+
+  def test_with_recipient_persists_host_email_without_action_mailbox
+    refute defined?(::ActionMailbox::InboundEmail)
+    raw = "Subject: saved\r\n\r\nbinary\x00\xff".b
+    %w[alpha beta].each do |key|
+      receipt = Box.with_recipient(recipient: "SUPPORT@#{key.upcase}.EXAMPLE.COM") do |destination|
+        assert_equal key, Email::Tenancy.require_context!
+        assert_equal key, ServiceTenantRecord.current_shard.to_s
+        assert_equal 42, destination.mailbox_id
+        assert_equal "customer:42", destination.owner_ref
+        assert destination.frozen?
+        assert_raises(FrozenError) { destination.recipient.replace("other@example.com") }
+        assert_raises(FrozenError) { destination.owner_ref << "changed" }
+        ServiceEmailReceipt.create!(mailbox_id: destination.mailbox_id,
+          recipient: destination.recipient, raw: raw).id
+      end
+      Box.for_tenant(key) do |session|
+        saved = ServiceEmailReceipt.find(receipt)
+        assert_equal raw, saved.raw
+        assert_equal "support@#{key}.example.com", saved.recipient
+        assert_equal 1, ServiceEmailReceipt.count
+        assert_equal 0, session.messages(42).count
+      end
+    end
+    assert_nil Email::Tenancy.current_key
+  end
+
+  def test_lookup_restores_nested_context_and_does_not_wrap_host_errors
+    Box.for_tenant("alpha") do
+      assert_equal :host_result, Box.with_recipient(recipient: "support@beta.example.com") { :host_result }
+      assert_equal "alpha", Email::Tenancy.require_context!
+      assert_equal "alpha", ServiceTenantRecord.current_shard.to_s
+      error = assert_raises(ActiveRecord::RecordNotFound) do
+        Box.with_recipient(recipient: "support@beta.example.com") { raise ActiveRecord::RecordNotFound, "host record missing" }
+      end
+      assert_equal "host record missing", error.message
+      assert_equal "alpha", Email::Tenancy.require_context!
+      assert_equal "alpha", ServiceTenantRecord.current_shard.to_s
+    end
+    assert_nil Email::Tenancy.current_key
+    assert_raises(ArgumentError) { Box.with_recipient(recipient: "support@alpha.example.com") }
+  end
+
+  def test_lookup_rejects_inactive_destinations_before_host_persistence
+    assert_raises(Box::Unavailable) { Box.with_recipient(recipient: "support@unknown.example.com") { flunk } }
+    Box.for_tenant("alpha") do |session|
+      address = session.add_address(42, address: "pending@alpha.example.com")
+      assert_raises(Box::Unavailable) { Box.with_recipient(recipient: address.address) { flunk } }
+      session.activate_address!(address.id, evidence: "test")
+      snapshot = Box.with_recipient(recipient: address.address) { |destination| destination }
+      assert_equal address.id, snapshot.address_id
+      assert_equal address.receiving_domain_id, snapshot.receiving_domain_id
+      session.suspend_address(42, address.id)
+      assert_raises(Box::Unavailable) { Box.with_recipient(recipient: address.address) { flunk } }
+      session.suspend(42)
+      assert_raises(Box::Unavailable) { Box.with_recipient(recipient: "support@alpha.example.com") { flunk } }
+      session.resume(42)
+    end
+    Box::ReceivingDomain.find_by!(domain: "alpha.example.com").update!(state: "suspended")
+    assert_raises(Box::Unavailable) { Box.with_recipient(recipient: "support@alpha.example.com") { flunk } }
+    assert_nil Email::Tenancy.current_key
+  end
+
+  def test_receive_yields_destination_and_rolls_back_host_failures
+    assert_raises(ActiveRecord::RecordNotFound) do
+      Box.receive(recipient: "support@alpha.example.com") do |destination|
+        assert_equal "alpha", destination.tenant_key
+        ServiceEmailReceipt.create!(mailbox_id: destination.mailbox_id, raw: "raw")
+        raise ActiveRecord::RecordNotFound, "host failure"
+      end
+    end
+    Box.for_tenant("alpha") do |session|
+      assert_equal 0, ServiceEmailReceipt.count
+      assert_equal 0, session.messages(42).count
+    end
+  end
+
+  def test_receive_preserves_zero_argument_lambda_callbacks
+    inbound = Struct.new(:id).new(101)
+    assert_equal inbound, Box.receive(recipient: "support@alpha.example.com", &-> { inbound })
+    Box.for_tenant("alpha") { |session| assert_equal 1, session.messages(42).count }
+  end
+
+  def test_lookup_never_provisions_a_missing_tenant
+    directory = Box.register_domain(domain: "missing.example.com", tenant_key: "missing", account_id: "shared")
+    Box.activate_domain!(directory.id, evidence: "test directory entry")
+    before = Dir.children(SERVICE_ROOT).sort
+    assert_raises(ActiveRecord::ConnectionNotEstablished) do
+      Box.with_recipient(recipient: "support@missing.example.com") { flunk "entered missing tenant" }
+    end
+    assert_equal before, Dir.children(SERVICE_ROOT).sort
+    assert_nil Email::Tenancy.current_key
   end
 
   def test_overlapping_ids_and_operation_names_remain_isolated


### PR DESCRIPTION
Applications can now use the managed mailbox registry without querying its internal models. `Mailboxes.with_recipient` checks the active domain/address/mailbox and yields an immutable destination inside the configured tenant context, allowing host-owned email persistence without ActionMailbox.

The existing `Mailboxes.receive` path yields the same destination while preserving its transaction and ActionMailbox membership behavior. Hosts can persist verified raw email and signed metadata, then link their business record to the resolved mailbox before commit. Existing blocks and zero-argument lambda callbacks remain compatible. Host `RecordNotFound` errors propagate instead of being misreported as unavailable mailboxes.

### Verification

- Full suites on Ruby 3.4.1 / Rails 7.2, 8.0 and 8.1: 257 top-level tests, 916 assertions each, all passing.
- Separate SQLite tenant databases: host-owned binary persistence without ActionMailbox, colliding IDs, lifecycle rejection, context restoration and missing-tenant refusal.
- Real Rails ingress: saved raw email/metadata and business links, routing after commit, retry deduplication, rollback on host persistence failure.
- Packaged gem consumer checks pass; independent review has no remaining blockers.

Docs explain both persistence paths, host policy boundaries and managed mailbox retention. See `docs/verification/2026-09-12-destination-context.md` for the test report. No application deployment or gem publication.
