### PR TITLE
Add opt-in domain catch-all mailbox receiving

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+- Add optional domain catch-all receiving on an existing active mailbox address,
+  with explicit verification evidence and a unique active catch-all constraint.
+  Exact registered addresses always win, including rejected inactive addresses;
+  unknown local parts retain their actual envelope recipient without new aliases.
+  Destination snapshots identify fallback, while sending stays exact-address only.
+  A separate generator upgrades existing mailbox schemas; catch-all is never
+  enabled automatically.
+
 - Allow production Rails schema preloading to boot without a selected tenant.
   Tenant model pool access still fails closed with
   `Cloudflare::Email::ActiveRecord::TenantConnectionUnavailable`, an

--- a/app/views/cloudflare/email/management/mailboxes/show.html.erb
+++ b/app/views/cloudflare/email/management/mailboxes/show.html.erb
@@ -53,6 +53,9 @@
           <% receiving = @mailbox.state == "active" && address.state == "active" && address.receiving_domain&.state == "active" %>
           <li class="record-row address-row">
             <span class="record-title"><%= address.address %></span>
+            <% if address.has_attribute?(:catch_all) && address[:catch_all] %>
+              <span class="badge">Domain catch-all configured</span>
+            <% end %>
             <span class="badge"><%= receiving ? "Accepting mail" : address.state == "pending" ? "Pending setup" : "Receiving paused" %></span>
           </li>
         <% end %>

--- a/docs/mailboxes.md
+++ b/docs/mailboxes.md
@@ -34,7 +34,8 @@ require "cloudflare/email/mailboxes"
 Loading this module enables mailbox lookup on the gem's Cloudflare ingress.
 Existing receiving addresses must be registered and activated before switching
 an existing application over. Unregistered or suspended destinations return
-HTTP 422 and the Worker rejects the delivery; there is no default-mailbox fallback.
+HTTP 422 and the Worker rejects the delivery by default. You can explicitly
+configure a domain catch-all below when your application needs that behavior.
 
 For separate organization databases, follow the
 [activerecord-tenanted setup](activerecord-tenanted.md) **before loading the
@@ -145,6 +146,67 @@ Addresses use lowercase ASCII dot-atom local parts and domains. Alias addresses
 are explicit: the module does not automatically strip `+tags` or invent address
 fallbacks. Reserve application-specific names such as Rebulk's `tracking` in
 your mailbox-management policy before creation.
+
+## Receive unregistered local parts with an optional catch-all
+
+Catch-all receiving is **off by default** and is available in the unreleased
+version. It lets one existing address receive otherwise unregistered addresses
+on its exact domain, without creating an alias row for each incoming local part.
+For example, `anything@acme.example.com` can arrive in an existing support mailbox.
+It does not cover subdomains such as `anything@other.acme.example.com`.
+
+Fresh installations include the schema. For an existing installation, generate
+the optional upgrade and apply it to the database containing your mailbox tables:
+
+```sh
+bin/rails generate cloudflare:email:mailboxes:catch_all
+bin/rails db:migrate
+```
+
+With separate tenant databases, pass
+`--tenant-migrations-path=db/tenant_migrate` and run your application's tenant
+migration command for every affected tenant. Updating the gem alone keeps older
+schemas working with exact-address routing. Enabling a catch-all without its
+migration raises a configuration error.
+
+First configure and verify the domain's catch-all Email Routing rule in Cloudflare
+to send mail to your Worker. Then use your authorized provisioning code:
+
+```ruby
+Cloudflare::Email::Mailboxes.for_tenant("organization-123") do |account|
+  mailbox = account.mailboxes.find_by!(owner_ref: "team:42")
+  address = account.addresses(mailbox.id).find_by!(address: "support@acme.example.com")
+  account.enable_catch_all(address.id,
+    evidence: "Domain catch-all Worker route verified in setup ticket 57")
+
+  # Later, stop accepting unregistered local parts:
+  # account.disable_catch_all(address.id)
+end
+```
+
+The address, mailbox and receiving domain must be active before enabling it.
+The evidence is an operator assertion, as with ordinary address activation;
+this call does not change Cloudflare rules. Only one active address per domain
+can serve as a catch-all. A database constraint also protects concurrent changes.
+Suspending that address pauses fallback. If another catch-all is enabled while
+it is suspended, disable the old flag before reactivating the old address.
+
+Exact registered addresses always take precedence. An exact address that is
+pending, suspended, or belongs to a suspended mailbox is rejected; it does not
+fall through to another mailbox. The catch-all also stops receiving when its
+mailbox or domain is suspended.
+
+Both `with_recipient` and `receive` yield `destination.catch_all == true` only
+when fallback was used. `destination.recipient` remains the actual envelope
+recipient, while `address_id` identifies the existing backing address. Stored
+mailbox membership retains that actual recipient too. Apps can use this flag to
+enforce additional rules, such as allowing fallback only while an organization
+has one site, before accepting/persisting the message.
+
+Catch-all receiving grants **no additional sending addresses**. Outbound From,
+Sender and envelope sender must still match an exact active registered address.
+Disable catch-all receiving through the API; the management UI displays its
+configuration but does not enable or disable it.
 
 ## Read incoming mail
 

