### PR TITLE
Fix tenant-enabled production Rails eager boot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+- Allow production Rails schema preloading to boot without a selected tenant.
+  Tenant model pool access still fails closed with
+  `Cloudflare::Email::ActiveRecord::TenantConnectionUnavailable`, an
+  `ActiveRecord::ConnectionNotEstablished` error retaining the original
+  `ConfigurationError` as its cause. No default tenant is selected.
+
 - Add a reusable Worker `relayEmail` pipeline with host backend/header policies,
   bounded raw reads, optional fail-open archive hooks, safe HTTP outcomes and
   deadlines. `archiveEmail` writes raw bytes and envelope metadata to an optional

--- a/lib/cloudflare/email/active_record/base.rb
+++ b/lib/cloudflare/email/active_record/base.rb
@@ -4,13 +4,25 @@ require "cloudflare/email/tenancy"
 module Cloudflare
   module Email
     module ActiveRecord
+      # Rails may inspect every model's pool while preloading schema metadata
+      # before any request has selected a tenant. Report an unavailable
+      # connection using Rails' error hierarchy so boot can recover, while
+      # retaining the same fail-closed guard for every caller.
+      class TenantConnectionUnavailable < ::ActiveRecord::ConnectionNotEstablished; end
+
       # Uses the host's abstract tenant connection owner when explicitly configured.
       class Base < Tenancy.model_base(::ActiveRecord::Base)
         self.abstract_class = true
 
         class << self
           def connection_pool
-            Tenancy.require_context! if Tenancy.enabled?
+            if Tenancy.enabled?
+              begin
+                Tenancy.require_context!
+              rescue ConfigurationError => error
+                raise TenantConnectionUnavailable, error.message
+              end
+            end
             super
           end
         end

--- a/script/verify_package.rb
+++ b/script/verify_package.rb
@@ -65,4 +65,7 @@ Dir.mktmpdir("cloudflare-email-package-") do |temporary|
   run!({ "CLOUDFLARE_EMAIL_TEST_GEM_ROOT" => extracted }, RbConfig.ruby,
        File.join(root, "test/support/mailbox_ingress.rb"), chdir: root)
   puts "PASS: packaged tenant mailbox ingress, routing jobs, retention, and migrations"
+  run!({ "CLOUDFLARE_EMAIL_TEST_GEM_ROOT" => extracted }, RbConfig.ruby,
+       File.join(root, "test/support/production_tenancy_boot.rb"), chdir: root)
+  puts "PASS: packaged production eager boot and fail-closed tenant connections"
 end

--- a/test/support/activerecord_tenanted.rb
+++ b/test/support/activerecord_tenanted.rb
@@ -97,7 +97,7 @@ class ActualTenantedMailboxTest < Minitest::Test
     Tenancy.with("beta") do
       assert_raises(Cloudflare::Email::ConfigurationError) { records[0].reload }
     end
-    assert_raises(Cloudflare::Email::ConfigurationError) { Mailboxes::Mailbox.count }
+    assert_raises(Cloudflare::Email::ActiveRecord::TenantConnectionUnavailable) { Mailboxes::Mailbox.count }
     assert_raises(RuntimeError) { Tenancy.with("alpha") { raise "callback failed" } }
     assert_nil TenantRecord.current_tenant
     assert_nil Tenancy.current_key

