### PR TITLE
Add reusable email Worker relay and optional R2 archive support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+- Add a reusable Worker `relayEmail` pipeline with host backend/header policies,
+  bounded raw reads, optional fail-open archive hooks, safe HTTP outcomes and
+  deadlines. `archiveEmail` writes raw bytes and envelope metadata to an optional
+  R2 bucket. Default and custom forwarding share the same HTTP transport.
+- Keep provider authentication interpretation, archive keys, retry decisions and
+  fallback destinations with the host; existing default v2/v3 forwarding remains
+  compatible. Archive deadlines bound waiting but cannot cancel an in-flight write.
+
 - Add `Mailboxes.with_recipient` for active-address resolution and immutable
   destination context with host-owned persistence, without ActionMailbox.
 - Yield the same destination from `Mailboxes.receive` so apps can link their

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Version **0.2.0**. Ruby 3.2+, Rails 7.2–8.1; Ruby 4.0 is tested with Rails 8.1
 | [Management engine (unreleased)](docs/management-engine.md) | Mount an optional server-rendered mailbox UI using your app's authentication |
 | [Custom ingress (unreleased)](docs/custom-ingress.md) | Reuse authentication, signed metadata, and tenant routing in your existing ingestion pipeline |
 | [Routing diagnostics (unreleased)](docs/routing-diagnostics.md) | Inspect exact-domain DNS and Worker routes without changing infrastructure |