--- a/lib/cloudflare/email/mailboxes/models.rb
+++ b/lib/cloudflare/email/mailboxes/models.rb
@@ -78,6 +78,7 @@ module Cloudflare
         validates :address, uniqueness: true, length: { maximum: 254 }
         validates :state, inclusion: { in: %w[pending active suspended] }
         validate :validate_directory
+        validate :validate_catch_all
         validate { validate_parent_tenant(mailbox, :mailbox) }
         scope :active, -> { where(state: "active") }
 
@@ -101,6 +102,22 @@ module Cloudflare
           end
           if new_record? && registered.state != "active"
             errors.add(:receiving_domain_id, "must be active before creating addresses")
+          end
+        end
+
+        def validate_catch_all
+          # Existing exact-address installations need not migrate until they
+          # opt into catch-all receiving.
+          return unless has_attribute?(:catch_all) && self[:catch_all]
+          errors.add(:catch_all_evidence, "is required") if self[:catch_all_evidence].to_s.strip.empty?
+          if will_save_change_to_catch_all? && state != "active"
+            errors.add(:catch_all, "requires an active address")
+          end
+          return unless state == "active"
+          errors.add(:catch_all, "requires an active mailbox") unless mailbox&.state == "active"
+          errors.add(:catch_all, "requires an active receiving domain") unless receiving_domain&.state == "active"
+          if self.class.where(receiving_domain_id: receiving_domain_id, catch_all: true, state: "active").where.not(id: id).exists?
+            errors.add(:catch_all, "already exists for this receiving domain")
           end
         end
       end

--- a/lib/cloudflare/email/mailboxes/service.rb
+++ b/lib/cloudflare/email/mailboxes/service.rb
@@ -7,9 +7,9 @@ module Cloudflare
       # A routing snapshot, not a model or an authorization token. Use it inside
       # the yielded tenant context; later jobs must resolve/check policy again.
       Destination = Struct.new(:tenant_key, :mailbox_id, :address_id,
-        :receiving_domain_id, :recipient, :owner_ref, keyword_init: true) do
+        :receiving_domain_id, :recipient, :owner_ref, :catch_all, keyword_init: true) do
         def initialize(**attributes)
-          super(**attributes.transform_values { |value| value.is_a?(String) ? value.dup.freeze : value })
+          super(**{ catch_all: false }.merge(attributes).transform_values { |value| value.is_a?(String) ? value.dup.freeze : value })
           freeze
         end
       end
@@ -126,6 +126,29 @@ module Cloudflare
           # Failed requests leave the address pending; the existing provisioner
           # upserts a rule, making a deliberate retry safe.
           activate_address!(address.id, evidence: "Cloudflare address rule provisioned for Worker #{worker_name}")
+        end
+
+        # This records the host's verified provider routing decision; it does
+        # not provision Cloudflare DNS/rules or authorize arbitrary From values.
+        def enable_catch_all(address_id, evidence:)
+          context!
+          catch_all_schema!
+          raise ArgumentError, "catch-all route verification evidence is required" if evidence.to_s.strip.empty?
+          Address.transaction do
+            address = Address.where(tenant_key: tenant_key, state: "active").find(address_id)
+            active_mailbox!(address.mailbox_id)
+            active_domain!(address)
+            address.update!(catch_all: true, catch_all_evidence: evidence)
+            address
+          end
+        end
+
+        def disable_catch_all(address_id)
+          context!
+          catch_all_schema!
+          # Disabling is permitted even after suspension; retain the previous
+          # verification evidence for operator inspection.
+          Address.where(tenant_key: tenant_key).find(address_id).tap { |address| address.update!(catch_all: false) }
         end
 
         def suspend(mailbox_id)