--- a/test/support/production_tenancy_boot.rb
+++ b/test/support/production_tenancy_boot.rb
@@ -1,0 +1,96 @@
+# Fresh process: real production Rails boot, including AR's attribute preloader.
+ENV["RAILS_ENV"] = "production"
+require "tmpdir"
+require "fileutils"
+require "minitest/autorun"
+require "rails"
+require "active_record/railtie"
+
+GEM_ROOT = ENV.fetch("CLOUDFLARE_EMAIL_TEST_GEM_ROOT") { File.expand_path("../..", __dir__) }
+$LOAD_PATH.unshift File.join(GEM_ROOT, "lib")
+require "cloudflare-email"
+require "cloudflare/email/tenancy"
+
+APP_ROOT = Dir.mktmpdir("cloudflare-email-production-tenancy")
+FileUtils.mkdir_p("#{APP_ROOT}/config")
+File.write("#{APP_ROOT}/config/database.yml", <<~YAML)
+  production:
+    adapter: sqlite3
+    database: #{APP_ROOT}/shared.sqlite3
+YAML
+Minitest.after_run do
+  ActiveRecord::Base.connection_handler.clear_all_connections!
+  FileUtils.remove_entry(APP_ROOT)
+end
+
+class ProductionTenantApp < Rails::Application
+  config.root = APP_ROOT
+  config.eager_load = true
+  config.enable_reloading = false
+  config.secret_key_base = "a" * 64
+  config.logger = Logger.new(File::NULL)
+  # Rails 8.1's production attribute preloader deliberately asks each
+  # descendant for its pool here, outside any tenant/request context.
+  config.active_record.check_schema_cache_dump_version = false
+
+  initializer "configure_test_tenancy", after: "active_record.initialize_database" do
+    class ::ProductionTenantRecord < ActiveRecord::Base
+      self.abstract_class = true
+      connects_to shards: %i[alpha beta].to_h { |key|
+        [key, {writing: {adapter: "sqlite3", database: "#{APP_ROOT}/#{key}.sqlite3"}}]
+      }
+    end
+    Cloudflare::Email::Tenancy.configure(
+      base_class: ProductionTenantRecord,
+      switch: ->(key, &block) { ProductionTenantRecord.connected_to(role: :writing, shard: key.to_sym, &block) },
+      current: -> { ProductionTenantRecord.current_shard.to_s },
+    )
+    require "cloudflare/email/active_record/event_receipt"
+    %w[alpha beta].each do |key|
+      Cloudflare::Email::Tenancy.with(key) do
+        ProductionTenantRecord.connection.create_table(:cloudflare_email_event_receipts) do |t|
+          t.string :state
+        end
+      end
+    end
+  end
+end
+
+ProductionTenantApp.initialize!
+
+class ProductionTenantBootTest < Minitest::Test
+  Tenancy = Cloudflare::Email::Tenancy
+  Receipt = Cloudflare::Email::ActiveRecord::EventReceipt
+  PoolError = Cloudflare::Email::ActiveRecord::TenantConnectionUnavailable
+
+  def test_boot_keeps_pool_and_query_access_closed_without_context
+    assert Rails.env.production?
+    assert Rails.application.config.eager_load
+    refute Rails.application.config.active_record.check_schema_cache_dump_version
+    assert_nil Tenancy.current_key
+    error = assert_raises(PoolError) { Receipt.connection_pool }
+    assert_kind_of ActiveRecord::ActiveRecordError, error
+    assert_kind_of Cloudflare::Email::ConfigurationError, error.cause
+    ProductionTenantRecord.connected_to(role: :writing, shard: :alpha) do
+      assert_raises(PoolError) { Receipt.count }
+    end
+  end
+
+  def test_explicit_context_works_and_mismatched_host_still_fails
+    %w[alpha beta].each do |key|
+      Tenancy.with(key) do
+        Receipt.delete_all
+        Receipt.create!(id: 1, state: key)
+      end
+    end
+    Tenancy.with("alpha") do
+      assert_equal "alpha", Receipt.find(1).state
+      ProductionTenantRecord.connected_to(role: :writing, shard: :beta) do
+        error = assert_raises(PoolError) { Receipt.count }
+        assert_match(/does not match/, error.message)
+      end
+    end
+    Tenancy.with("beta") { assert_equal "beta", Receipt.find(1).state }
+    assert_nil Tenancy.current_key
+  end
+end

--- a/test/support/tenancy.rb
+++ b/test/support/tenancy.rb
@@ -94,6 +94,11 @@ class TenantFoundationTest < Minitest::Test
     error = assert_raises(Cloudflare::Email::ActiveRecord::TenantConnectionUnavailable) { Receipt.count }
     assert_kind_of ActiveRecord::ConnectionNotEstablished, error
     assert_kind_of Cloudflare::Email::ConfigurationError, error.cause