+| [Reusable Worker pipeline (unreleased)](templates/worker/README.md#reuse-the-transport-in-an-existing-worker) | Keep custom backend and archive policies while sharing bounded email forwarding |
 | [SQLite tenant databases](docs/activerecord-tenanted.md) | Give each organization its own SQLite database with `activerecord-tenanted` |
 | [Durable outbox](docs/outbox.md) | Detailed setup, callbacks, retries, and recovery |
 | [Delivery events](docs/delivery-events.md) | Cloudflare Queue setup and recipient status tracking |

--- a/templates/worker/README.md
+++ b/templates/worker/README.md
@@ -139,6 +139,95 @@ supports v3 before enabling metadata in a custom Worker. Keep sensitive provider
 data out of metadata unless your application's retention and access policies
 permit storing it with email records.
 
+## Reuse the transport in an existing Worker
+
+`relayEmail` provides bounded reading, an optional archive, backend selection and
+one HTTP delivery attempt. Your Worker decides how a result maps to SMTP
+rejection, retry, fallback forwarding or logging. It does not call `setReject`
+or `forward` and does not extract or interpret sender authentication evidence.
+The existing default export and `forwardEmail` keep their existing behavior.
+
+```js
+import { relayEmail, archiveEmail, signedEmailHeaders } from "./cloudflare-ingress.js";
+
+export default {
+  async email(message, env) {
+    const outcome = await relayEmail(message, {
+      maxEmailBytes: 25 * 1024 * 1024,
+      timeoutMs: 15_000,
+      archiveTimeoutMs: 10_000,
+      // Omit archive when no bucket is configured. Key policy belongs to your app.
+      archive: env.EMAIL_ARCHIVE ? (args) => archiveEmail({
+        ...args, bucket: env.EMAIL_ARCHIVE,
+        key: `email/${crypto.randomUUID()}.eml`,
+      }) : undefined,
+      accepts: async ({ to }) => to.endsWith("@inbound.example.com"),
+      // Select only host-configured backends; never use a URL from an email header.
+      resolveBackend: async ({ from, to }) => ({
+        url: env.RAILS_INGRESS_URL, secret: env.INGRESS_SECRET,
+      }),
+      headers: ({ raw, from, to, backend }) => signedEmailHeaders({
+        raw, from, to, secret: backend.secret,
+      }),
+    });
+    // Example host policy: permanent rejection only for invalid/unaccepted mail;
+    // throw for delivery failures so Cloudflare can apply its retry behavior.
+    if (outcome.status === "rejected") message.setReject("email not accepted");
+    if (outcome.status === "failed") throw new Error("email relay unavailable");
+  },
+};
+```
+
+The relay reads the original stream once, enforcing the actual byte limit even
+when `rawSize` underreports it. It archives before checking `accepts` and before
+resolving the backend, so an archive can retain mail rejected by host policy.
+Invalid envelopes, unreadable streams and oversized messages are not archived.
+An archive exception or timeout does not prevent delivery: the result has
+`archiveFailed: true`. The archive deadline defaults to 10 seconds and can be
+changed with `archiveTimeoutMs`. It stops waiting but cannot cancel an R2 write:
+a timed-out archive may still finish later if the runtime remains alive. Monitor
+that flag if the archive is your outage recovery mechanism. Other callback
+implementations must finish within the Worker's runtime limits; the `timeoutMs`
+option applies to the HTTP request only.
+
+`accepts` must return exactly `true` to accept. `resolveBackend` returns an object
+with `url` and any additional host configuration needed by `headers`. Backend
+URLs must use HTTPS, or HTTP on localhost, `127.0.0.1` or `[::1]`; embedded
+credentials and fragments are rejected. Generic relay envelope checks enforce
+bounded strings without control characters, leaving address shape to the host.
+`signedEmailHeaders` retains the gem ingress's stricter ASCII address validation.
+
+The `headers` callback receives `{ raw, from, to, backend, archive }`, where
+`archive` is the archive callback's return value, or undefined on omission or
+failure. It can return a header object or `Headers`, including Basic credentials
+for an existing custom endpoint. The relay sends exactly `raw`, follows no
+redirects, cancels response bodies without reading them, and never includes
+backend response content or callback exception text in results. Callbacks are
+trusted host code: preserve the supplied bytes and keep secrets out of logs.
+Do not put an archive key or other per-attempt value into signed provider metadata;
+doing so changes the persisted message identity on retries.
+
+Every result has `status`, `reason` and `archiveFailed`. HTTP responses also add
+`httpStatus`:
+
+| Status | Reasons |
+| --- | --- |
+| `delivered` | `delivered` (HTTP 2xx) |
+| `rejected` | `invalid_envelope`, `too_large`, `not_accepted` |
+| `failed` | `unreadable`, `invalid_options`, `acceptance_failed`, `backend_failed`, `invalid_backend`, `headers_failed`, `timeout`, `fetch_failed`, `http_status` |
+
+All non-2xx responses, including redirects and permanent client errors, return
+`failed`/`http_status`; your host chooses which are permanent, retryable or eligible
+for fallback. The relay never retries on its own.
+
+`archiveEmail({ bucket, key, raw, from, to })` writes raw RFC822 bytes to an R2
+binding and returns `{ key }`. Keys must be nonempty, at most 1,024 UTF8 bytes and
+contain no ASCII control characters. It stores `message/rfc822` content type and
+ASCII-safe `from`, `to` and `size` custom metadata; non-ASCII envelope characters
+become `?` in this display metadata only. Retention, unique keys, archive browsing
+and recovery authorization belong to the host. Rails email persistence starts
+after delivery and does not replace this optional outage archive.
+
 ## Validate changes
 
 ```sh

--- a/templates/worker/src/index.js
+++ b/templates/worker/src/index.js
@@ -54,6 +54,12 @@ function validIngressUrl(value) {
   } catch { return false; }
 }
 
+// Generic relays preserve host address semantics; signed gem ingress is stricter.
+function validTransportEnvelope(from, to) {
+  return [from, to].every(value => typeof value === "string" && value.length <= 254 &&
+    !/[\x00-\x1f\x7f]/.test(value)) && to.length > 0;
+}
+
 async function readBounded(stream, limit) {
   const reader = stream.getReader();
   const chunks = [];
@@ -62,13 +68,18 @@ async function readBounded(stream, limit) {
     while (true) {
       const { done, value } = await reader.read();
       if (done) break;
+      if (!(value instanceof Uint8Array)) throw new TypeError("invalid message chunk");
       size += value.byteLength;
       if (size > limit) {
-        await reader.cancel();
-        throw new Error("message exceeds size limit");
+        const error = new Error("message exceeds size limit");
+        error.code = "EMAIL_TOO_LARGE";
+        throw error;
       }
       chunks.push(value);
     }
+  } catch (error) {
+    void reader.cancel().catch(() => {});
+    throw error;
   } finally { reader.releaseLock(); }
   const raw = new Uint8Array(size);
   let offset = 0;
@@ -142,6 +153,103 @@ export async function signedEmailHeaders({ secret, raw, from, to, metadata, time
   return headers;
 }
 
+// Stores only transport metadata. The key and retention policy belong to the host.
+export async function archiveEmail({ bucket, key, raw, from, to }) {
+  if (!bucket || typeof bucket.put !== "function" || typeof key !== "string" ||
+      key.length === 0 || new TextEncoder().encode(key).length > 1024 || /[\x00-\x1f\x7f]/.test(key) ||
+      !(raw instanceof Uint8Array) || !validTransportEnvelope(from, to)) {
+    throw new TypeError("invalid email archive arguments");
+  }
+  await bucket.put(key, raw, {
+    httpMetadata: { contentType: "message/rfc822" },
+    customMetadata: { from: from.replace(/[^\x20-\x7e]/g, "?"),
+      to: to.replace(/[^\x20-\x7e]/g, "?"), size: String(raw.byteLength) },
+  });
+  return { key };
+}
+
+async function postEmail(url, headers, raw, timeoutMs) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  let response;
+  try {
+    response = await fetch(url, { method: "POST", headers, body: raw,
+      redirect: "manual", signal: controller.signal });
+  } catch {
+    return { reason: controller.signal.aborted ? "timeout" : "fetch_failed" };
+  } finally { clearTimeout(timeout); }
+  // Never read or return backend error bodies; they can contain mail or secrets.
+  try { void response.body?.cancel().catch(() => {}); } catch { /* cancellation is best effort */ }
+  return { reason: response.ok ? "delivered" : "http_status", httpStatus: response.status };
+}
+
+async function archiveWithin(saveArchive, args, timeoutMs) {
+  let timeout;
+  try {
+    return await Promise.race([
+      Promise.resolve().then(() => saveArchive(args)),
+      new Promise((_, reject) => {
+        timeout = setTimeout(() => reject(new Error("archive timed out")), timeoutMs);
+      }),
+    ]);
+  } finally { clearTimeout(timeout); }
+}
+
+// A host-controlled relay: no SMTP rejection, sender policy, fallback or retries.
+// Callback exceptions are deliberately reduced to fixed, non-sensitive reasons.
+export async function relayEmail(message, options = {}) {
+  let archiveFailed = false;
+  const result = (status, reason, httpStatus) => ({ status, reason, archiveFailed,
+    ...(httpStatus === undefined ? {} : { httpStatus }) });
+  if (!options || typeof options !== "object") return result("failed", "invalid_options");
+  const { maxEmailBytes = 25 * 1024 * 1024, timeoutMs = 15_000, archiveTimeoutMs = 10_000,
+    resolveBackend, headers: buildHeaders, archive: saveArchive, accepts } = options;
+  if (!Number.isSafeInteger(maxEmailBytes) || maxEmailBytes <= 0 ||
+      !Number.isSafeInteger(timeoutMs) || timeoutMs <= 0 || timeoutMs > 2_147_483_647 ||
+      !Number.isSafeInteger(archiveTimeoutMs) || archiveTimeoutMs <= 0 || archiveTimeoutMs > 2_147_483_647 ||
+      typeof resolveBackend !== "function" || typeof buildHeaders !== "function" ||
+      (saveArchive !== undefined && typeof saveArchive !== "function") ||
+      (accepts !== undefined && typeof accepts !== "function")) return result("failed", "invalid_options");
+  if (!message || !validTransportEnvelope(message.from, message.to)) {
+    return result("rejected", "invalid_envelope");
+  }
+  const { from, to } = message;
+  if (message.rawSize > maxEmailBytes) return result("rejected", "too_large");
+  let raw;
+  try { raw = await readBounded(message.raw, maxEmailBytes); }
+  catch (error) {
+    return error?.code === "EMAIL_TOO_LARGE" ? result("rejected", "too_large") : result("failed", "unreadable");
+  }
+  let archive;
+  if (saveArchive) {
+    try { archive = await archiveWithin(saveArchive, { raw, from, to }, archiveTimeoutMs); }
+    catch { archiveFailed = true; }
+  }
+  if (accepts) {
+    try {
+      if (await accepts({ from, to }) !== true) return result("rejected", "not_accepted");
+    } catch { return result("failed", "acceptance_failed"); }
+  }
+  let backend;
+  let url;
+  try {
+    backend = await resolveBackend({ from, to });
+    url = backend?.url;
+  }
+  catch { return result("failed", "backend_failed"); }
+  if (typeof url !== "string" || !validIngressUrl(url)) {
+    return result("failed", "invalid_backend");
+  }
+  let headers;
+  try {
+    const supplied = await buildHeaders({ raw, from, to, backend, archive });
+    if (!supplied || typeof supplied !== "object") return result("failed", "headers_failed");
+    headers = new Headers(supplied);
+  } catch { return result("failed", "headers_failed"); }
+  const delivery = await postEmail(url, headers, raw, timeoutMs);
+  return result(delivery.reason === "delivered" ? "delivered" : "failed", delivery.reason, delivery.httpStatus);
+}
+
 export async function forwardEmail(message, env, { metadata } = {}) {
     if (!env.RAILS_INGRESS_URL || !env.INGRESS_SECRET) {
       message.setReject("worker missing RAILS_INGRESS_URL or INGRESS_SECRET");
@@ -181,28 +289,10 @@ export async function forwardEmail(message, env, { metadata } = {}) {
       return;
     }
 
-    let res;
-    const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), 15_000);
-    try {
-      res = await fetch(env.RAILS_INGRESS_URL, {
-        method: "POST",
-        headers,
-        body: raw,
-        signal: controller.signal,
-        // Workers supports follow/manual; non-2xx handling below rejects redirects.
-        redirect: "manual",
-      });
-    } catch (err) {
-      message.setReject(controller.signal.aborted ? "upstream fetch timed out" : "upstream fetch failed");
-      return;
-    } finally {
-      clearTimeout(timeout);
-    }
-
-    if (!res.ok) {
-      message.setReject(`upstream returned ${res.status}`);
-    }
+    const delivery = await postEmail(env.RAILS_INGRESS_URL, headers, raw, 15_000);
+    if (delivery.reason === "timeout") message.setReject("upstream fetch timed out");
+    else if (delivery.reason === "fetch_failed") message.setReject("upstream fetch failed");
+    else if (delivery.reason === "http_status") message.setReject(`upstream returned ${delivery.httpStatus}`);
 }
 
 export default {

--- a/templates/worker/test/relay.test.ts
+++ b/templates/worker/test/relay.test.ts
@@ -1,0 +1,226 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { archiveEmail, relayEmail, signedEmailHeaders } from "../src/index.js";
+
+const raw = new Uint8Array([0, 255, 13, 10, 128]);
+function message(bytes = raw, rawSize = bytes.length) {
+  return { from: "sender@example.com", to: "inbox@tenant.example.com", rawSize,
+    raw: new ReadableStream({ start(c) { c.enqueue(bytes); c.close(); } }) };
+}
+function options(overrides = {}) {
+  return { resolveBackend: async () => ({ url: "https://rails.example.com/ingest", secret: "test-secret" }),
+    headers: async ({ raw, from, to, backend }) => signedEmailHeaders({ raw, from, to, secret: backend.secret }),
+    ...overrides };
+}
+afterEach(() => { vi.unstubAllGlobals(); vi.useRealTimers(); });
+
+describe("host-controlled relay", () => {
+  it("archives once before acceptance and backend lookup, signs and sends exact binary bytes", async () => {
+    const order: string[] = [];
+    const put = vi.fn(async (key, body, metadata) => {
+      order.push("archive");
+      expect(key).toBe("mail/one.eml");
+      expect(body).toEqual(raw);
+      expect(metadata).toEqual({ httpMetadata: { contentType: "message/rfc822" },
+        customMetadata: { from: "sender@example.com", to: "inbox@tenant.example.com", size: "5" } });
+    });
+    const fetch = vi.fn(async (_url, init) => {
+      order.push("fetch");
+      expect(init.body).toEqual(raw);
+      expect(init.headers.get("X-CF-Email-Signature-Version")).toBe("2");
+      expect(init.redirect).toBe("manual");
+      expect(init.signal).toBeInstanceOf(AbortSignal);
+      return new Response(null, { status: 202 });
+    });
+    vi.stubGlobal("fetch", fetch);
+    const result = await relayEmail(message(), options({
+      archive: (args) => archiveEmail({ ...args, bucket: { put }, key: "mail/one.eml" }),
+      accepts: async () => { order.push("accepts"); return true; },
+      resolveBackend: async () => { order.push("backend"); return { url: "https://rails.example.com/ingest", secret: "test-secret" }; },
+      headers: async (args) => {
+        expect(args.archive).toEqual({ key: "mail/one.eml" });
+        order.push("headers");
+        return signedEmailHeaders({ ...args, secret: args.backend.secret });
+      },
+    }));
+    expect(order).toEqual(["archive", "accepts", "backend", "headers", "fetch"]);
+    expect(result).toEqual({ status: "delivered", reason: "delivered", httpStatus: 202, archiveFailed: false });
+    expect(fetch).toHaveBeenCalledOnce();
+    expect(put).toHaveBeenCalledOnce();
+  });
+
+  it("continues after archive failure without exposing exception content", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => new Response(null, { status: 204 })));
+    const result = await relayEmail(message(), options({ archive: async () => { throw new Error("PRIVATE EMAIL SECRET"); } }));
+    expect(result).toEqual({ status: "delivered", reason: "delivered", httpStatus: 204, archiveFailed: true });
+  });
+
+  it("archives rejected recipients without resolving a backend", async () => {
+    const archive = vi.fn(async () => ({ key: "retained.eml" }));
+    const resolveBackend = vi.fn();
+    expect(await relayEmail(message(), options({ archive, accepts: async () => false, resolveBackend })))
+      .toEqual({ status: "rejected", reason: "not_accepted", archiveFailed: false });
+    expect(archive).toHaveBeenCalledOnce();
+    expect(resolveBackend).not.toHaveBeenCalled();
+  });
+
+  it("continues when the archive deadline expires, allowing a late archive completion", async () => {
+    vi.useFakeTimers();
+    let finish;
+    const archive = vi.fn(() => new Promise(resolve => { finish = resolve; }));
+    const fetch = vi.fn(async () => new Response(null, { status: 200 }));
+    vi.stubGlobal("fetch", fetch);
+    const pending = relayEmail(message(), options({ archive, archiveTimeoutMs: 20,
+      headers: async ({ archive }) => { expect(archive).toBeUndefined(); return {}; },
+    }));
+    await vi.advanceTimersByTimeAsync(19);
+    expect(fetch).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(1);
+    expect(await pending).toEqual({ status: "delivered", reason: "delivered", httpStatus: 200, archiveFailed: true });
+    finish({ key: "late.eml" });
+    await Promise.resolve();
+    expect(fetch).toHaveBeenCalledOnce();
+    expect(archive).toHaveBeenCalledOnce();
+  });
+
+  it("uses the validated URL even when the headers callback changes the backend", async () => {
+    const fetch = vi.fn(async () => new Response(null, { status: 200 }));
+    vi.stubGlobal("fetch", fetch);
+    await relayEmail(message(), options({ headers: async ({ backend }) => {
+      backend.url = "http://untrusted.example.com/secret";
+      return { Authorization: "Basic private" };
+    } }));
+    expect(fetch.mock.calls[0][0]).toBe("https://rails.example.com/ingest");
+  });
+
+  it("bounds actual streaming bytes even when rawSize is false", async () => {
+    const cancel = vi.fn();
+    const stream = new ReadableStream({ start(c) { c.enqueue(raw); }, cancel });
+    const archive = vi.fn();
+    expect(await relayEmail({ ...message(), raw: stream, rawSize: 1 }, options({ maxEmailBytes: 4, archive })))
+      .toEqual({ status: "rejected", reason: "too_large", archiveFailed: false });
+    expect(cancel).toHaveBeenCalledOnce();
+    expect(archive).not.toHaveBeenCalled();
+  });
+
+  it("rejects declared oversize or invalid envelopes without reading", async () => {
+    const getReader = vi.fn();
+    expect((await relayEmail({ ...message(), raw: { getReader }, rawSize: 100 }, options({ maxEmailBytes: 50 }))).reason).toBe("too_large");
+    expect((await relayEmail({ ...message(), raw: { getReader }, to: "bad\r\naddress" }, options())).reason).toBe("invalid_envelope");
+    expect(getReader).not.toHaveBeenCalled();
+  });
+
+  it("reports read failures and invalid chunks without forwarding", async () => {
+    const fetch = vi.fn(); vi.stubGlobal("fetch", fetch);
+    for (const stream of [new ReadableStream({ start(c) { c.error(new Error("secret")); } }),
+      new ReadableStream({ start(c) { c.enqueue("bad chunk"); c.close(); } })]) {
+      expect(await relayEmail({ ...message(), raw: stream }, options()))
+        .toEqual({ status: "failed", reason: "unreadable", archiveFailed: false });
+    }
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it.each(["http://rails.example.com", "https://user:secret@example.com", "https://example.com/#secret", "ftp://example.com", "invalid"])
+    ("rejects unsafe backend %s", async (url) => {
+      const fetch = vi.fn(); vi.stubGlobal("fetch", fetch);
+      expect((await relayEmail(message(), options({ resolveBackend: async () => ({ url }) }))).reason).toBe("invalid_backend");
+      expect(fetch).not.toHaveBeenCalled();
+    });
+
+  it("supports a host-selected loopback backend and Basic headers", async () => {
+    const fetch = vi.fn(async (url, init) => {
+      expect(url).toBe("http://127.0.0.1:3000/ingest");
+      expect(init.headers.get("Authorization")).toBe("Basic dGVzdDp0ZXN0");
+      expect(init.body).toEqual(raw);
+      return new Response(null, { status: 200 });
+    });
+    vi.stubGlobal("fetch", fetch);
+    const result = await relayEmail(message(), options({
+      resolveBackend: async ({ to }) => ({ url: to.includes("tenant") ? "http://127.0.0.1:3000/ingest" : "https://other.example.com" }),
+      headers: async () => ({ Authorization: "Basic dGVzdDp0ZXN0", "Content-Type": "message/rfc822" }),
+    }));
+    expect(result.status).toBe("delivered");
+  });
+
+  it("leaves Unicode and legacy address shapes to host acceptance with custom headers", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => new Response(null, { status: 200 })));
+    const from = "séndér@example.com";
+    const to = '"quoted local"@TENANT.example.com';
+    const accepts = vi.fn(async (envelope) => {
+      expect(envelope).toEqual({ from, to });
+      return true;
+    });
+    expect((await relayEmail({ ...message(), from, to }, options({ accepts,
+      headers: async () => ({ Authorization: "Basic dGVzdDp0ZXN0" }),
+    }))).status).toBe("delivered");
+    expect(accepts).toHaveBeenCalledOnce();
+  });
+
+  it.each([301, 400, 401, 413, 422, 429, 500, 503])("returns HTTP %i without reading response content or retrying", async (status) => {
+    const cancel = vi.fn();
+    const response = new Response(new ReadableStream({ cancel }), { status });
+    const text = vi.spyOn(response, "text");
+    const fetch = vi.fn(async () => response); vi.stubGlobal("fetch", fetch);
+    expect(await relayEmail(message(), options())).toEqual({ status: "failed", reason: "http_status", httpStatus: status, archiveFailed: false });
+    expect(text).not.toHaveBeenCalled();
+    expect(cancel).toHaveBeenCalledOnce();
+    expect(fetch).toHaveBeenCalledOnce();
+  });
+
+  it("does not wait for an unresponsive response cancellation", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => new Response(new ReadableStream({ cancel: () => new Promise(() => {}) }), { status: 200 })));
+    expect((await relayEmail(message(), options())).status).toBe("delivered");
+  });
+
+  it("aborts fetch on the configured timeout and returns no exception text", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal("fetch", vi.fn(async (_url, { signal }) => new Promise((_resolve, reject) => {
+      signal.addEventListener("abort", () => reject(new Error("private backend")));
+    })));
+    const pending = relayEmail(message(), options({ timeoutMs: 25, headers: async () => ({}) }));
+    await vi.advanceTimersByTimeAsync(25);
+    expect(await pending).toEqual({ status: "failed", reason: "timeout", archiveFailed: false });
+  });
+
+  it.each([
+    [{ accepts: async () => { throw new Error("secret"); } }, "acceptance_failed"],
+    [{ resolveBackend: async () => { throw new Error("secret"); } }, "backend_failed"],
+    [{ resolveBackend: async () => null }, "invalid_backend"],
+    [{ headers: async () => { throw new Error("secret"); } }, "headers_failed"],
+    [{ headers: async () => ({ "Bad\nHeader": "secret" }) }, "headers_failed"],
+    [{ maxEmailBytes: 0 }, "invalid_options"],
+    [{ timeoutMs: Infinity }, "invalid_options"],
+    [{ timeoutMs: 2 ** 31 }, "invalid_options"],
+    [{ archive: true }, "invalid_options"],
+    [{ archiveTimeoutMs: 0 }, "invalid_options"],
+    [{ archiveTimeoutMs: 2 ** 31 }, "invalid_options"],
+  ])("returns safe callback/configuration failure %#", async (overrides, reason) => {
+    expect(await relayEmail(message(), options(overrides))).toEqual({ status: "failed", reason, archiveFailed: false });
+  });
+
+  it("returns fetch failures without backend secrets", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => { throw new Error("secret-url"); }));
+    expect(await relayEmail(message(), options())).toEqual({ status: "failed", reason: "fetch_failed", archiveFailed: false });
+  });
+});
+
+describe("R2 archive helper", () => {
+  it("validates archive arguments before invoking the bucket", async () => {
+    const put = vi.fn();
+    const args = { bucket: { put }, key: "mail/id.eml", raw, from: "", to: "inbox@example.com" };
+    for (const overrides of [{ key: "" }, { key: "x".repeat(1025) }, { key: "\u0000" }, { raw: "bad" },
+      { from: "sender\r\n@example.com" }, { to: "" }]) {
+      await expect(archiveEmail({ ...args, ...overrides })).rejects.toThrow("invalid email archive arguments");
+    }
+    expect(put).not.toHaveBeenCalled();
+    await expect(archiveEmail(args)).resolves.toEqual({ key: "mail/id.eml" });
+    expect(put.mock.calls[0][2].customMetadata.from).toBe("");
+  });
+
+  it("stores ASCII-safe envelope metadata while preserving raw Unicode mail bytes", async () => {
+    const put = vi.fn();
+    await archiveEmail({ bucket: { put }, key: "mail/unicode.eml", raw,
+      from: "séndér@example.com", to: "inbox@tenant.example.com" });
+    expect(put.mock.calls[0][1]).toEqual(raw);
+    expect(put.mock.calls[0][2].customMetadata.from).toBe("s?nd?r@example.com");
+  });
+});


### PR DESCRIPTION
Custom email Workers can now reuse the gem's transport while keeping backend selection, archive keys, headers and retry policy in the application. `relayEmail` performs a bounded raw read, optional fail-open archive step, host acceptance/backend/header callbacks and one bounded HTTP attempt. `archiveEmail` writes the original bytes and envelope metadata to an optional R2 bucket.

The bundled Worker and reusable relay share HTTP transport, including deadlines, redirect refusal and response cancellation. Default v2/v3 behavior remains covered. No sender-authentication parsing was added: provider metadata remains a host assertion.

Validation: 84 Worker tests, Wrangler dry-run, full Rails suite (257 top-level tests / 916 assertions), packaged gem checks, and actual local workerd-to-Rails ingress checks pass. Independent review found a read-error classification regression, which was fixed and covered. The companion Rebulk wrapper also passes both-backend and local R2 recovery tests.

Archive timeout bounds waiting but cannot cancel an underlying write. Host callbacks and retry decisions remain application responsibilities. This PR does not publish the gem or deploy a Worker.