@@ -282,19 +305,37 @@ module Cloudflare
 
         def resolve_destination(address, directory)
           destination = Address.where(tenant_key: tenant_key, address: address,
-            receiving_domain_id: directory.id, state: "active").first
-          raise Unavailable, "mailbox address unavailable" unless destination
+            receiving_domain_id: directory.id).first
+          fallback = destination.nil?
+          if fallback && catch_all_schema_available?
+            destination = Address.where(tenant_key: tenant_key, receiving_domain_id: directory.id,
+              catch_all: true, state: "active").first
+          end
+          # An exact pending/suspended address intentionally reserves its name.
+          # It must never fall through to another mailbox's catch-all.
+          raise Unavailable, "mailbox address unavailable" unless destination&.state == "active"
           mailbox = active_mailbox!(destination.mailbox_id)
           active_domain!(destination)
           Destination.new(tenant_key: tenant_key, mailbox_id: mailbox.id,
             address_id: destination.id, receiving_domain_id: directory.id,
-            recipient: address, owner_ref: mailbox.owner_ref)
+            recipient: address, owner_ref: mailbox.owner_ref, catch_all: fallback)
         rescue ::ActiveRecord::RecordNotFound
           raise Unavailable, "mailbox address unavailable"
         end
 
         def context!
           raise ConfigurationError, "mailbox session used outside its tenant context" unless Tenancy.require_context! == tenant_key
+        end
+
+        def catch_all_schema_available?
+          Address.connection.column_exists?(Address.table_name, :catch_all) &&
+            Address.connection.column_exists?(Address.table_name, :catch_all_evidence)
+        end
+
+        def catch_all_schema!
+          unless catch_all_schema_available?
+            raise ConfigurationError, "run cloudflare:email:mailboxes:catch_all migrations for this tenant first"
+          end
         end
 
         def ensure_storage_connection!

--- a/lib/generators/cloudflare/email/mailboxes/catch_all/catch_all_generator.rb
+++ b/lib/generators/cloudflare/email/mailboxes/catch_all/catch_all_generator.rb
@@ -1,0 +1,21 @@
+require "rails/generators"
+require "rails/generators/active_record"
+
+module Cloudflare
+  module Email
+    module Generators
+      class CatchAllGenerator < ::Rails::Generators::Base
+        include ::ActiveRecord::Generators::Migration
+        namespace "cloudflare:email:mailboxes:catch_all"
+        source_root File.expand_path("templates", __dir__)
+        class_option :tenant_migrations_path, type: :string, default: "db/migrate",
+          desc: "Migration directory applied to every tenant database"
+
+        def copy_migration
+          migration_template "add_cloudflare_email_catch_all.rb",
+            File.join(options[:tenant_migrations_path], "add_cloudflare_email_catch_all.rb")
+        end
+      end
+    end
+  end
+end

--- a/lib/generators/cloudflare/email/mailboxes/catch_all/templates/add_cloudflare_email_catch_all.rb
+++ b/lib/generators/cloudflare/email/mailboxes/catch_all/templates/add_cloudflare_email_catch_all.rb
@@ -6,7 +6,7 @@ class AddCloudflareEmailCatchAll < ActiveRecord::Migration[7.1]
     unless column_exists?(:cloudflare_email_addresses, :catch_all_evidence)
       add_column :cloudflare_email_addresses, :catch_all_evidence, :text
     end
-    unless index_exists?(:cloudflare_email_addresses, name: "idx_cf_email_domain_catch_all")
+    unless index_exists?(:cloudflare_email_addresses, :receiving_domain_id, name: "idx_cf_email_domain_catch_all")
       add_index :cloudflare_email_addresses, :receiving_domain_id, unique: true,
         where: "catch_all = TRUE AND state = 'active'", name: "idx_cf_email_domain_catch_all"
     end

--- a/lib/generators/cloudflare/email/mailboxes/catch_all/templates/add_cloudflare_email_catch_all.rb
+++ b/lib/generators/cloudflare/email/mailboxes/catch_all/templates/add_cloudflare_email_catch_all.rb
@@ -1,0 +1,18 @@
+class AddCloudflareEmailCatchAll < ActiveRecord::Migration[7.1]
+  def up
+    unless column_exists?(:cloudflare_email_addresses, :catch_all)
+      add_column :cloudflare_email_addresses, :catch_all, :boolean, null: false, default: false
+    end
+    unless column_exists?(:cloudflare_email_addresses, :catch_all_evidence)
+      add_column :cloudflare_email_addresses, :catch_all_evidence, :text
+    end
+    unless index_exists?(:cloudflare_email_addresses, name: "idx_cf_email_domain_catch_all")
+      add_index :cloudflare_email_addresses, :receiving_domain_id, unique: true,
+        where: "catch_all = TRUE AND state = 'active'", name: "idx_cf_email_domain_catch_all"
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration, "Disable catch-all receiving before an explicit forward schema change"
+  end
+end