+    # Construction can reach either guard: cold attributes need a pool first,
+    # while cached attributes reach the record's init_internals guard directly.
+    Tenancy.with("alpha") { Receipt.reset_column_information }
+    assert_raises(Cloudflare::Email::ActiveRecord::TenantConnectionUnavailable) { Receipt.new }
+    Tenancy.with("alpha") { Receipt.new }
     assert_raises(Cloudflare::Email::ConfigurationError) { Receipt.new }
     assert_raises(Cloudflare::Email::ConfigurationError) { Tenancy.require_context! }
   end

--- a/test/support/tenancy.rb
+++ b/test/support/tenancy.rb
@@ -91,7 +91,9 @@ class TenantFoundationTest < Minitest::Test
   end
 
   def test_requires_explicit_context_even_if_host_defaults_to_a_tenant
-    assert_raises(Cloudflare::Email::ConfigurationError) { Receipt.count }
+    error = assert_raises(Cloudflare::Email::ActiveRecord::TenantConnectionUnavailable) { Receipt.count }
+    assert_kind_of ActiveRecord::ConnectionNotEstablished, error
+    assert_kind_of Cloudflare::Email::ConfigurationError, error.cause
     assert_raises(Cloudflare::Email::ConfigurationError) { Receipt.new }
     assert_raises(Cloudflare::Email::ConfigurationError) { Tenancy.require_context! }
   end
@@ -116,7 +118,7 @@ class TenantFoundationTest < Minitest::Test
   def test_host_switch_cannot_silently_override_selected_tenant
     Tenancy.with("alpha") do
       TenantRecord.connected_to(role: :writing, shard: :beta) do
-        assert_raises(Cloudflare::Email::ConfigurationError) { Receipt.count }
+        assert_raises(Cloudflare::Email::ActiveRecord::TenantConnectionUnavailable) { Receipt.count }
       end
     end
   end
@@ -125,7 +127,7 @@ class TenantFoundationTest < Minitest::Test
     %i[EventReceipt OutboundDelivery OutboundRecipient OutboundReconciliation].each do |name|
       klass = Cloudflare::Email::ActiveRecord.const_get(name)
       assert klass < TenantRecord
-      assert_raises(Cloudflare::Email::ConfigurationError) { klass.connection_pool }
+      assert_raises(Cloudflare::Email::ActiveRecord::TenantConnectionUnavailable) { klass.connection_pool }
     end
   end
 

--- a/test/tenancy_test.rb
+++ b/test/tenancy_test.rb
@@ -3,6 +3,11 @@ require "open3"
 require "rbconfig"
 
 class TenancyTest < Minitest::Test
+  def test_production_eager_boot_preserves_explicit_tenant_guards
+    output, status = Open3.capture2e(RbConfig.ruby, File.expand_path("support/production_tenancy_boot.rb", __dir__))
+    assert status.success?, output
+  end
+
   def test_optional_single_database_job_context
     output, status = Open3.capture2e(RbConfig.ruby, File.expand_path("support/default_tenant_jobs.rb", __dir__))
     assert status.success?, output


### PR DESCRIPTION
Production Rails 8.1 can inspect every model's connection pool while preloading schema attributes before a request selects a tenant. The gem's tenant guard raised a ConfigurationError outside Rails' recoverable database-error hierarchy, preventing the application from booting with mailbox tenancy enabled.

Keep the guard closed and raise `Cloudflare::Email::ActiveRecord::TenantConnectionUnavailable` (an `ActiveRecord::ConnectionNotEstablished`) at the pool boundary, retaining the original configuration error as its cause. Rails can finish booting without selecting a default tenant; unscoped queries and mismatched tenant connections still fail. Rails may defer remaining attribute definitions until model access after its expected warning.

Validation:
- Reproduced the original failure against the unmodified pool guard at Rails' production preloader.
- Full gem suite: 258 runs, 917 assertions, no failures/errors.
- Actual activerecord-tenanted SQLite integration: 3 runs, 23 assertions, no failures/errors.
- New production eager-boot fixture: 2 runs, 14 assertions; verifies boot, missing context, ambient host tenant rejection, and mismatched tenant rejection.
- Packaged consumer verification includes the production boot regression.

The database pool guard's exception type changes intentionally; direct tenancy APIs and existing record context guards retain ConfigurationError.