--- a/lib/generators/cloudflare/email/mailboxes/templates/create_cloudflare_email_mailboxes.rb
+++ b/lib/generators/cloudflare/email/mailboxes/templates/create_cloudflare_email_mailboxes.rb
@@ -19,10 +19,14 @@ class CreateCloudflareEmailMailboxes < ActiveRecord::Migration[7.1]
       t.string :address, null: false
       t.string :state, null: false, default: "pending"
       t.text :provisioning_evidence
+      t.boolean :catch_all, null: false, default: false
+      t.text :catch_all_evidence
       t.timestamps
     end
     add_index :cloudflare_email_addresses, :address, unique: true, name: "idx_cf_email_mailbox_address"
     add_index :cloudflare_email_addresses, :mailbox_id, name: "idx_cf_email_address_mailbox"
+    add_index :cloudflare_email_addresses, :receiving_domain_id, unique: true,
+      where: "catch_all = TRUE AND state = 'active'", name: "idx_cf_email_domain_catch_all"
 
     create_table :cloudflare_email_mailbox_messages do |t|
       t.string :tenant_key, null: false

--- a/test/support/activerecord_tenanted.rb
+++ b/test/support/activerecord_tenanted.rb
@@ -75,7 +75,10 @@ class ActualTenantedMailboxTest < Minitest::Test
     Mailboxes::ReceivingDomain.delete_all
     %w[alpha beta].each do |key|
       Mailboxes::ReceivingDomain.create!(domain: "#{key}.example.com", tenant_key: key, account_id: "account", state: "active")
-      Tenancy.with(key) { Mailboxes::Mailbox.delete_all }
+      Tenancy.with(key) do
+        Mailboxes::Address.delete_all
+        Mailboxes::Mailbox.delete_all
+      end
     end
   end
 
@@ -124,6 +127,29 @@ class ActualTenantedMailboxTest < Minitest::Test
       assert_equal "GlobalID", GlobalID::Locator.locate(gid).name
       without_tenant = gid.to_s.split("?", 2).first
       assert_raises(ActiveRecord::Tenanted::MissingTenantError) { GlobalID::Locator.locate(without_tenant) }
+    end
+  end
+
+  def test_opted_in_catch_all_resolves_in_actual_tenant_and_preserves_exact_blocks
+    %w[alpha beta].each do |key|
+      Mailboxes.for_tenant(key) do |session|
+        mailbox = Mailboxes::Mailbox.create!(id: 123, name: key, tenant_key: key, owner_ref: "site:123")
+        address = session.add_address(mailbox.id, address: "support@#{key}.example.com")
+        session.activate_address!(address.id, evidence: "exact route verified")
+        session.enable_catch_all(address.id, evidence: "domain catch-all verified")
+        pending = session.add_address(mailbox.id, address: "reserved@#{key}.example.com")
+        assert_raises(Mailboxes::Unavailable) { Mailboxes.with_recipient(recipient: pending.address) { flunk } }
+      end
+      Mailboxes.with_recipient(recipient: "new@#{key}.example.com") do |destination|
+        assert_equal key, TenantRecord.current_tenant
+        assert_equal key, destination.tenant_key
+        assert_equal 123, destination.mailbox_id
+        assert destination.catch_all
+        assert_equal "new@#{key}.example.com", destination.recipient
+        assert_equal 2, Mailboxes::Address.count
+      end
+      assert_nil TenantRecord.current_tenant
+      assert_nil Tenancy.current_key
     end
   end
 end

--- a/test/support/mailbox_generator.rb
+++ b/test/support/mailbox_generator.rb
@@ -3,6 +3,7 @@ require "minitest/autorun"
 require "active_record"
 require "tmpdir"
 require "generators/cloudflare/email/mailboxes/mailboxes_generator"
+require "generators/cloudflare/email/mailboxes/catch_all/catch_all_generator"
 
 class MailboxGeneratorInstallationTest < Minitest::Test
   Generator = Cloudflare::Email::Generators::MailboxesGenerator
@@ -17,6 +18,8 @@ class MailboxGeneratorInstallationTest < Minitest::Test
       assert ActiveRecord::Base.connection.table_exists?(:cloudflare_email_mailbox_messages)
       assert ActiveRecord::Base.connection.table_exists?(:cloudflare_email_provider_correlations)
       assert ActiveRecord::Base.connection.table_exists?(:cloudflare_email_event_receipts)
+      assert ActiveRecord::Base.connection.column_exists?(:cloudflare_email_addresses, :catch_all, :boolean)
+      assert ActiveRecord::Base.connection.index_exists?(:cloudflare_email_addresses, name: "idx_cf_email_domain_catch_all")
       names = Dir.glob(File.join(dir, "config/initializers/*.rb")).sort.map { |path| File.basename(path) }
       assert_equal "00_cloudflare_email_tenancy.rb", names.first
       # Ruby source in every generated initializer parses successfully.
@@ -39,6 +42,32 @@ class MailboxGeneratorInstallationTest < Minitest::Test
       assert ActiveRecord::Base.connection.table_exists?(:cloudflare_email_mailboxes)
       assert ActiveRecord::Base.connection.table_exists?(:cloudflare_email_outbound_deliveries)
       refute ActiveRecord::Base.connection.table_exists?(:cloudflare_email_receiving_domains)
+    end
+  end
+
+  def test_optional_upgrade_preserves_existing_addresses_and_does_not_enable_catch_all
+    Dir.mktmpdir do |dir|
+      Generator.start(["--quiet", "--tenant-migrations-path=db/tenant_migrate",
+        "--directory-migrations-path=db/directory_migrate"], destination_root: dir)
+      path = File.join(dir, "db/tenant_migrate")
+      database = File.join(dir, "tenant.sqlite3")
+      migrate(path, database)
+      connection = ActiveRecord::Base.connection
+      connection.remove_index(:cloudflare_email_addresses, name: "idx_cf_email_domain_catch_all")
+      connection.remove_column(:cloudflare_email_addresses, :catch_all)
+      connection.remove_column(:cloudflare_email_addresses, :catch_all_evidence)
+      connection.execute("INSERT INTO cloudflare_email_mailboxes (id, tenant_key, name, created_at, updated_at) VALUES (1, 'one', 'Existing', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)")
+      connection.execute("INSERT INTO cloudflare_email_addresses (tenant_key, mailbox_id, receiving_domain_id, local_part, domain, address, state, created_at, updated_at) VALUES ('one', 1, 9, 'old', 'example.com', 'old@example.com', 'active', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)")
+      Cloudflare::Email::Generators::CatchAllGenerator.start(["--quiet", "--tenant-migrations-path=db/tenant_migrate"], destination_root: dir)
+      assert_equal 4, Dir.glob(File.join(path, "*.rb")).length
+      migrate(path, database)
+      record = ActiveRecord::Base.connection.select_one("SELECT * FROM cloudflare_email_addresses")
+      assert_equal "old@example.com", record.fetch("address")
+      assert_equal 0, record.fetch("catch_all")
+      assert_nil record.fetch("catch_all_evidence")
+      assert ActiveRecord::Base.connection.index_exists?(:cloudflare_email_addresses, name: "idx_cf_email_domain_catch_all")
+      AddCloudflareEmailCatchAll.new.migrate(:up)
+      assert_equal 1, ActiveRecord::Base.connection.select_value("SELECT COUNT(*) FROM cloudflare_email_addresses")
     end
   end
 

--- a/test/support/mailbox_generator.rb
+++ b/test/support/mailbox_generator.rb
@@ -19,7 +19,7 @@ class MailboxGeneratorInstallationTest < Minitest::Test
       assert ActiveRecord::Base.connection.table_exists?(:cloudflare_email_provider_correlations)
       assert ActiveRecord::Base.connection.table_exists?(:cloudflare_email_event_receipts)
       assert ActiveRecord::Base.connection.column_exists?(:cloudflare_email_addresses, :catch_all, :boolean)
-      assert ActiveRecord::Base.connection.index_exists?(:cloudflare_email_addresses, name: "idx_cf_email_domain_catch_all")
+      assert ActiveRecord::Base.connection.index_exists?(:cloudflare_email_addresses, :receiving_domain_id, name: "idx_cf_email_domain_catch_all")
       names = Dir.glob(File.join(dir, "config/initializers/*.rb")).sort.map { |path| File.basename(path) }
       assert_equal "00_cloudflare_email_tenancy.rb", names.first
       # Ruby source in every generated initializer parses successfully.
@@ -65,7 +65,7 @@ class MailboxGeneratorInstallationTest < Minitest::Test
       assert_equal "old@example.com", record.fetch("address")
       assert_equal 0, record.fetch("catch_all")
       assert_nil record.fetch("catch_all_evidence")
-      assert ActiveRecord::Base.connection.index_exists?(:cloudflare_email_addresses, name: "idx_cf_email_domain_catch_all")
+      assert ActiveRecord::Base.connection.index_exists?(:cloudflare_email_addresses, :receiving_domain_id, name: "idx_cf_email_domain_catch_all")
       AddCloudflareEmailCatchAll.new.migrate(:up)
       assert_equal 1, ActiveRecord::Base.connection.select_value("SELECT COUNT(*) FROM cloudflare_email_addresses")
     end

--- a/test/support/mailbox_models.rb
+++ b/test/support/mailbox_models.rb
@@ -99,6 +99,26 @@ class MailboxModelPersistenceTest < Minitest::Test
     assert_raises(ActiveRecord::ReadonlyAttributeError) { address.address = "other@customer.example.com" }
   end
 
+  def test_catch_all_is_off_by_default_and_requires_evidence_and_active_ownership
+    address = create_address
+    refute address.catch_all
+    address.catch_all = true
+    refute address.valid?
+    assert_includes address.errors[:catch_all], "requires an active address"
+    address.state = "active"
+    refute address.valid?
+    assert_includes address.errors[:catch_all_evidence], "is required"
+    address.catch_all_evidence = "operator checked wildcard routing"
+    assert address.valid?
+    address.save!
+    address.update!(state: "suspended")
+    assert address.catch_all
+    @mailbox.update!(state: "suspended")
+    address.state = "active"
+    refute address.valid?
+    assert_includes address.errors[:catch_all], "requires an active mailbox"
+  end
+
   private
 
   def create_address(**overrides)

--- a/test/support/mailbox_service.rb
+++ b/test/support/mailbox_service.rb
@@ -78,11 +78,12 @@ class MailboxServiceIntegrationTest < Minitest::Test
           ServiceEmailReceipt,
           Email::ActiveRecord::EventReceipt, Email::ActiveRecord::OutboundReconciliation,
           Email::ActiveRecord::OutboundRecipient, Delivery].each(&:delete_all)
-        ServiceTenantRecord.connection.execute("DELETE FROM sqlite_sequence WHERE name = 'cloudflare_email_mailboxes'")
-        ServiceTenantRecord.connection.execute("INSERT INTO sqlite_sequence(name, seq) VALUES ('cloudflare_email_mailboxes', 41)")
         domain = Box.register_domain(domain: "#{key}.example.com", tenant_key: key, account_id: "shared")
         Box.activate_domain!(domain.id, evidence: "operator verified DNS and sending", sending_enabled: true)
-        mailbox = session.create(name: "Support", address: "Support@#{key}.example.com", owner_ref: "customer:42")
+        # Explicit collision fixture is independent of SQLite's sequence state,
+        # including after the old-schema migration/rebuild regression below.
+        mailbox = Box::Mailbox.create!(id: 42, tenant_key: key, name: "Support", owner_ref: "customer:42")
+        session.add_address(mailbox.id, address: "Support@#{key}.example.com")
         @ids[key] = mailbox.id
         session.activate_address!(mailbox.addresses.first.id, evidence: "route verified")
       end
@@ -474,5 +475,139 @@ class MailboxServiceIntegrationTest < Minitest::Test
       assert_empty ActiveJob::Base.queue_adapter.enqueued_jobs
     end
     assert_requested request, times: 1
+  end
+
+  def test_optional_catch_all_preserves_envelope_and_membership_without_alias_rows
+    Box.for_tenant("alpha") do |session|
+      address = session.addresses(42).first
+      refute address.catch_all
+      assert_raises(Box::Unavailable) { Box.with_recipient(recipient: "unknown@alpha.example.com") { flunk } }
+      assert_raises(ArgumentError) { session.enable_catch_all(address.id, evidence: " ") }
+      session.enable_catch_all(address.id, evidence: "Cloudflare catch-all rule checked")
+      assert address.reload.catch_all
+      assert_equal "Cloudflare catch-all rule checked", address.catch_all_evidence
+      exact = Box.with_recipient(recipient: address.address) { |destination| destination }
+      refute exact.catch_all
+      snapshot = Box.with_recipient(recipient: "ANYTHING@ALPHA.EXAMPLE.COM") { |destination| destination }
+      assert snapshot.catch_all
+      assert snapshot.frozen?
+      assert_equal address.id, snapshot.address_id
+      assert_equal "anything@alpha.example.com", snapshot.recipient
+      assert_equal "customer:42", snapshot.owner_ref
+      Box.receive(recipient: "anything@alpha.example.com") { Struct.new(:id).new(911) }
+      assert_equal "anything@alpha.example.com", session.messages(42).first.recipient
+      assert_equal 1, session.addresses(42).count
+      session.disable_catch_all(address.id)
+      assert_raises(Box::Unavailable) { Box.with_recipient(recipient: "anything@alpha.example.com") { flunk } }
+      refute address.reload.catch_all
+      assert_equal "Cloudflare catch-all rule checked", address.catch_all_evidence
+    end
+  end
+
+  def test_exact_addresses_reserve_names_even_when_unavailable
+    Box.for_tenant("alpha") do |session|
+      session.enable_catch_all(session.addresses(42).first.id, evidence: "verified")
+      second = session.create(name: "Explicit", address: "reserved@alpha.example.com", owner_ref: "site:other")
+      exact = second.addresses.first
+      assert_raises(Box::Unavailable) { Box.with_recipient(recipient: exact.address) { flunk } }
+      session.activate_address!(exact.id, evidence: "verified")
+      resolved = Box.with_recipient(recipient: exact.address) { |destination| destination }
+      assert_equal second.id, resolved.mailbox_id
+      refute resolved.catch_all
+      session.suspend_address(second.id, exact.id)
+      assert_raises(Box::Unavailable) { Box.with_recipient(recipient: exact.address) { flunk } }
+      session.activate_address!(exact.id, evidence: "verified")
+      session.suspend(second.id)
+      assert_raises(Box::Unavailable) { Box.with_recipient(recipient: exact.address) { flunk } }
+      assert Box.with_recipient(recipient: "missing@alpha.example.com") { |destination| destination.catch_all }
+    end
+  end
+
+  def test_catch_all_requires_active_ownership_and_cannot_expand_sending_authority
+    Box.for_tenant("alpha") do |session|
+      address = session.addresses(42).first
+      session.suspend_address(42, address.id)
+      assert_raises(ActiveRecord::RecordNotFound) { session.enable_catch_all(address.id, evidence: "verified") }
+      session.activate_address!(address.id, evidence: "verified")
+      session.suspend(42)
+      assert_raises(ActiveRecord::RecordNotFound) { session.enable_catch_all(address.id, evidence: "verified") }
+      session.resume(42)
+      session.enable_catch_all(address.id, evidence: "verified")
+      assert_raises(ActiveRecord::RecordNotFound) do
+        session.prepare(42, operation_key: "unknown-sender", mail: mail(from: "anything@alpha.example.com"))
+      end
+      assert_equal 0, Delivery.count
+      assert session.prepare(42, operation_key: "exact-sender", mail: mail)
+      session.suspend(42)
+      assert_raises(Box::Unavailable) { Box.with_recipient(recipient: "anything@alpha.example.com") { flunk } }
+      session.resume(42)
+      Box::ReceivingDomain.find_by!(tenant_key: "alpha").update!(state: "suspended")
+      assert_raises(Box::Unavailable) { Box.with_recipient(recipient: "anything@alpha.example.com") { flunk } }
+      assert_raises(ActiveRecord::RecordNotFound) { session.enable_catch_all(address.id, evidence: "verified") }
+      session.disable_catch_all(address.id)
+      refute address.reload.catch_all
+    end
+  end
+
+  def test_domain_catch_all_unique_index_prevents_competing_activation_and_resume
+    Box.for_tenant("alpha") do |session|
+      original = session.addresses(42).first
+      second = session.add_address(42, address: "fallback@alpha.example.com")
+      session.activate_address!(second.id, evidence: "verified")
+      session.enable_catch_all(original.id, evidence: "verified")
+      assert_raises(ActiveRecord::RecordInvalid) { session.enable_catch_all(second.id, evidence: "verified") }
+      assert_raises(ActiveRecord::RecordNotUnique) { second.update_columns(catch_all: true, catch_all_evidence: "direct writer") }
+      session.suspend_address(42, original.id)
+      session.enable_catch_all(second.id, evidence: "replacement verified")
+      assert_raises(ActiveRecord::RecordInvalid) { session.activate_address!(original.id, evidence: "old route") }
+      assert_equal "suspended", original.reload.state
+      session.disable_catch_all(original.id)
+      session.activate_address!(original.id, evidence: "exact address restored")
+      resolved = Box.with_recipient(recipient: "unknown@alpha.example.com") { |destination| destination }
+      assert_equal second.id, resolved.address_id
+    end
+  end
+
+  def test_catch_all_is_domain_and_tenant_scoped_with_colliding_mailbox_ids
+    %w[alpha beta].each do |key|
+      Box.for_tenant(key) do |session|
+        session.enable_catch_all(session.addresses(42).first.id, evidence: "verified #{key}")
+      end
+      Box.receive(recipient: "same@#{key}.example.com") do |destination|
+        assert_equal key, destination.tenant_key
+        assert_equal 42, destination.mailbox_id
+        assert destination.catch_all
+        Struct.new(:id).new(922)
+      end
+    end
+    Box.for_tenant("alpha") do |session|
+      assert_equal "same@alpha.example.com", session.messages(42).first.recipient
+      unrelated = Box.register_domain(domain: "other.example.com", tenant_key: "alpha", account_id: "shared")
+      Box.activate_domain!(unrelated.id, evidence: "domain verified")
+      assert_raises(Box::Unavailable) { Box.with_recipient(recipient: "same@other.example.com") { flunk } }
+    end
+    Box.for_tenant("beta") { |session| assert_equal "same@beta.example.com", session.messages(42).first.recipient }
+    assert_nil Email::Tenancy.current_key
+  end
+
+  def test_old_tenant_schema_retains_exact_routing_without_enabling_catch_all
+    Box.for_tenant("alpha") do |session|
+      connection = ServiceTenantRecord.connection
+      connection.remove_index(:cloudflare_email_addresses, name: "idx_cf_email_domain_catch_all")
+      connection.remove_column(:cloudflare_email_addresses, :catch_all)
+      connection.remove_column(:cloudflare_email_addresses, :catch_all_evidence)
+      Box::Address.reset_column_information
+      exact = Box.with_recipient(recipient: "support@alpha.example.com") { |destination| destination }
+      refute exact.catch_all
+      assert_raises(Box::Unavailable) { Box.with_recipient(recipient: "unknown@alpha.example.com") { flunk } }
+      error = assert_raises(Email::ConfigurationError) { session.enable_catch_all(exact.address_id, evidence: "verified") }
+      assert_match(/migrations/, error.message)
+    ensure
+      connection.add_column(:cloudflare_email_addresses, :catch_all, :boolean, default: false, null: false)
+      connection.add_column(:cloudflare_email_addresses, :catch_all_evidence, :text)
+      connection.add_index(:cloudflare_email_addresses, :receiving_domain_id, unique: true,
+        where: "catch_all = TRUE AND state = 'active'", name: "idx_cf_email_domain_catch_all")
+      Box::Address.reset_column_information
+    end
   end
 end


### PR DESCRIPTION
Applications that receive arbitrary local parts for one organization can now route them to an existing mailbox without creating an unbounded set of alias rows. Catch-all receiving is off by default and requires an active address, mailbox, receiving domain, and explicit operator verification evidence.

Exact registered addresses always take precedence, including pending or suspended addresses that must reject rather than fall through. Destination snapshots flag fallback and retain the actual envelope recipient; outgoing sender authorization still requires an exact registered address. A partial unique database index prevents competing active catch-alls for one domain.

Fresh installs include the optional schema. Existing installs can run `cloudflare:email:mailboxes:catch_all` with their tenant migration path; older schemas keep exact-only routing. Docs explain setup and host policy checks, and the management page displays configured catch-alls without adding activation controls.

Validation:

- Full gem suite: 258 tests, 917 assertions, no failures.
- Two SQLite tenant service integration: 28 tests, 193 assertions, including overlapping IDs, exact-address rejection, active ownership, sender restrictions, database uniqueness, suspension/reactivation conflict, and old-schema compatibility.
- Actual activerecord-tenanted adapter: 4 tests, 41 assertions.
- Generator install/upgrade: 3 tests, 21 assertions; model checks: 6 tests, 42 assertions.
- Packaged consumer verification passed, including Rails ingress, migrations, tenant routing and production eager boot. `git diff --check` passed.
